### PR TITLE
Make english the base language for the RMXP texts + update some RMXP variables/switches names

### DIFF
--- a/Data/Map002.rxdata.yml
+++ b/Data/Map002.rxdata.yml
@@ -327,8 +327,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgMCA6W25hbWU9Pz8/XTpTYWx1dCBNYWtlciwgZXQgYmllbnZlbnVlIGRhbnMgbGEgZMOpbW8gdGVjaG5pcXVlIGRlIFBva8OpbW9uU0RLICE=
+        - 2, 0 :[name=???]:Hello Maker, and welcome to the PokémonSDK Technical Demo!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -338,44 +337,45 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgMSA6W25hbWU9U2lyTWFsb106SmUgc3VpcyBTaXJNYWxvLFtXQUlUIDQwXSBldCB2b2ljaSBtZXMgY29sbMOoZ3VlcyBBZXJ1bixbV0FJVCAxMDBdIE51cmkgWXVyaSxbV0FJVCAxMDBdIFBhbGJvbHNreSxbV0FJVCAxMDBdIFJleSxbV0FJVCAxMDBdIGV0IFdhbHZlbiAhW1dBSVQgMTAwXQ==
+        - 2, 1 :[name=SirMalo]:I am SirMalo,[WAIT 40] and here are my workmates Aerun,[WAIT
+          100] Nuri Yuri,[WAIT 100] Palbolsky,[WAIT 100] Rey,[WAIT 100] and Walven![WAIT
+          100]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgMiA6W25hbWU9U2lyTWFsb106Q2V0dGUgZMOpbW8gdGVjaG5pcXVlIGVzdCBsZSBmcnVpdCBkZSBub3RyZSBjb2xsYWJvcmF0aW9uIGNvbnRpbnVlbGxlIGV0IGR1IGNoZW1pbiBwYXJjb3VydSBkZXB1aXMgbGEgcHJlbWnDqHJlIHJlbGVhc2UgZGUgUG9rw6ltb25TREsu
+        - 2, 2 :[name=SirMalo]:This technical demo is the result of our continued
+          collaboration and shows how far we've come since the first release of PokémonSDK.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgMyA6W25hbWU9U2lyTWFsb106QmllbiBlbnRlbmR1LCBQb2vDqW1vblNESyBuZSBzZXJhaXQgamFtYWlzIGFycml2w6kganVzcXUnw6AgY2Ugbml2ZWF1IHNhbnMgbGVzIGRpdmVycyBjb250cmlidXRldXJzIHF1aSBvbnQgdG91cyBhcHBvcnTDqSBsZXVyIHBpZXJyZSDDoCBsJ8OpZGlmaWNlICE=
+        - 2, 3 :[name=SirMalo]:Of course, PokémonSDK would never have reached this
+          level without all the contributors who played their part!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgNCA6W25hbWU9U2lyTWFsb106UG91ciBjZSBxdWkgZXN0IGRlIGNldHRlIGTDqW1vLCBlbGxlIHRlIHBlcm1ldHRyYSBkJ2Vzc2F5ZXIgZW4gamV1IGxlcyBkaWZmw6lyZW50cyBzeXN0w6htZXMgcXVlIG5vdXMgb2Zmcm9ucyBhdmVjIFBva8OpbW9uU0RLLg==
+        - 2, 4 :[name=SirMalo]:As far as this demo is concerned, it will let you test
+          the different systems we offer with PokémonSDK ingame.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgNSA6W25hbWU9U2lyTWFsb106TWFpcyBlbGxlIGVzdCBhdXNzaSBlbiBsaWVuIGF2ZWMgUG9rw6ltb24gU3R1ZGlvLCBldCBlbGxlIHRlIHBlcm1ldHRyYSBkZSB2b2lyIGNvbW1lbnQgY2VzIGZvbmN0aW9ubmFsaXTDqXMgc29udCBpbXBsw6ltZW50w6llcy4=
+        - 2, 5 :[name=SirMalo]:But it is also connected with Pokémon Studio, and it
+          will let you see how these features are implemented.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgNiA6W25hbWU9U2lyTWFsb106VHUgYXJyaXZlcmFzIHNvdXMgcGV1IHN1ciBsJ8OObGUsIHVuZSBjb2xsZWN0aW9uIGRlIG1hcHMgc3VyIGxlc3F1ZWxsZXMgdHUgcG91cnJhcyB0ZSBiYWxhZGVyIGV0IGV4cMOpcmltZW50ZXIu
+        - 2, 6 :[name=SirMalo]:You will soon arrive on the Island, a collection of
+          maps on which you will be able to explore and experiment on.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgNyA6W25hbWU9U2lyTWFsb106SmUgdGUgY29uc2VpbGxlIGRlIGQnYWJvcmQgdGUgcmVuZHJlIMOgIGxhIFRvdXIsIMOnYSBzZXJhIGxlIGTDqWJ1dCBkZSB0b24gcGFyY291cnMgZGFucyBjZXR0ZSBkw6ltby4=
+        - 2, 7 :[name=SirMalo]:You'll want to start by going to the Tower, as it will
+          be the beginning of your journey. Someone will wait for you there.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -385,13 +385,12 @@ events:
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 2, 8 :[name=SirMalo]:Mais avant de te laisser partir, je vais te demander
-          quelques informations.
+        - 2, 8 :[name=SirMalo]:But before you leave, I have to ask you for some information.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 2, 9 :[name=SirMalo]:Sais-tu comment changer tes touches ?
+        - 2, 9 :[name=SirMalo]:Do you know how to change your controls?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -409,7 +408,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 2, 10 :[name=SirMalo]:Super ! Continuons avec la prochaine question.
+        - 2, 10 :[name=SirMalo]:Great! Then let's continue with the next question.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -424,19 +423,18 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 2, 11 :[name=SirMalo]:Pour changer tes touches, appuie sur la touche F1.
+        - 2, 11 :[name=SirMalo]:To change your controls, press the F1 button at any
+          point after this introduction!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgMTIgVHUgcG91cnJhcyBhbG9ycyBtb2RpZmllciB0ZXMgY29udHLDtGxlcyBjb21tZSBib24gdGUgc2VtYmxlLg==
+        - 2, 12 :[name=SirMalo]:You can then modify your controls as you see fit.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgMTMgOltuYW1lPVNpck1hbG9dOlBhc3NvbnMgw6AgbGEgcXVlc3Rpb24gc3VpdmFudGUu
+        - 2, 13 :[name=SirMalo]:Let's move on to the next question.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -584,21 +582,20 @@ events:
         code: 112
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgMTQgOltuYW1lPVNpck1hbG9dOlF1ZWxsZSBlc3QgbCdhcHBhcmVuY2UgcXVpIHRlIGTDqWZpbml0IGxlIG1pZXV4ID8=
+        - 2, 14 :[name=SirMalo]:Which appearence defines you the best?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 2, 15 Gauche
-          - 2, 16 Droite
+        - - 2, 15 Left
+          - 2, 16 Right
         - 2
         indent: 1
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Gauche
+        - 2, 15 Left
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -641,7 +638,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Droite
+        - 2, 16 Right
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -727,7 +724,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 2, 17 :[name=SirMalo]:Pour finir, quel est ton nom ?
+        - 2, 17 :[name=SirMalo]:Finally, what is your name?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -738,14 +735,12 @@ events:
         code: 303
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgMTggOltuYW1lPVNpck1hbG9dOlxuWzFdID8gQydlc3QgdW4gdHLDqHMgYmVhdSBub20gIQ==
+        - 2, 18 :[name=SirMalo]:\n[1]? It's a great name!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          SmUgbCdhaSBiaWVuIMOpY3JpdCA/
+        - Did I write it properly?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -821,41 +816,20 @@ events:
         code: 413
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 2, 19 :[name=SirMalo]:Tout est bon, jeune Maker !
+        - 2, 19 :[name=SirMalo]:We're done, young Maker!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MiwgMjAgOltuYW1lPVNpck1hbG9dOlR1IHZhcyBwb3V2b2lyIGV4cMOpcmltZW50ZXIgY2V0dGUgZMOpbW8gZXQgZMOpY291dnJpciBsZXMgZm9uY3Rpb25uYWxpdMOpcyBkZSBQb2vDqW1vblNESyAh
+        - 2, 20 :[name=SirMalo]:You can now experiment with this demo and discover
+          the features of PokémonSDK!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 2, 21 :[name=SirMalo]:Amuse-toi bien !
+        - 2, 21 :[name=SirMalo]:Have fun!
         indent: 0
         code: 101
-      - !ruby/object:RPG::EventCommand
-        parameters:
-        - -1
-        - !ruby/object:RPG::MoveRoute
-          repeat: false
-          skippable: false
-          list:
-          - &1 !ruby/object:RPG::MoveCommand
-            code: 42
-            parameters:
-            - 0
-          - !ruby/object:RPG::MoveCommand
-            code: 0
-            parameters: []
-        indent: 0
-        code: 209
-      - !ruby/object:RPG::EventCommand
-        parameters:
-        - *1
-        indent: 0
-        code: 509
       - !ruby/object:RPG::EventCommand
         parameters: []
         indent: 0
@@ -910,6 +884,47 @@ events:
         - 1
         indent: 0
         code: 242
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - "!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        indent: 0
+        code: 108
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - Delete the 4 next commands to have a teleportation
+        indent: 0
+        code: 408
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - without issues!
+        indent: 0
+        code: 408
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - "!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        indent: 0
+        code: 408
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          repeat: false
+          skippable: false
+          list:
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+        indent: 0
+        code: 209
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - *1
+        indent: 0
+        code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
         - 50
@@ -1062,6 +1077,36 @@ events:
         - 30
         indent: 0
         code: 106
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - "!!!IMPORTANT, PLEASE READ!!!"
+        indent: 0
+        code: 108
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - This event lowers the opacity of the player and display
+        indent: 0
+        code: 408
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - a white image to give the illusion of a flash happening
+        indent: 0
+        code: 408
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - and to let the player "exit" the ship. You might want to
+        indent: 0
+        code: 408
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - delete these commands to ensure you'll have a proper
+        indent: 0
+        code: 408
+      - !ruby/object:RPG::EventCommand
+        parameters:
+        - teleportation! (search a comment beginning with !!!!!!!!)
+        indent: 0
+        code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
         - !ruby/object:RPG::AudioFile

--- a/Data/Map003.rxdata.yml
+++ b/Data/Map003.rxdata.yml
@@ -1766,8 +1766,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMCBCaWVudmVudWUgISBKZSB2ZW5kcyBkZXMgUG9rw6kgQmFsbCBtb2lucyBjaMOocmVzIHF1J8OgIGPDtHTDqS4uLg==
+        - 3, 0 Welcome! I'm selling Poké Balls for less than next door...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1792,8 +1791,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMSBKZSB2b3VzIGFzc3VyZSwgYydlc3QgZGUgbGEgcXVhbGl0w6kgIQ==
+        - 3, 1 I can assure you of their quality!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1820,8 +1818,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMiBMYSBwZWludHVyZSBlc3QgcGV1dC3DqnRyZSB1biBwZXUgw6ljb3JjaMOpZSwgbWFpcyB2b3VzIG5lIHNlcmV6IHBhcyBkw6nDp3VcRSBkZSBjZXMgQmFsbHMgIQ==
+        - 3, 2 The paint might be peeled a bit, but you won't be disappointed in those
+          Balls!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1848,8 +1846,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMyBDZXMgQmFsbHMgc29udCB0b21iw6llcyBkJ3VuIGNhbWlvbiBtYWlzIGMnZXN0IGRlIGxhIHF1YWxpdMOpICE=
+        - 3, 3 These are goods which fell of the truck, but still, it's high quality!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2155,8 +2152,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNyBWb3VzIG4nYXZleiByaWVuIMOgIHZlbmRyZSAh
+        - 3, 7 You have nothing to sell!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2286,8 +2282,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgOSBDb21tZSBjZXQgb2JqZXQgZXN0IMOgIHRlcnJlLCB2b3VzIHBvdXZleiB1dGlsaXNlciBsYSBjb21tYW5kZSBcY1s1XSJwaWNrX2l0ZW0iXGNbMF0gcG91ciBxdWUgbCfDqXbDqG5lbWVudCBzb2l0IHN1cHByaW3DqSBqdXN0ZSBhcHLDqHMu
+        - 3, 9 As this item is on the ground, you can use the \c[5]"pick_item"\c[0]
+          command to have the event deleted afterward.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2343,8 +2339,9 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTAgQ29tbWUgY2V0IG9iamV0IGEgbGUgdGFnIFxjWzVdImludmlzaWJsZV8iXGNbMF0sIGlsIG4nYSBwYXMgZCdvbWJyZSBldCBwZXV0IMOqdHJlIGTDqXRlY3TDqSBhdmVjIGxlIENoZXJjaCdPYmpldC4=
+        - 3, 10 As this item has the \c[5]"invisible_"\c[0] tag at the beginning of
+          its name, it does not have a shadow and can be detected by the Drowsing
+          Machine.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3249,31 +3246,28 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTEgOltuYW1lPVNpck1hbG9dOkFoLCB0ZSB2b2lsw6AgIQ==
+        - 3, 11 :[name=SirMalo]:Ah, here you are!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Bienvenue dans la Tour !
+        - Welcome to the Tower!
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTIgOltuYW1lPVNpck1hbG9dOkTDqXNvbMOpLCBqZSBtZSBzdWlzIHJlbmR1IGNvbXB0ZSBlbiBhcnJpdmFudCBxdWUgaidhdmFpcyBvdWJsacOpIGRlIHRlIGZvdXJuaXIgdGVzIENoYXVzc3VyZXMgZGUgY291cnNlLi4u
+        - 3, 12 :[name=SirMalo]:Sorry, I realized when I got here that I forgot to
+          give you these Running Shoes...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTMgOltuYW1lPVNpck1hbG9dOkonZXNww6hyZSBxdWUgdHUgbmUgbSdlbiB2ZXV4IHBhcyA/
+        - 3, 13 :[name=SirMalo]:I hope you're not angry?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTQgOltuYW1lPVNpck1hbG9dOlF1b2lxdSdpbCBlbiBzb2l0LCB0aWVucywgZW5maWxlIMOnYS4=
+        - 3, 14 :[name=SirMalo]:Anyway, here, slip these on.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3303,13 +3297,12 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 15 \c[18]\N[1] obtient les Chaussures de course ! [WAIT 130]
+        - 3, 15 \c[18]\N[1] received a pair of \c[27]Running Shoes\c[18]! [WAIT 130]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTYgOltuYW1lPVNpck1hbG9dOlR1IHZldXggcXVlIGplIHRlIHByw6lzZW50ZSB1biBwZXUgbGUgSHViIENlbnRyYWwgPw==
+        - 3, 16 :[name=SirMalo]:Do you want me to give you a tour of the Central Hub?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3327,8 +3320,8 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTcgOltuYW1lPVNpck1hbG9dOlN1aXMtbW9pLCBqZSB2YWlzIHRlIG1vbnRyZXIgbGVzIGRpZmbDqXJlbnRzIHNlcnZpY2VzIHF1J29uIHkgdHJvdXZlLg==
+        - 3, 17 :[name=SirMalo]:Follow me, I will show you the different services
+          we offer.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3447,19 +3440,19 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTggOltuYW1lPVNpck1hbG9dOkNldCBlc2NhbGF0b3IgbcOobmUgdmVycyBsJ0VzcGFjZSBXaS1GaSwgb8O5IHR1IHBldXggdGVzdGVyIGxlcyBcY1s1XWZvbmN0aW9ubmFsaXTDqXMgZW4gbGlnbmVcY1swXS4=
+        - 3, 18 :[name=SirMalo]:This escalator leads to the Wi-Fi area, where you
+          can test the \c[5]online features\c[0].
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 19 :[name=SirMalo]:Mais pour l'instant, toutes ne sont pas encore disponibles...
+        - 3, 19 :[name=SirMalo]:But for now, not all features are available...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMjAgOltuYW1lPVNpck1hbG9dOk4naMOpc2l0ZSBwYXMgw6AgaW5zcGVjdGVyIGxlcyBcY1s1XcOpdsOobmVtZW50cyBkZSBsJ2VzY2FsYXRvclxjWzBdIHBvdXIgcmVnYXJkZXIgY29tbWVudCBpbCBmb25jdGlvbm5lIGV0IMOgIGxlcyByw6l1dGlsaXNlciBkYW5zIHRvbiBwcm9wcmUgamV1Lg==
+        - 3, 20 :[name=SirMalo]:Do not hesitate to inspect the \c[5]elevator event\c[0]
+          to check how it works and to reuse these in your own game.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3526,26 +3519,24 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMjEgOltuYW1lPVNpck1hbG9dOkljaSwgYydlc3QgbGUgY29tcHRvaXIgZHUgQ2VudHJlIFBva8OpbW9uLg==
+        - 3, 21 :[name=SirMalo]:Here is the Pokémon Center counter.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMjIgOltuYW1lPVNpck1hbG9dOlR1IHBldXggeSBmYWlyZSBzb2lnbmVyIHRlcyBQb2vDqW1vbiBncmF0dWl0ZW1lbnQgIQ==
+        - 3, 22 :[name=SirMalo]:You can heal your Pokémon for free!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMjMgOltuYW1lPVNpck1hbG9dOkwnw6l2w6huZW1lbnQgZXN0IFxjWzVdZHluYW1pcXVlXGNbMF0gZXQgYWZmaWNoZSBhdXRhbnQgZGUgUG9rw6liYWxscyBxdWUgZGUgUG9rw6ltb24gcXVlIHR1IGFzIGRhbnMgdG9uIMOpcXVpcGUu
+        - 3, 23 :[name=SirMalo]:The event is \c[5]dynamic\c[0] and displays as many
+          Poké Balls as Pokémon in your party.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMjQgOltuYW1lPVNpck1hbG9dOklsIHRlIHBlcm1ldCBhdXNzaSBkZSB0ZSBcY1s1XXTDqWzDqXBvcnRlciBkYW5zIGxlIGRlcm5pZXIgQ2VudHJlIHZpc2l0w6lcY1swXSBlbiBjYXMgZGUgZMOpZmFpdGUgZW4gY29tYmF0Lg==
+        - 3, 24 :[name=SirMalo]:It also permits you to \c[5]teleport yourself to the
+          last visited Center\c[0] in case of defeat.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3580,8 +3571,8 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMjUgOltuYW1lPVNpck1hbG9dOlR1IGFzIGF1c3NpIGxlIFBDIGp1c3RlLWzDoCBxdWkgdGUgcGVybWV0IGQnYWNjw6lkZXIgYXUgXGNbNV1zeXN0w6htZSBkZSBzdG9ja2FnZVxjWzBdIGRlIFBva8OpbW9uLg==
+        - 3, 25 :[name=SirMalo]:You also have the PC just right there which allows
+          you to access the Pokémon \c[5]storage system\c[0],
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3681,14 +3672,14 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMjYgOltuYW1lPVNpck1hbG9dOlNpIHR1IGVtcHJ1bnRlcyBjZXMgZXNjYWxpZXJzLCB0dSBhcnJpdmVyYXMgw6AgbCdBcsOobmUgZGUgQ29tYmF0Lg==
+        - 3, 26 :[name=SirMalo]:If you take these stairs, you'll end up in the Battle
+          Arena.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMjcgOltuYW1lPVNpck1hbG9dOkNldCBlbmRyb2l0IHRlIHBlcm1ldCBkZSBcY1s1XWNvbmZpZ3VyZXIgdG91cyBsZXMgdHlwZXMgZGUgY29tYmF0c1xjWzBdIHBlcm1pcyBwYXIgUG9rw6ltb25TREsu
+        - 3, 27 :[name=SirMalo]:This place allows you to \c[5]setup every type of
+          battle\c[0] permitted by PokémonSDK.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3755,20 +3746,19 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMjggOltuYW1lPVNpck1hbG9dOkNldHRlIHBhcnRpZSwgYydlc3QgbGEgQm91dGlxdWUgUG9rw6ltb24u
+        - 3, 28 :[name=SirMalo]:This part is the Pokémon Shop.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 29 :[name=SirMalo]:Tu peux y acheter toutes sortes de produits pour t'aider
-          dans ton aventure.
+        - 3, 29 :[name=SirMalo]:You can buy all sorts of products to help you in your
+          journey.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMzAgOltuYW1lPVNpck1hbG9dOlBva8OpbW9uU0RLIHRlIHBlcm1ldCBkZSBwYXJhbcOpdHJlciBwbGVpbiBkZSBcY1s1XXR5cGVzIGRlIEJvdXRpcXVlc1xjWzBdIGRpZmbDqXJlbnRzLCBhdmVjIGRlcyBzdG9ja3MgbGltaXTDqXMgb3Ugbm9uLg==
+        - 3, 30 :[name=SirMalo]:PokémonSDK allows you to setup a lot of different
+          \c[5]shop types\c[0], with limited stocks or not.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3845,8 +3835,7 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMzEgOltuYW1lPVNpck1hbG9dOkJpZW4gISDDgCBsJ8OpdGFnZSwgb24gdHJvdXZlIHBsZWluIGQnYXV0cmVzIHN5c3TDqG1lcy4=
+        - 3, 31 :[name=SirMalo]:Alright, on this floor we can find many other systems.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3880,8 +3869,8 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMzIgOltuYW1lPVNpck1hbG9dOkRlcnJpw6hyZSBsZSBjb21wdG9pciBkZSBnYXVjaGUsIHR1IHRyb3V2ZXJhcyBsZSBcY1s1XU1hw650cmUgZGVzIGNhcGFjaXTDqXNcY1swXSBldCBsZSBcY1s1XURvbm5ldXIgZGUgY2FwYWNpdMOpXGNbMF0u
+        - 3, 32 :[name=SirMalo]:Behind the left counter, you'll find the \c[5]Move
+          Reminder\c[0] and the \c[5]Move Tutor\c[0].
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3916,20 +3905,18 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMzMgOltuYW1lPVNpck1hbG9dOkRlcnJpw6hyZSBsZSBjb21wdG9pciBkZSBkcm9pdGUsIGMnZXN0IGxhIFxjWzVdUGVuc2lvblxjWzBdLg==
+        - 3, 33 :[name=SirMalo]:Behind the right counter is the \c[5]Day Care\c[0].
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMzQgOltuYW1lPVNpck1hbG9dOlR1IHBldXggeSBsYWlzc2VyIGp1c3F1J8OgIGRldXggUG9rw6ltb24gcG91ciBxdSdpbHMgcydlbnRyYWluZW50IGRlIGxldXIgY8O0dMOpLg==
+        - 3, 34 :[name=SirMalo]:You can leave there up to two Pokémon to have them
+          train on their side.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMzUgOltuYW1lPVNpck1hbG9dOlF1aSBzYWl0LCBpbHMgcG91cnJvbnQgbcOqbWUgdCdhcHBvcnRlciB1biDFknVmICE=
+        - 3, 35 :[name=SirMalo]:Who knows, you might even get an Egg!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3964,14 +3951,13 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMzYgOltuYW1lPVNpck1hbG9dOkxlcyBwZXJzb25uZXMgYXNzaXNlcyBkYW5zIGxhIHpvbmUgZGUgZMOpdGVudGUganVzdGUgaWNpIHBldXZlbnQgYXVzc2kgdCdhcHByZW5kcmUgZGVzIGNob3NlcyB1dGlsZXMu
+        - 3, 36 :[name=SirMalo]:The seated people in the relaxation area just here
+          might also teach you useful things.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMzcgOltuYW1lPVNpck1hbG9dOk4naMOpc2l0ZSBwYXMgw6AgbGV1ciBhZHJlc3NlciBsYSBwYXJvbGUgIQ==
+        - 3, 37 :[name=SirMalo]:Don't hesitate to have a talk with them!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4038,14 +4024,14 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMzggOltuYW1lPVNpck1hbG9dOkNldCBhc2NlbnNldXItbMOgIHRlIHBlcm1ldCBkZSB2aXNpdGVyIGxlcyBcY1s1XVpvbmVzIEVudmlyb25uZW1lbnRzXGNbMF0u
+        - 3, 38 :[name=SirMalo]:This elevator here allows you to visit the \c[5]Environmental
+          Zones\c[0].
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMzkgOltuYW1lPVNpck1hbG9dOkNlcyBtYXBzIHByw6lzZW50ZW50IHRvdXMgbGVzIGVudmlyb25uZW1lbnRzIHF1J2lsIGVzdCBwb3NzaWJsZSBkZSBjcsOpZXIgZGFucyBQb2vDqW1vblNESywgZXQgbGVzIGZvbmN0aW9ubmFsaXTDqXMgYXNzb2Npw6llcy4=
+        - 3, 39 :[name=SirMalo]:These maps showcase all the environments you can create
+          with PokémonSDK, and their associated features.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4141,14 +4127,14 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNDAgOltuYW1lPVNpck1hbG9dOkVuZmluLCBjZXQgYXNjZW5zZXVyLWzDoCB0ZSBwZXJtZXQgZGUgdmlzaXRlciBsZXMgXGNbNV1ab25lcyBTeXN0w6htZXNcY1swXS4=
+        - 3, 40 :[name=SirMalo]:Finally, this elevator allows you to visit the \c[5]System
+          Zones\c[0].
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNDEgOltuYW1lPVNpck1hbG9dOkNlIHNvbnQgZGlmZsOpcmVudGVzIG1hcHMgcXVpIGNvbnRpZW5uZW50IGwnZW5zZW1ibGUgZGVzIGZvbmN0aW9ubmFsaXTDqXMgcGVybWlzZXMgcGFyIFBva8OpbW9uU0RLIMOgIGwnaW50w6lyaWV1ciBkZXMgw6l2w6huZW1lbnRzLg==
+        - 3, 41 :[name=SirMalo]:Those are different maps which contain most features
+          permitted inside events by PokémonSDK.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4192,8 +4178,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNDIgOltuYW1lPVNpck1hbG9dOkplIHZvaXMgcXUnb24gYSDDoCBmYWlyZSDDoCB1blxFIGhhYml0dcOpXEUgISA=
+        - 3, 42 :[name=SirMalo]:I see I'm talking to a professional!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4267,13 +4252,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNDMgOltuYW1lPVNpck1hbG9dOkFoLCBtYWlzIHR1IG4nYXMgdG91am91cnMgcGFzIGRlIFBva8OpbW9uICE=
+        - 3, 43 :[name=SirMalo]:Oh, I see you still don't have any Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Attends une seconde...
+        - Wait a second...
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -4514,8 +4498,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNDQgOltuYW1lPVNpck1hbG9dOlRpZW5zLCBjaG9pc2lzIHVuZSBkZSBjZXMgw6lxdWlwZXMu
+        - 3, 44 :[name=SirMalo]:Here, choose one of these teams.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4540,21 +4523,21 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNDUgOltuYW1lPVNpck1hbG9dOlR1IGFzIGRvbmMgY2hvaXNpIGwnw4lxdWlwZSBbVEVBTV0sIGNvbnN0aXR1w6llIGRlIFtQS00xXSwgW1BLTTJdIGV0IFtQS00zXS4gRXN0LWNlIHF1ZSDDp2EgdGUgY29udmllbnQgPw==
+        - 3, 45 :[name=SirMalo]:So, you have chosen the [TEAM] Team, which includes
+          [PKM1], [PKM2] and [PKM3]. Does this suit you?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 3, 46 Oui
-          - 3, 47 Non
+        - - 3, 46 Yes
+          - 3, 47 No
         - 2
         indent: 1
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 3, 46 Yes
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4568,7 +4551,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 3, 47 No
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4622,8 +4605,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNDggXGNbMThdXE5bMV0gb2J0aWVudCBsJ8OJcXVpcGUgW1RFQU1dICEgW1dBSVQgMTUwXQ==
+        - 3, 48 \c[18]\N[1] obtains the \c[27][TEAM] \c[18]Team! [WAIT 150]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4649,8 +4631,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNDkgOltuYW1lPVNpck1hbG9dOlRpZW5zLCBwcmVuZHMgYXVzc2kgY2V0dGUgY2FydGUgZGUgbCfDjmxlLg==
+        - 3, 49 :[name=SirMalo]:Here, take this map of the Island.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4711,42 +4692,42 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNTAgOltuYW1lPVNpck1hbG9dOlRlIHZvaWzDoCBmaW4gcHLDqnRcRSBwb3VyIGV4cGxvcmVyIHRvdXQgY2UgcXVlIGNldHRlIFRvdXIgYSDDoCB0ZSBtb250cmVyICE=
+        - 3, 50 :[name=SirMalo]:You are now ready to explore everything the Tower
+          has to show you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNTEgOltuYW1lPVNpck1hbG9dOlNvaXMgXGZbY3VyaWV1c2XCp2N1cmlldXhdLCBuJ2jDqXNpdGUgcGFzIMOgIGludMOpcmFnaXIgYXZlYyB0b3V0IGNlIHF1ZSB0dSB2ZXJyYXMu
+        - 3, 51 :[name=SirMalo]:Be curious, do not hesitate to interact with everything
+          you'll see.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNTIgOltuYW1lPVNpck1hbG9dOkQnYWlsbGV1cnMsIGNoYXF1ZSBsaWV1IGRlIGNldHRlIMOObGUgcmVuZmVybWUgdW4gb2JqZXQgYXBwZWzDqSBcY1s1XVBpZXJyZSBJbnNvbGl0ZVxjWzBdLg==
+        - 3, 52 :[name=SirMalo]:By the way, every location on this Island possess
+          an item called \c[5]Intriguing Stone\c[0].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNTMgOltuYW1lPVNpck1hbG9dOlJhbWFzc2VyIGNldCBvYmpldCwgb3UgbGUgcsOpY3Vww6lyZXIgYXVwcsOocyBkJ3VuIFBOSiwgaW5kaXF1ZSBxdWUgdHUgYXMgcHUgZXhww6lyaW1lbnRlciB0b3V0IGNlIHF1ZSBsYSBtYXAgcHJvcG9zZS4=
+        - 3, 53 :[name=SirMalo]:Picking up this item, or getting it from a NPC, means
+          that you should have experienced everything the map offers.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNTQgOltuYW1lPVNpck1hbG9dOlZpZW5zIG1lIHZvaXIgcXVhbmQgdHUgbGVzIGF1cmFzIHRvdXRlcyByw6ljdXDDqXLDqWVzLCBqZSBzZXJhaSBqdXN0ZSDDoCBjw7R0w6kgZGUgbCdhc2NlbnNldXIgZGUgZ2F1Y2hlICE=
+        - 3, 54 :[name=SirMalo]:Come see me when you've got them all back, I'll be
+          there by the elevator on the left!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 55 :[name=SirMalo]:Allez, je file.
+        - 3, 55 :[name=SirMalo]:Well, I'm off.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Amuse-toi bien !
+        - Have fun!
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -4893,19 +4874,18 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 56 Bonjour !
+        - 3, 56 Hello!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          SmUgY29ubmFpcyB0b3V0IHN1ciBsZXMgYXR0YXF1ZXMgcXUnYXBwcmVubmVudCBsZXMgUG9rw6ltb24gZW4gZ3JhbmRpc3NhbnQu
+        - I know everything about the moves a Pokémon can learn when growing.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNTcgU2kgw6dhIHRlIGRpdCwgamUgcGV1eCBmYWlyZSBhcHByZW5kcmUgw6AgdW4gZGUgdGVzIGNvbXBhZ25vbnMgdW5lIGF0dGFxdWUgcXUnaWwgYXVyYWl0IHB1IG91YmxpZXIgYXUgY291cnMgZGUgc2EgY3JvaXNzYW5jZS4=
+        - 3, 57 If you want, I can teach one of your companions a move they might
+          have forget during their growth.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4986,8 +4966,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNTggUmllbiBuZSB0J2ludMOpcmVzc2FpdCA/
+        - 3, 58 Nothing suited you?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5015,8 +4994,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNTkgSmUgc3VpcyBzw7tyIHF1ZSB0b24gUG9rw6ltb24gc2VyYSBwbHVzIHB1aXNzYW50IGFpbnNpICE=
+        - 3, 59 I'm sure your Pokémon will be stronger this way!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5044,8 +5022,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNjAgTWFsaGV1cmV1c2VtZW50LCBqZSBuZSBwZXV4IHJpZW4gYXBwcmVuZHJlIMOgIHRvbiBQb2vDqW1vbi4uLg==
+        - 3, 60 Unfortunately, there is nothing to teach to your Pokémon...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5068,8 +5045,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNjEgT24gcGV1dCBwYXJmb2lzIHRvbWJlciBzdXIgZGVzIGF0dGFxdWVzIGluc291cMOnb25uw6llcyAh
+        - 3, 61 You can sometimes come across unsuspected moves!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5128,14 +5104,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNjIgSmUgcGV1eCBhcHByZW5kcmUgdW5lIGF0dGFxdWUgdHLDqHMgcHJhdGlxdWUgcG91ciB0J2FpZGVyIMOgIGNhcHR1cmVyIGRlcyBQb2vDqW1vbi4=
+        - 3, 62 I can teach a very useful move to help you catch Pokémon.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNjMgw4dhIHQnaW50w6lyZXNzZSA/
+        - 3, 63 Are you interested?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5153,8 +5127,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNjQgw4AgcXVlbCBQb2vDqW1vbiB2ZXV4LXR1IGwnZW5zZWlnbmVyID8=
+        - 3, 64 To which Pokémon do you want to teach it?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5247,14 +5220,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNjUgQ2V0dGUgYXR0YXF1ZSBsYWlzc2UgdG91am91cnMgYXUgbW9pbnMgMSBQViDDoCBzYSBjaWJsZS4=
+        - 3, 65 This move always leaves at least 1 HP to its target.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 66 Un must-have pour tout Dresseur qui se respecte, si tu veux mon avis
-          !
+        - 3, 66 It's a must-have for any self-respecting Trainer, if you want my opinion.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5283,8 +5254,7 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNjcgTWFsaGV1cmV1c2VtZW50LCBqZSBuZSBwZXV4IHBhcyBhcHByZW5kcmUgbWEgdGVjaG5pcXVlIMOgIHRvbiBQb2vDqW1vbi4uLg==
+        - 3, 67 Unfortunately, I can't teach this move to your Pokémon...
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5321,8 +5291,7 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNjggVHUgYXMgY2hhbmfDqSBkJ2F2aXMgPw==
+        - 3, 68 Did you change your mind?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5350,8 +5319,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNjkgUG91cnRhbnQsIGNldHRlIHRlY2huaXF1ZSBwZXV0IMOqdHJlIHRyw6hzIHV0aWxlIHBvdXIgY2VydGFpbmVzIGNhcHR1cmVzIGTDqWxpY2F0ZXMu
+        - 3, 69 But this move can be very useful for some very delicate catches.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5565,18 +5533,18 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 70 :[name=SirMalo]:Tiens, \N[1] !
+        - 3, 70 :[name=SirMalo]:Well, \N[1]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Alors, comment avance ton exploration ?
+        - So, how is your exploration faring?
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNzEgOltuYW1lPVNpck1hbG9dOlBvdXIgaW5mb3JtYXRpb24sIGlsIGV4aXN0ZSAxNiBQaWVycmVzIEluc29saXRlcyBkYW5zIGNldHRlIGTDqW1vLg==
+        - 3, 71 :[name=SirMalo]:Just for the record, there is 16 Intriguing Stones
+          in this demo.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5601,7 +5569,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 72 :[name=SirMalo]:Et je vois que tu en as... [STONE] !
+        - 3, 72 :[name=SirMalo]:And I see you have... [STONE] of these!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5622,38 +5590,35 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNzMgOltuYW1lPVNpck1hbG9dOi4uLiBKJ2VuIGNvbm5haXMgdW5cRSBxdWkgYSB1dGlsaXPDqSBsYSBjb25zb2xlICE=
+        - 3, 73 :[name=SirMalo]:... I know someone who used the console!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNzQgOltuYW1lPVNpck1hbG9dOkMnZXN0IHRyw6hzIGJpZW4gcXVlIHR1IHQnYXBwcmVubmVzIMOgIHQnZW4gc2VydmlyLg==
+        - 3, 74 :[name=SirMalo]:It's very good to learn how to use it!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNzUgOltuYW1lPVNpck1hbG9dOkF0dGVudGlvbiBjZXBlbmRhbnQgw6AgbmUgcGFzIHRlIGfDomNoZXIgbCdleHDDqXJpZW5jZSBkZSBqZXUgZXQgbGUgbW9tZW50IGx1ZGlxdWUgZCdhcHByZW50aXNzYWdlIHF1ZSBub3VzIHRlIHByb3Bvc29ucyBhdmVjIGNldHRlIGTDqW1vLg==
+        - 3, 75 :[name=SirMalo]:But be sure not to spoil you the game experience and
+          the fun learning moment we're offering with this demo.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNzYgOltuYW1lPVNpck1hbG9dOlNpIHR1IGFzIGTDqWrDoCBjb21wbMOpdMOpIGNldHRlIGTDqW1vIGF1cGFyYXZhbnQsIGV0IHF1ZSB0dSB2ZXV4IGp1c3RlIHJlY2V2b2lyIGxhIHLDqWNvbXBlbnNlIGRlIG5vdXZlYXUsIHR1IHBldXggY29udGludWVyICE=
+        - 3, 76 :[name=SirMalo]:If you already have completed this demo before, and
+          you just want to receive the reward again, you can continue!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNzcgOltuYW1lPVNpck1hbG9dOlNpbm9uLCBvbiB0J2ludml0ZSDDoCBjb250aW51ZXIgZGUgam91ZXIgbm9ybWFsZW1lbnQsIHR1IGFwcHJlbmRyYXMgYmllbiBwbHVzIGFpbnNpICE=
+        - 3, 77 :[name=SirMalo]:Else, I invite you to continue playing the normal
+          way, you'll learn a lot more this way!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNzggOltuYW1lPVNpck1hbG9dOkplIHZhaXMgdGUgZmFpcmUgbW9uIGRpc2NvdXJzIGRlIHLDqXVzc2l0ZSB0b3V0IGRlIG3Dqm1lLCBhdSBjYXMgb8O5Lg==
+        - 3, 78 :[name=SirMalo]:I'm still going to tell you my speech, just in case.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5675,41 +5640,40 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgNzkgOltuYW1lPVNpck1hbG9dOkbDqWxpY2l0YXRpb25zICE=
+        - 3, 79 :[name=SirMalo]:Congratulations!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Tu as obtenu toutes les Pierres Insolites !
+        - You have obtained every Intriguing Stones!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgODAgOltuYW1lPVNpck1hbG9dOkNlbGEgdmV1dCBkaXJlIHF1ZSB0dSBhcyBlbiBwcmluY2lwZSBtw6ltb3Jpc8OpIG/DuSBlc3QgbW9udHLDqWUgY2hhcXVlIGZvbmN0aW9ubmFsaXTDqSAh
+        - 3, 80 :[name=SirMalo]:This means you should have memorized where each feature
+          is showed!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgODEgOltuYW1lPVNpck1hbG9dOkdyw6JjZSDDoCDDp2EsIHR1IHNhdXJhcyDDoCBxdWVsbGUgbWFwIHRlIHLDqWbDqXJlciBzaSB0dSBhcyB1biBkb3V0ZSBzdXIgbCd1bmUgZCdlbnRyZSBlbGxlcy4=
+        - 3, 81 :[name=SirMalo]:Thanks to that, you'll know which map you should refer
+          to when you have a doubt about a given feature.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 82 :[name=SirMalo]:Encore bravo !
+        - 3, 82 :[name=SirMalo]:Again, congrats!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          U2FjaGUsIGQnYWlsbGV1cnMsIHF1ZSBqJ2FpIHVuZSBwZXRpdGUgc3VycHJpc2UgcG91ciB0b2ksIHBvdXIgY29tbcOpbW9yZXIgY2V0dGUgZmluIGQnYXZlbnR1cmUuLi4=
+        - By the way, I have a small surprise for you, to commemorate the end of your
+          journey...
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Suis-moi !
+        - Follow me!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -5790,7 +5754,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 83 :[name=SirMalo]:Encore un petit effort, tu y es presque !
+        - 3, 83 :[name=SirMalo]:Just a little more effort, you're almost there!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5817,13 +5781,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 84 :[name=SirMalo]:Tu es sur la bonne voie !
+        - 3, 84 :[name=SirMalo]:You're on the right way!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgODUgOltuYW1lPVNpck1hbG9dOkNlcnRhaW5lcyBzb250IHBsdXMgZHVyZXMgw6AgdHJvdXZlciBxdWUgZCdhdXRyZXMsIG1haXMgdHUgcGV1eCBsZSBmYWlyZSAh
+        - 3, 85 :[name=SirMalo]:Some are harder to find than others, but you can do
+          it!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5850,14 +5814,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgODYgOltuYW1lPVNpck1hbG9dOlR1IGFzIGZhaXQgbGEgbW9pdGnDqSwgYmllbiBqb3XDqSAh
+        - 3, 86 :[name=SirMalo]:You've done one half, well played!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          TmUgcmVsw6JjaGUgcGFzIHRlcyBlZmZvcnRzICE=
+        - Don't let up in your efforts!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -5884,19 +5846,17 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 87 :[name=SirMalo]:Pas mal !
+        - 3, 87 :[name=SirMalo]:Not bad!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          VHUgYXMgcXVhc2ltZW50IGF0dGVpbnQgbGEgbW9pdGnDqSAh
+        - You've almost done the first half!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          Q29udGludWUgY29tbWUgw6dhICE=
+        - Keep it up!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -5923,18 +5883,17 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 88 :[name=SirMalo]:Tu progresses bien !
+        - 3, 88 :[name=SirMalo]:You're progressing well!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgODkgOltuYW1lPVNpck1hbG9dOkFzLXR1IHJlbmNvbnRyw6kgY2VydGFpbnMgZGUgbWVzIGNvbGzDqGd1ZXMgPw==
+        - 3, 89 :[name=SirMalo]:Did you encounter some of my colleagues?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Ils ont tous une Pierre Insolite avec eux, alors fonce les trouver !
+        - They all have an Intriguing Stone, so go on and find them!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -5961,14 +5920,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgOTAgOltuYW1lPVNpck1hbG9dOkFsb3JzLCBsYSBkw6ltbyB0ZSBwbGHDrnQgPw==
+        - 3, 90 :[name=SirMalo]:So, do you enjoy the demo?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          T24gcydlc3QgZG9ubsOpIMOgIGZvbmQgcG91ciBxdWUgdm91cyBwYXNzaWV6IHRvdXMgdW4gYm9uIG1vbWVudCBkZXNzdXMgIQ==
+        - We gave it our all to make you have a nice moment on it!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -5995,14 +5952,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgOTEgOltuYW1lPVNpck1hbG9dOk4naMOpc2l0ZSBwYXMgw6AgZXhwbG9yZXIgZXQgw6AgcGFybGVyIMOgIHRvdXQgbGUgbW9uZGUgIQ==
+        - 3, 91 :[name=SirMalo]:Don't hesitate to explore and talk to everyone!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          VHUgYXBwcmVuZHJhcyBwbGVpbiBkZSBjaG9zZXMgY29tbWUgw6dhLg==
+        - You'll learn lots of things this way!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -6080,20 +6035,19 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgOTIgOltuYW1lPVNpck1hbG9dOk9oIHNhbHV0IFxOWzFdLCBjb21tZW50IHR1IHZhcyA/IEonZXNww6hyZSBxdWUgY2V0dGUgc3VycHJpc2UgdCdhIHBsdSwgZXQgcXVlIHR1IHQnZXMgYmllbiBhbXVzw6lcRSBzdXIgY2V0dGUgZMOpbW8gdGVjaG5pcXVlICE=
+        - 3, 92 :[name=SirMalo]:Oh hi \N[1], how are you? I hope you enjoyed this
+          little surprise, and you had fun playing this technical demo!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgOTMgOltuYW1lPVNpck1hbG9dOkonZXNww6hyZSBhdXNzaSBxdSdlbGxlIHRlIHNlcnZpcmEgw6AgbCdhdmVuaXIsIHNpIHR1IGNoZXJjaGVzIGRlcyBpbmZvcm1hdGlvbnMgcG91ciB0b24gcHJvcHJlIGZhbmdhbWUgIQ==
+        - 3, 93 :[name=SirMalo]:I also hope it'll be useful to you in the future,
+          if you're seeking some information for your own fangame!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgOTQgOltuYW1lPVNpck1hbG9dOkZhaXMtbGUgbm91cyBzYXZvaXIgc2kgdHUgY3LDqWVzIHRvbiBwcm9wcmUgamV1ICE=
+        - 3, 94 :[name=SirMalo]:Let us know if you happen to create your own!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6144,8 +6098,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgOTUgQydlc3QgdW4gcGl0aXQgdG91dG91IMOgIHNvbiBwYXBhIMOnYSAh
+        - 3, 95 Who's daddy's little good boy?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6192,7 +6145,7 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 96 Heu... C'est pas ce que tu crois !
+        - 3, 96 Erm, it's not what it looks like..!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6243,7 +6196,7 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 97 Rocabot, attaque Rugissement !
+        - 3, 97 Rockruff, use Growl!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6268,8 +6221,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgOTggVHLDqHMgYmllbiAh
+        - 3, 98 Good!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6320,8 +6272,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgOTkgTW9uIFJvY2Fib3QgZXN0IHRyw6hzIGZvcnQsIGV0IGlsIGludGlkbWlkZSB0b3VzIGxlcyBQb2vDqW1vbiBxdWUgamUgY29tYmF0cyAh
+        - 3, 99 My Rockruff is very strong, and it intimidates every Pokémon we're
+          battling!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6372,7 +6324,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 100 Voulez-vous caresser le Rocabot ?
+        - 3, 100 Would you like to pet the Rockruff?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6441,7 +6393,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 101 Roca ! Roca !
+        - 3, 101 Ruff! Ruff!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6535,8 +6487,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTAyIFJvY2Fib3QgYSBsJ2FpciBkw6nDp3UuLi4=
+        - 3, 102 Rockruff seems disappointed...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6628,32 +6579,32 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTAzIDpbbmFtZT1KdWxlc106VCdlcyBhdSBjb3VyYW50IGRlIGwnaGlzdG9pcmUgZGUgbGEgbWV1ZiBxdSdlc3QgdG9tYsOpZSBkZSBsJ2F1dHJlIGPDtHTDqSBkZSBsYSByZW1iYXJkZSBkZXJyacOocmUgbGEgVG91ciB5IGEgcGFzIGxvbmd0ZW1wcyA/
+        - 3, 103 :[name=Jules]:Do you know about this chick who fell off the other
+          side of the guardrail not long ago, behind the Tower?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTA0IDpbbmFtZT1KdWxlc106U8OpcmlldXgsIGMnZXN0IGNoYXVkIGRlIGNhbmVyIGNvbW1lIMOnYSwgYydlc3QgbcOqbWUgcGFzIGJhZGFzcyBvdSBxdW9pLi4u
+        - 3, 104 :[name=Jules]:No kidding, dying like that is wack, not even badass
+          or something...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTA1IDpbbmFtZT1KdWxlc106WSBlbiBhIHF1aSBkaXNlbnQgcXVlIHNvbiBmYW50w7RtZSBoYW50ZSBsZXMgbGlldXggcGVuZGFudCBsYSBudWl0IGRlcHVpcyBzYSBtb3J0Lg==
+        - 3, 105 :[name=Jules]:Some people are saying her ghost haunts the grounds
+          at night since her death.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTA2IDpbbmFtZT1KdWxlc106U2kgaifDqXRhaXMgbW9ydCBkZSBsYSBtw6ptZSBtYW5pw6hyZSwgaidzZXJhaXMgYXVzc2kgdmVudSBoYW50ZXIgbGEgem9uZSB0ZWxsZW1lbnQgaidhdXJhaXMgZXUgbGUgc2V1bS4g
+        - 3, 106 :[name=Jules]:If I died the same way, I'd be too salty not to haunt
+          the area.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTA3IDpbbmFtZT1KdWxlc106TWFpcyBib24sIMOnYSBleGlzdGUgcGFzIGxlcyBmYW50w7RtZXMsIGxlcyBzZXVscyB2cmFpcyBTcGVjdHJlcyBjJ2VzdCBsZXMgUG9rw6ltb24sIHBhcyB2cmFpID8g
+        - 3, 107 :[name=Jules]:But well, revenants don't exist, the only ghosts are
+          the Pokémon, right..?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6698,20 +6649,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTA4IDpbbmFtZT1KdWxlc106SidwZXV4IHQnYWlkZXIgcCd0J8OqdHJlID8=
+        - 3, 108 :[name=Jules]:Ya want some help maybe?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTA5IDpbbmFtZT1KdWxlc106Li4uIFQnYXMgcXVlbHF1ZSBjaG9zZSDDoCBtZSBkaXJlID8=
+        - 3, 109 :[name=Jules]:... Yo, you got somethin' to say to me?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          QXp5LCBqJ3Qnw6ljb3V0ZS4=
+        - Spit it out, I'm all ears.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -6731,48 +6679,44 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTExIDpbbmFtZT1KdWxlc106UXUnZXN0LWNlIHF1ZSB0dSBtJ2RpcyBsw6AgPw==
+        - 3, 111 :[name=Jules]:What you talkin' 'bout, fam?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTEyIDpbbmFtZT1KdWxlc106WSBhIHVuZSBtZXVmIG5vbW3DqWUgTWFyaXNzYSBxdWkgc291aGFpdGUgbWUgZGlyZSDDoCBxdWVsIHBvaW50IGVsbGUgbSdhaW1lID8=
+        - 3, 112 :[name=Jules]:Ayy, there's this chick Marissa lookin' to drop some
+          love letters on me?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTEzIDpbbmFtZT1KdWxlc106SmUuLi4gSmUgc3VpcyB0b3VjaMOpLCBtYWlzLi4u
+        - 3, 113 :[name=Jules]:I'm feelin' it, but like...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 114 :[name=Jules]:PTDR, c'est qui ?
+        - 3, 114 :[name=Jules]:LMFAO, who's that?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTE1IDpbbmFtZT1KdWxlc106R2VucmUsIHBvdXJxdW9pIGVsbGUgZXN0IHBhcyB2ZW51ZSBtZSBsZSBkaXJlIGQnZWxsZS1tw6ptZSA/
+        - 3, 115 :[name=Jules]:Like, why ain't she come up and tell me herself?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Et j'la connais pas moi, cette Marissa.
+        - I don't even know this Marissa chick.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTE2IDpbbmFtZT1KdWxlc106Qm9uLCBzaSBlbGxlIHZldXQgcXUnb24gYXBwcmVubmUgw6Agc2UgY29ubmHDrnRyZSwgaidmZXJhaSB1biBlZmZvcnQgZW4gYm9uIGdlbnRsZW1hbiBxdWUgaidzdWlzLi4u
+        - 3, 116 :[name=Jules]:Alright, if she's lookin' to get to know each other,
+          I'll make an effort, you know, being the classy gentleman I am and all that.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTE3IDpbbmFtZT1KdWxlc106RWxsZSBlc3Qgb8O5LCBkdSBjb3VwID8=
+        - 3, 117 :[name=Jules]:So where's she at then?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6782,7 +6726,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 118 :[name=Jules]:Hein...? Quoi ?
+        - 3, 118 :[name=Jules]:Huh... What? She literally dead?!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6792,14 +6736,13 @@ events:
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTE5IDpbbmFtZT1KdWxlc106QXR0ZW5kcywgbWUgZGlzIHBhcyBxdWUuLi4gYydlc3QgbGEgbWV1ZiBxdSdlc3QgdG9tYsOpZSByw6ljZW1tZW50ID8h
+        - 3, 119 :[name=Jules]:Hold up, you ain't tellin' me she's the chick who went
+          down recently, right?!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTIwIDpbbmFtZT1KdWxlc106T2ssIGondmV1eCBwbHVzIHJpZW4gc2F2b2lyLCDDp2EgbSdpbnTDqXJlc3NlIHBsdXMsIG1lIHBhcmxlIHBsdXMsIEErLg==
+        - 3, 120 :[name=Jules]:Aight, I don't wanna know nothin' more, I'm out, peace.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6888,14 +6831,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTIxIDpbbmFtZT1KdWxlc106TWUgcGFybGUgcGx1cyBzJ3RldXBsYWl0LCB0b24gaGlzdG9pcmUgZGUgZmFudMO0bWUgcXVpIG1lIGtpZmZlIMOnYSBtZSBmYWl0IGZyb2lkIGRhbnMgbGUgZG9zLi4u
+        - 3, 121 :[name=Jules]:Yo, stop talkin' to me, please. That ghost story of
+          yours is giving me the chills. I'm out.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTIyIDpbbmFtZT1KdWxlc106Sidlc3DDqHJlIHF1ZSB0dSBtJ2FzIHBhcyBtYXVkaXQgYXZlYyB0ZXMgYsOqdGlzZXMgbMOgLg==
+        - 3, 122 :[name=Jules]:Hope you ain't cursed me with that nonsense of yours.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7339,20 +7281,18 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTIzIEMnZXN0IHVuZSBhZmZpY2hlIHByb21vdGlvbm5lbGxlLiBVbiBzbG9nYW4gZXN0IG1hcnF1w6kgZGVzc3VzLg==
+        - 3, 123 It's a promotional poster. A slogan is written on it.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTI0ICJVbiBqb3VyIHZvdXMgc2VyZXogbGVzIG1laWxsZXVycyBkcmVzc2V1cnMsIHZvdXMgdm91cyBiYXR0cmV6IHNhbnMgcsOpcGl0ICE=
+        - 3, 124 "You wanna be the very best, like no one ever was.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          UmVqb2lnbmV6IGxhIGxpZ3VlIGRlIHZvdHJlIHLDqWdpb24sIGZhaXRlcyB0b3V0IHBvdXIgw6p0cmUgdmFpbnF1ZXVyLCBldCBnYWduZXogdm9zIGTDqWZpcyAhIg==
+        - If catching the best is your real quest, and to train them is your cause,
+          join your local league!"
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -8814,24 +8754,23 @@ events:
         code: 235
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTI1IDpbbmFtZT1TaXJNYWxvXTpOb3VzLXkgdm9pbMOgLCBhdmVjIHRvdXRlIGwnw6lxdWlwZSwgZXQgdGVzIHByZW1pZXJzIFBva8OpbW9uICE=
+        - 3, 125 :[name=SirMalo]:Here we are, with the whole team and your very first
+          Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 126 :[name=SirMalo]:Ce qu'on va faire ?
+        - 3, 126 :[name=SirMalo]:What we're going to do?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTI3IDpbbmFtZT1TaXJNYWxvXTpPbiB2YSBmYWlyZSB1bmUgcGhvdG8gY29tbcOpbW9yYXRpdmUgIQ==
+        - 3, 127 :[name=SirMalo]:We're going to take a commemorative photo!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 128 :[name=SirMalo]:Regarde vers le bas...
+        - 3, 128 :[name=SirMalo]:Look down...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8901,12 +8840,12 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 129 :[name=SirMalo]:Et dis "OUISTICRAM" !
+        - 3, 129 :[name=SirMalo]:Say "Chespin"!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 130 :[name=Tout le monde]::[align=center]:OUISTICRAM !
+        - 3, 130 :[name=Everyone]::[align=center]:CHESPIN!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8996,20 +8935,21 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTMxIDpbbmFtZT1TaXJNYWxvXTpFdCB2b2lsw6AsIGxhIHBob3RvIGVzdCBwcmlzZS4uLiBPdSBwbHV0w7R0IGRldnJhaXMtamUgZGlyZSA6IGxlIHNjcmVlbnNob3QgIQ==
+        - 3, 131 :[name=SirMalo]:There, the photo is taken... Or should I say the
+          screenshot!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTMyIDpbbmFtZT1TaXJNYWxvXTpUdSBwZXV4IGxlIHJldHJvdXZlciBkYW5zIGxlIGRvc3NpZXIgZHUgcHJvamV0LCBub21tw6kgInRlY2huaWNhbF9kZW1vLnBuZyIu
+        - 3, 132 :[name=SirMalo]:You can find it in the folder of the demo, named
+          "technical_demo.png".
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTMzIDpbbmFtZT1TaXJNYWxvXTpDZWxhIG5vdXMgZmVyYWl0IHN1cGVyIHBsYWlzaXIgcXVlIHR1IHBvc3RlcyBjZSBzY3JlZW4gc3VyIGxlIERpc2NvcmQgZGUgUG9rw6ltb24gV29ya3Nob3AgZGFucyBsZSBzYWxvbiAjcHNkay1kaXNjdXNzaW9ucywgYWNjb21wYWduw6kgZGUgdGVzIA==
+        - '3, 133 :[name=SirMalo]:We would love if you could share this screen and
+          your reactions about the demo on the Pokémon Workshop Discord server, in
+          the channel #psdk-talk!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9020,20 +8960,18 @@ events:
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTM0IDpbbmFtZT1TaXJNYWxvXTpFbmNvcmUgbWVyY2kgZCdhdm9pciBqb3XDqSBqdXNxdSdhdSBib3V0LCBqJ2VzcMOocmUgcXVlIHR1IGFzIHByaXMgYXV0YW50IGRlIHBsYWlzaXIgw6AgYXJwZW50ZXIgY2V0dGUgZMOpbW8gcXVlIG5vdXMgYXZvbnMgZXUgw6AgbGEgZmFpcmUgIQ==
+        - 3, 134 :[name=SirMalo]:Thanks again for playing until the end, we hope you
+          had as much fun when journeying through this demo as us creating it!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTM1IDpbbmFtZT1TaXJNYWxvXTpPbiBlc3DDqHJlIHRlIHZvaXIgdHLDqHMgYmllbnTDtHQgc3VyIGxlIERpc2NvcmQgIQ==
+        - 3, 135 :[name=SirMalo]:We hope to see you soon on the Discord!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTM2IDpbbmFtZT1TaXJNYWxvXTpFdCBzdXIgY2UsIGNyw6lkaXRzICE=
+        - 3, 136 :[name=SirMalo]:And now, roll the credits!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9229,14 +9167,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTM3IEljaSwgb24gZW5jb3VyYWdlIGxlcyBqZXVuZXMgRHJlc3NldXJzIMOgIGF0dHJhcGVyIHBsZWluIHBsZWluIHBsZWluIGRlIFBva8OpbW9uICE=
+        - 3, 137 Here, we encourage young Trainers to catch lots and lots of Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTM4IEplIHZhaXMgdXRpbGlzZXIgbGEgY29tbWFuZGUgXGNbNV0iZ2l2ZV9pdGVtIlxjWzBdIHBvdXIgdGUgZG9ubmVyIDEwIFBva8OpYmFsbHMu
+        - 3, 138 I'm going to use the \c[5]"give_item"\c[0] command to give you 10
+          Poké Balls.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9246,14 +9183,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTM5IExhIFRvdXIgcmVnb3JnZSBkJ3VuZSBncmFuZGUgdmFyacOpdMOpIGRlIFBva8OpbW9uIMOgIGF0dHJhcGVyLg==
+        - 3, 139 The Tower brims with a great variety of Pokémon to catch.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTQwIEFsb3JzIG4naMOpc2l0ZSBwYXMgw6AgZW4gbGFuY2VyIGRhbnMgdG91cyBsZXMgc2VucyAh
+        - 3, 140 So don't hesitate to launch a lot of these in all directions!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9307,14 +9242,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTQxIExhIFRvdXIgcmVnb3JnZSBkJ3VuZSBncmFuZGUgdmFyacOpdMOpIGRlIFBva8OpbW9uIMOgIGF0dHJhcGVyLg==
+        - 3, 141 The Tower brims with a great variety of Pokémon to catch.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTQyIEFsb3JzIG4naMOpc2l0ZSBwYXMgw6AgZW4gbGFuY2VyIGRhbnMgdG91cyBsZXMgc2VucyAh
+        - 3, 142 So don't hesitate to launch a lot of these in all directions!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9365,19 +9298,18 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 3, 143 Eh, psst...
+        - 3, 143 Hey, psst...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTQ0IEplIHZhaXMgdGUgZmlsZXIgdW4gdHJ1YyBkaXNjcsOpdG9zLi4u
+        - 3, 144 I'm gonna slip you something on the down low...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MywgMTQ1IEplIGxlIG1ldHMgZGlyZWN0ZW1lbnQgZGFucyB0b24gc2FjIGdyw6JjZSDDoCBsYSBjb21tYW5kZSBcY1s1XSIkYmFnLmFkZF9pdGVtIlxjWzBdLg==
+        - 3, 145 I put it directly in your bag using the \c[5]"$bag.add_item"\c[0]
+          command.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9392,8 +9324,7 @@ events:
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          QWxsZXosIGJvdWdlIGRlIGzDoC4=
+        - Now scram.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand

--- a/Data/Map004.rxdata.yml
+++ b/Data/Map004.rxdata.yml
@@ -823,62 +823,57 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 'choice(26, 9, "4, 20 1: Hall de la Tour",'
+        - 'choice(26, 9, "4, 20 1: Main Hall",'
         indent: 0
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"4, 21 2: Prairie ruisselante",'
+        - '"4, 21 2: Prairie Stream",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"4, 22 3: Crique turbulente",'
+        - '"4, 22 3: Turbulent Creek",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"4, 23 4: Caverne rocailleuse",'
+        - '"4, 23 4: Rocky Cavern",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"4, 24 5: Marais cendreux",'
+        - '"4, 24 5: Ashen Marsh",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          IjQsIDI1IDY6IFRvdW5kcmEgdmVyZ2xhY8OpZSIs
+        - '"4, 25 6: Icy Tundra",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          IjQsIDI2IDc6IFBpc3RlIGFtw6luYWfDqWUiLA==
+        - '"4, 26 7: Built Road",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          IjQsIDI3IDg6IEluc3RhbGxhdGlvbiBtYWxmYW3DqWUiLA==
+        - '"4, 27 8: Shady Facility",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"4, 28 Retour")'
+        - '"4, 28 Return")'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMCBOb3VzIHNvbW1lcyBhY3R1ZWxsZW1lbnQgw6AgbCfDqXRhZ2UgXHZbMTAzXS4=
+        - 4, 0 We are currently on floor \v[103].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          w4AgcXVlbCBlbnZpcm9ubmVtZW50IHNvdWhhaXRlei12b3VzIGFsbGVyID8=
+        - Which environment may I take you to?
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -916,8 +911,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMSBOb3VzIHNvbW1lcyBkw6lqw6Agw6AgY2V0IMOpdGFnZS4=
+        - 4, 1 We are already on that floor?!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -949,12 +943,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 4, 2 Certainement.
+        - 4, 2 Certainly.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Nous descendons.
+        - Elevator going down.
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1064,12 +1058,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 4, 3 Certainement.
+        - 4, 3 Certainly.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Nous montons.
+        - Elevator going up.
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1315,8 +1309,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgNCBQcmVtaWVyIMOpdGFnZSA6IEhhbGwgZGUgbGEgVG91ci4=
+        - 4, 4 The first floor has the Main Hall.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1338,8 +1331,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgNSBEZXV4acOobWUgw6l0YWdlIDogUHJhaXJpZSBydWlzc2VsYW50ZS4=
+        - 4, 5 The second floor has the Prairie Stream.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1361,8 +1353,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgNiBUcm9pc2nDqG1lIMOpdGFnZSA6IENyaXF1ZSB0dXJidWxlbnRlLg==
+        - 4, 6 The third floor has the Turbulent Creek.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1384,8 +1375,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgNyBRdWF0cmnDqG1lIMOpdGFnZSA6IENhdmVybmUgcm9jYWlsbGV1c2Uu
+        - 4, 7 The fourth floor has the Rocky Cavern.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1407,8 +1397,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgOCBDaW5xdWnDqG1lIMOpdGFnZSA6IE1hcmFpcyBjZW5kcmV1eC4=
+        - 4, 8 The fifth floor has the Ashen Marsh.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1430,8 +1419,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgOSBTaXhpw6htZSDDqXRhZ2UgOiBUdW5kcmEgdmVyZ2xhY8OpZS4=
+        - 4, 9 The sixth floor has the Icy Tundra.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1453,8 +1441,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMTAgU2VwdGnDqG1lIMOpdGFnZSA6IFBpc3RlIGFtw6luYWfDqWUu
+        - 4, 10 The seventh floor has the Built Road.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1476,8 +1463,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMTEgSHVpdGnDqG1lIMOpdGFnZSA6IEluc3RhbGxhdGlvbiBtYWxmYW3DqWUu
+        - 4, 11 The eighth floor has the Shady Facility.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1643,8 +1629,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMTIgUHJlbWllciDDqXRhZ2UgOiBIYWxsIGRlIGxhIFRvdXIu
+        - 4, 12 The first floor has the Main Hall.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1666,8 +1651,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMTMgRGV1eGnDqG1lIMOpdGFnZSA6IFByYWlyaWUgcnVpc3NlbGFudGUu
+        - 4, 13 The second floor has the Prairie Stream.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1689,8 +1673,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMTQgVHJvaXNpw6htZSDDqXRhZ2UgOiBDcmlxdWUgdHVyYnVsZW50ZS4=
+        - 4, 14 The third floor has the Turbulent Creek.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1712,8 +1695,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMTUgUXVhdHJpw6htZSDDqXRhZ2UgOiBDYXZlcm5lIHJvY2FpbGxldXNlLg==
+        - 4, 15 The fourth floor has the Rocky Cavern.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1735,8 +1717,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMTYgQ2lucXVpw6htZSDDqXRhZ2UgOiBNYXJhaXMgY2VuZHJldXgu
+        - 4, 16 The fifth floor has the Ashen Marsh.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1758,8 +1739,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMTcgU2l4acOobWUgw6l0YWdlIDogVHVuZHJhIHZlcmdsYWPDqWUu
+        - 4, 17 The sixth floor has the Icy Tundra.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1781,8 +1761,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMTggU2VwdGnDqG1lIMOpdGFnZSA6IFBpc3RlIGFtw6luYWfDqWUu
+        - 4, 18 The seventh floor has the Built Road.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1804,8 +1783,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NCwgMTkgSHVpdGnDqG1lIMOpdGFnZSA6IEluc3RhbGxhdGlvbiBtYWxmYW3DqWUu
+        - 4, 19 The eighth floor has the Shady Facility.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map005.rxdata.yml
+++ b/Data/Map005.rxdata.yml
@@ -322,20 +322,18 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMCBKJ8OpdHVkaWUgbGEgZGl2ZXJzaXTDqSBkZSBsYSBmYXVuZSBkZXMgZGlmZsOpcmVudHMgw6l0YWdlcy4=
+        - 5, 0 I study the diversity of the wildlife in each floor.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMSAgRCdhaWxsZXVycywgY2VzIGhlcmJlcy1sw6Agc29udCBwYXJ0aWN1bGnDqHJlcywgbGVzIFBva8OpbW9uIHF1aSB2aXZlbnQgZGVkYW5zIGF0dGFxdWVudCB0b3Vqb3VycyBwYXIgZGV1eCAh
+        - 5, 1 By the way, this patch of grass is particular as the Pokémon in it
+          always attack in groups of two!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMiBJbCBwYXJhw650IHF1ZSBjJ2VzdCBkw7sgw6AgdW5lIFxjWzVdY29uZmlndXJhdGlvbiBwYXJ0aWN1bGnDqHJlIGR1IGdyb3VwZSBkZSByZW5jb250cmVcY1swXS4=
+        - 5, 2 Apparently it's due to a \c[5]specific setup of the encounter group\c[0].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -389,8 +387,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMyBKZSBzYWlzIHBhcyBzaSB0dSBsZSBzYXZhaXMsIG1haXMgaWwgZXN0IHBvc3NpYmxlIGRlIHDDqmNoZXIgZGVwdWlzIHVuIHBvbnQgISBDJ2VzdCBiZWF1IGxhIHRlY2hub2xvZ2llICE=
+        - 5, 3 I don't know if you already know, but it's possible to fish from a
+          bridge!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -402,8 +400,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMTggSmUgdm9pcyBxdWUgdHUgbidhcyBwYXMgZGUgY2FubmUgw6AgcMOqY2hlICEgVGllbnMsIGplIHQnZW4gZG9ubmUgcXVlbHF1ZXMgdW5lcyAh
+        - 5, 18 I see you don't have any fishing rod! Here, take these!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -437,14 +434,13 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgNCBEJ2FpbGxldXJzLCBqZSBzdWlzIGNvbnNpZMOpcsOpIGNvbW1lIMOpdGFudCBzdXIgbGUgcG9udCwgZG9uYyB0dSBwb3VycmFzIHBhc3NlciBlbiBkZXNzb3VzIGRlIG1vaS4=
+        - 5, 4 Moreover, as I'm considered on the bridge, you'll be able to pass under
+          me.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgNSBFdCBzaSB0dSBlc3NheWVzIGRlIG1lIHBhcmxlciBkZXB1aXMgbCdlYXUsIGplIG5lIHRlIHLDqXBvbmRyYWlzIHBhcyAh
+        - 5, 5 And if you try to talk to me while surfing, I won't answer you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -505,7 +501,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 5, 6 Vei-veinard !
+        - 5, 6 Chan-chansey!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -708,8 +704,7 @@ events:
         code: 249
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgNyBMZXZlaW5hcmQgc29pZ25lIHZvdHJlIMOpcXVpcGUuW1dBSVQgOTBd
+        - 5, 7 Chansey heals your team.[WAIT 90]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1609,20 +1604,19 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgOCBJbCBleGlzdGUgdW5lIGzDqWdlbmRlIHF1aSBkaXQgcXVlIGNlbHVpIHF1aSBhcnJpdmUgw6AgcmVtb250ZXIgbGEgY2FzY2FkZSBzZSB2ZXJyYSBvZmZyaXIgdW5lIHBpZXJyZSBkJ3VuZSB2YWxldXIgaW5lc3RpbWFibGUuIFBlcnNvbm5lIG4nYSBqYW1haXMgZXNzYXnDqSBjZWxhIGRpdC4g
+        - 5, 8 A legend says that the one who succeed in ascending the waterfall will
+          be granted a stone of inestimable value.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 5, 9 Il faut pour cela pouvoir utiliser Cascade. Y'a un nageur en contrebas
-          qui l'offre, mais il faut Surf pour lui parler...
+        - 5, 9 For that, Waterfall is needed.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMTAgSidhaSBjcnUgdm9pciBxdSd1bmUgQ1MgU3VyZiBhIMOpdMOpIG91Ymxpw6kgZGUgbCdhdXRyZSBjw7R0w6kgZHUgcG9udCwgbWFpcyBpbCBmYXV0IGxhIENTIENvdXBlIHBvdXIgbCdhdHRlaW5kcmUuLi4gcXVlIGplIHZhaXMgZ2VudGltZW50IHRlIGRvbm5lciAhIEFwcsOocyB0b3V0LCBzaSBqZSB0ZSBsYSBkb25uZSwgeSdhIG1veWVuIHF1ZSB0dSB2w6lyaWZpZXMgbGEgdsOpcmFjaXTDqSBkZSBjZXR0ZSBsw6lnZW5kZSwgZG9uYyDDp2EgdmF1dCBsZSBjb3VwICE=
+        - 5, 10 I think I saw a dropped HM Surf at the other side of the bridge, but
+          to reach it, you need the HM Cut... which I'll generously give you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1637,8 +1631,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMTEgVCdpbWFnaW5lcyBzaSBlbGxlIGVzdCByw6llbGxlID8gw4dhIHNlcmFpdCDDoCBham91dGVyIGF1eCBteXN0w6hyZXMgZGUgbGEgVG91ciBwb3VyIHPDu3IgIQ==
+        - 5, 11 Can you believe if it's actually real?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1689,8 +1682,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMTIgVCdpbWFnaW5lcyBzaSBlbGxlIGVzdCByw6llbGxlID8gQ2Egc2VyYWl0IMOgIGFqb3V0ZXIgYXV4IG15c3TDqHJlcyBkZSBsYSBUb3VyIHBvdXIgc8O7ciAh
+        - 5, 12 Can you believe if it's actually real?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1735,8 +1727,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMTMgTGEgbMOpZ2VuZGUgZGlzYWl0IGRvbmMgdnJhaS4uLg==
+        - 5, 13 So the legend was true...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1787,20 +1778,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMTQgSmUgcHLDqWbDqHJlIGxhcmdlbWVudCBtZSBiYWlnbmVyIGRhbnMgbCdlYXUgZGUgY2V0IMOpdGFnZSBxdWUgY2VsbGUgZGUgbCfDqXRhZ2UganVzdGUgYXUgZGVzc3VzLi4uIFknYSB0cm9wIGRlIHJhcGlkZXMsIGonc3VpcyBwYXMgdW5lIG5hZ2V1c2Ugb2x5bXBpcXVlIG1vaSAh
+        - 5, 14 I definitely prefer to swim in this water than in the floor just above...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 5, 15 Et en plus, ici, y'a la cascade ! Ce genre de sons, c'est hyper relaxant
-          !
+        - 5, 15 To add to that, there's the waterfall here!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NSwgMTYgRW4gcGFybGFudCBkZSBjYXNjYWRlLCDDp2EgdGUgZGlyYWl0IHBhcyBxdWUgamUgdGUgZG9ubmUgbGEgQ1MgQ2FzY2FkZSA/IENvbW1lIMOnYSwgdHUgcG91cnJhcyBsYSByZW1vbnRlciBjb21tZSB0dSB2ZXV4ICE=
+        - 5, 16 Talking about that, are you interested in the HM Waterfall?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1861,7 +1849,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 5, 17 Alors ? Ca fait quoi de remonter une cascade ?
+        - 5, 17 So? How is it to climb a waterfall?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map006.rxdata.yml
+++ b/Data/Map006.rxdata.yml
@@ -454,36 +454,34 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 0 Mon reflet dans cette flaque est absolument magnifique...
+        - 6, 0 My reflection in this puddle is absolutely gorgeous...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMiBOZSB2aWVucyBwYXMgbGUgZMOpZm9ybWVyIGVuIG1hcmNoYW50IGRlc3N1cyAh
+        - 6, 2 Don't distort it by stepping on it!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMSBJbCBhcHBhcmHDrnQgZ3LDomNlIGF1IFxjWzVddGFnICJbcmVmbGVjdGlvbj1vbl0iXGNbMF0gZGFucyBtb24gbm9tIGQnZXZlbnQu
+        - 6, 1 It appears thanks to the \c[5]"[reflection=on]" tag\c[0] present in
+          my name.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 30 Mais ce n'est pas suffisant...
+        - 6, 30 But it's not all there is to it...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMzEgTGVzIHRpbGVzIGRvaXZlbnQgw6p0cmUgdHJhbnNwYXJlbnQgcG91ciB2b2lyIGxlIHJlZmxldC4=
+        - 6, 31 The tiles must be transparent to see the reflection.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 32 Pour ce qui est de la couleur de fond, tu peux simplement utiliser
-          un panorama de la couleur voulue !
+        - 6, 32 As for the background color, you can just use a panorama with the
+          wanted color!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1068,8 +1066,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMyA6W25hbWU9R2/DqWxpc2VdOkdvICEgR28gISBHb2/DqcOpw6kgISBbV0FJVCA2MF0=
+        - 6, 3 :[name=Wingull]:Wiiii! Wiiii! Wiiiin![WAIT 60]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1160,7 +1157,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 4 Vei-veinard !
+        - 6, 4 Chan-chansey!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1363,8 +1360,7 @@ events:
         code: 249
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgNSBMZXZlaW5hcmQgc29pZ25lIHZvdHJlIMOpcXVpcGUuW1dBSVQgOTBd
+        - 6, 5 Chansey heals your team.[WAIT 90]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2143,25 +2139,24 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 33 J'adore jouer dans les flaques !
+        - 6, 33 I like to play in puddles!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMzQgUXVhbmQgdHUgbWFyY2hlcyBzdXIgdW4gU3lzdGVtdGFnIFxjWzVdUHVkZGxlXGNbMF0sIHVuZSBwZXRpdGUgb25kZSBhcHBhcmHDrnQgIQ==
+        - 6, 34 When you walk in a \c[5]Puddle\c[0] Systemtag, a little ripple appears!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMzUgVHUgbCdhcyBwZXV0LcOqdHJlIHJlbWFycXXDqSwgbGEgZmxhcXVlIG5lIHNvcnQgcGFzIGRlIGwnZWF1LiBDJ2VzdCBwYXJjZSBxdWUgbCdhbmltYXRpb24gZXN0IGZhaXRlIHBvdXIgc2Ugam91ZXIgc291cyBsYSBmbGFxdWUgIQ==
+        - 6, 35 Maybe you saw that, but the ripple doesn't leave the water. It's because
+          the animation is made to be displayed under this puddle!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 36 Donc il faut que la flaque soit transparente ! La gentille madame
-          qui s'admire te l'expliquera !
+        - '6, 36 So the puddle must be transparent! The nice lady who admires herself
+          will explain this to you! '
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2187,8 +2182,7 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMzcgUGxvdWMuLi4gUGxvYy4gSMOpaMOpICE=
+        - 6, 37 Plop... Plop. Hehe!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2247,20 +2241,18 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgNiBMYSBtZXIgZXN0IHBhcnRpY3VsacOocmVtZW50IGFnaXTDqWUgaWNpLg==
+        - 6, 6 The sea is quite choppy here.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgNyBMZXMgaW5nw6luaWV1cnMgZGUgbGEgVG91ciBvbnQgw6lxdWlww6kgbGEgc2FsbGUgZCd1biBtw6ljYW5pc21lIGfDqW7DqXJhbnQgZGUgZm9ydCBjb3VyYW50cy4=
+        - 6, 7 The Tower's engineers equiped this room with a mechanism that generates
+          powerful rapids.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgOCBDJ2VzdCBwcm9kaWdpZXV4LCBpbHMgb250IG3Dqm1lIHLDqXVzc2kgw6AgY3LDqWVyIHVuIHRvdXJiaWxsb24gIQ==
+        - 6, 8 It's quite impressive, they even succeeded in creating a whirlpool!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2276,13 +2268,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 9 Je vois que tu as la CS Surf...
+        - 6, 9 I see you have the HM Surf...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMTAgVHUgdmFzIHBvdXZvaXIgdm9ndWVyIGVuIHRvdXRlIGxpYmVydMOpICE=
+        - 6, 10 You can sail freely!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2295,18 +2286,17 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 11 Oh !
+        - 6, 11 Oh!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - On dirait que tu n'as pas la CS Surf !
+        - It seems like you don't have the HM Surf!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMTIgTGFpc3NlLW1vaSBhcnJhbmdlciDDp2EuLi4=
+        - 6, 12 Let me fix that...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2316,8 +2306,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMTMgVHUgdmFzIHBvdXZvaXIgdm9ndWVyIGVuIHRvdXRlIGxpYmVydMOpICE=
+        - 6, 13 You can now sail freely!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2376,19 +2365,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 14 J'adore marcher dans le sable !
+        - 6, 14 I love to walk on the sand!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMTUgw4dhIGxhaXNzZSBkZXMgdHJhY2VzIGRlIHBhcyBwYXJ0b3V0ICE=
+        - 6, 15 It leaves footprints everywhere!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMTYgTWFpcyBjZSBzYWJsZS1sw6AgZXN0IGluZmVzdMOpIGRlIFBva8OpbW9uIHNhdXZhZ2VzIHF1aSBzZSBjYWNoZW50Li4u
+        - 6, 16 But this sand is infested with wild Pokémon hiding in it...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2442,20 +2429,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMTcgSidhaW1lIGJlYXVjb3VwIGNlIHBldGl0IGlsw7R0IGlzb2zDqS4=
+        - 6, 17 I really enjoy this small isolated islet.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMTggUmFyZXMgc29udCBjZXV4IHF1aSBtZSByZW5kZW50IHZpc2l0ZSwgZG9uYyBqJ2FpbWUgYmllbiBsZXMgcsOpY29tcGVuc2VyICE=
+        - 6, 18 Rare are those who visit me, so I always make sure to reward them!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMTkgVmV1eC10dSBxdWUgaidlbnNlaWduZSBsYSBjYXBhY2l0w6kgU2lwaG9uIMOgIHVuIGRlIHRlcyBQb2vDqW1vbiA/
+        - 6, 19 Do you want me to teach the move Whirlpool to one of your Pokémon?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2473,8 +2457,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMjAgw4AgcXVlbCBQb2vDqW1vbiB2ZXV4LXR1IGwnZW5zZWlnbmVyID8=
+        - 6, 20 To which Pokémon should I teach it?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2596,8 +2579,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMjEgSWwgc2VtYmxlcmFpdCBxdWUgdG9uIFtQT0tFXSBjb25uYWlzc2UgZMOpasOgIFNpcGhvbi4uLg==
+        - 6, 21 It seems like your [POKE] already knows Whirlpool...
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2615,8 +2597,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMjIgQWxvcnMgZW5zZWlnbm9ucyBTaXBob24gw6AgdG9uIFtQT0tFXS4=
+        - 6, 22 Alright, let's teach Whirlpool to your [POKE].
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2636,7 +2617,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 23 Ton [POKE] pourra maintenant traverser les tourbillons marins !
+        - 6, 23 Your [POKE] will now be able to across the marine swirls!
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2673,13 +2654,13 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 24 Je crains que ton [POKE] ne soit en mesure d'apprendre cette attaque...
+        - 6, 24 I'm afraid your [POKE] isn't able to learn this move...
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMjUgVHUgcGV1eCB0cm91dmVyIGNlcnRhaW5lcyBlc3DDqGNlcyBkZSBQb2vDqW1vbiBwb3V2YW50IG1hw650cmlzZXIgU2lwaG9uIGRhbnMgbGEgbWVyIGF1dG91ciBkZSBub3VzLCBvdSBkYW5zIGxhIHJpdmnDqHJlLCDDoCBsJ8OpdGFnZSBpbmbDqXJpZXVyLg==
+        - 6, 25 You can find certain Pokémon species that can learn Whirlpool in the
+          sea around us, or in the river in the floor below.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2705,7 +2686,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 26 Tu ne veux pas aller explorer la haute mer ?
+        - 6, 26 Don't you want to explore the high sea?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2733,7 +2714,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 6, 27 Tu ne veux pas aller explorer la haute mer ?
+        - 6, 27 Don't you want to explore the high sea?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2815,14 +2796,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMjggSmUgbSfDqWNoYXVmZmUgYXZhbnQgZCdhZmZyb250ZXIgbGVzIHJhcGlkZXMgIQ==
+        - 6, 28 I'm warming up before challenging the rapids!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NiwgMjkgQ29tbWUgaidhaSBsZSB0YWcgXGNbNV0ic3VyZl8iXGNbMF0gZGFucyBtb24gbm9tLCBqJ2FwcGFyYcOucyBjb21tZSBpbCBmYXV0IGVuIGpldS4=
+        - 6, 29 As I have the \c[5]"surf_" tag\c[0] in my name, I can't leave the
+          water and I correctly interact with it.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map007.rxdata.yml
+++ b/Data/Map007.rxdata.yml
@@ -420,14 +420,13 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMCA6W25hbWU9Pz8/XTpFbmNvcmUgdW5lIGJvbm5lIGpvdXJuw6llIGRlIGJvdWxvdCBhY2NvbXBsaWUgIQ==
+        - 7, 0 :[name=???]:Another great day of work done!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMSA6W25hbWU9Pz8/XTpMZSBzb2wgw6AgbCdvdWVzdCBkZSBsYSBzYWxsZSBlc3QgZW5jb3JlIHN1cGVyIGZyYWdpbGUgbWFpcyDDp2EgZGV2cmEgYXR0ZW5kcmUsIHByaW9yaXTDqSDDoCBsJ2lub25kYXRpb24gYXUgc291cy1zb2wuLi4=
+        - '7, 1 :[name=???]:The floor on the east part of the room is still very fragile,
+          but that''ll wait: priority to the flooding in the basement...'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -472,42 +471,40 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMiA6W25hbWU9Pz8/XTpQYXJkb24sIGplIHBhcmxhaXMgdG91dCBzZXVsLCBqZSBuZSB0J2F2YWlzIHBhcyByZW1hcnF1w6lcRS4uLg==
+        - 7, 2 :[name=???]:Sorry, I was thinking out loud, I didn't even see you...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMyA6W25hbWU9QWVydW5dOk9uIG0nYXBwZWxsZSBBZXJ1biBpY2ksIG91IGwnVXJzYXJpbmcsIMOgIGNhdXNlIGRlIG1hIGJlbGxlIGJhcmJlLCBkb25jIGMnZXN0IGNvbW1lIHR1IHByw6lmw6hyZXMu
+        - 7, 3 :[name=Aerun]:My name's Aerun, but some call me the Ursaring, because
+          of my pretty beard.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgNCA6W25hbWU9QWVydW5dOlNpck1hbG8gdCdhIHBhcmzDqSBkZSBtb2kgamUgcHLDqXN1bWUsIGV0IGRvbmMgamUgcGVuc2UgcXVlIHRvbiBidXQsIGMnZXN0IGRlIHLDqWN1cMOpcmVyIGxhIFBpZXJyZSBJbnNvbGl0ZSBkZSBjZXQgw6l0YWdlICE=
+        - 7, 4 :[name=Aerun]:SirMalo told you about me I presume.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 7, 5 :[name=Aerun]:Sache que j'ai fini de la cacher il y a peu.
+        - 7, 5 :[name=Aerun]:I hid it just a moment ago.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgNiA6W25hbWU9QWVydW5dOkV0IHBvdXIgcsOpdsOpbGVyIHNhIHBvc2l0aW9uLCBpbCB0ZSBmYXVkcmEgcsOpdXNzaXIgbCfDqXByZXV2ZSBkZSBjZXQgw6l0YWdlICE=
+        - 7, 6 :[name=Aerun]:And to unveil its position, you'll have to pass the test
+          of this floor!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 7, 7 :[name=Aerun]:Dans cette salle, il y a 5 rochers, et 5 interrupteurs.
+        - 7, 7 :[name=Aerun]:In this floor, you'll find 5 boulders and 5 switches.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgOCA6W25hbWU9QWVydW5dOlRhIG1pc3Npb24gdmEgw6p0cmUgZGUgcG91c3NlciBjZXMgcm9jaGVycyBzdXIgbGV1cnMgaW50ZXJydXB0ZXVycyByZXNwZWN0aWZzLg==
+        - 7, 8 :[name=Aerun]:Your mission is to push these boulders on their respective
+          switches.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -519,8 +516,8 @@ events:
         code: 203
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgOSA6W25hbWU9QWVydW5dOlR1IGVuIHRyb3V2ZXJhcyAzIGljaSwgw6AgZmFpcmUgdG9tYmVyIGRhbnMgbGVzIHRyb3VzIHB1aXMgw6AgYW1lbmVyIGF1eCBpbnRlcnJ1cHRldXJzLi4uW1dBSVQgNjBd
+        - 7, 9 :[name=Aerun]:You'll find 3 of these here, to push into the holes and
+          then bring to the switches...[WAIT 60]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -532,8 +529,8 @@ events:
         code: 203
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMTAgOltuYW1lPUFlcnVuXTpVbiBpY2ksIG1haXMgaWwgdGUgZmF1ZHJhIEVzY2FsYWRlIHBvdXIgeSBhY2PDqWRlci4uLltXQUlUIDMwXQ==
+        - 7, 10 :[name=Aerun]:One here, but you'll need Rock Climb to reach it...[WAIT
+          30]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -552,14 +549,13 @@ events:
         code: 203
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMTEgOltuYW1lPUFlcnVuXTpFdCBwb3VyIGZpbmlyLCB1biDDoCBkcm9pdGUsIG1haXMgaWwgZmF1ZHJhIHF1ZSB0dSBwYXNzZXMgbGUgc29sIGZpc3N1csOpLg==
+        - 7, 11 :[name=Aerun]:And finally, one to the right, but you need to cross
+          the cracked floor.[WAIT 90]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMTIgOltuYW1lPUFlcnVuXTpKZSB0ZSBjb25zZWlsbGUgZCdhdm9pciB1biBWw6lsbyBDb3Vyc2UgcG91ciBjZWNpLltXQUlUIDkwXQ==
+        - 7, 12 :[name=Aerun]:I'd advise you to get a Mach Bike for that.[WAIT 90]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -576,8 +572,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMTMgOltuYW1lPUFlcnVuXTpKZSB2YWlzIHRlIGRvbm5lciBsYSBDUyBGb3JjZSwgY29tbWUgw6dhLCB0dSBwb3VycmFzIHBvdXNzZXIgbGVzIHJvY2hlcnMu
+        - 7, 13 :[name=Aerun]:I'll give you the HM Strength.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -587,14 +582,14 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMTQgOltuYW1lPUFlcnVuXTpQb3VyIEVzY2FsYWRlLCB0dSBuJ2F1cmFzIHF1J8OgIGRlbWFuZGVyIGF1IG1vaW5lIGVuIGJhcyBkZXMgZXNjYWxpZXJzLg==
+        - 7, 14 :[name=Aerun]:As for Rock Climb, just ask the monk downstairs.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMTUgOltuYW1lPUFlcnVuXTpFdCBzaSB0dSBibG9xdWVzIHVuIGRlIHRlcyByb2NoZXJzLCB2aWVucyBtZSB2b2lyLCBqZSByw6lpbml0aWFsaXNlcmFpIGxhIHBvc2l0aW9uIGRlIGNldXggcXVpIG4nYXVyb250IHBhcyBhdHRlaW50IGxldXIgZGVzdGluYXRpb24gIQ==
+        - 7, 15 :[name=Aerun]:And if you were to stuck one of the boulders, come see
+          me, I will reset the position of the boulders that didn't make it to their
+          switches!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -711,27 +706,26 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMTYgOltuYW1lPUFlcnVuXTpUdSBhcyBiZXNvaW4gcXVlIGplIHLDqWluaXRpYWxpc2UgbGEgcG9zaXRpb24gZGVzIHJvY2hlcnMgbm9uIHBsYWPDqXMgPw==
+        - 7, 16 :[name=Aerun]:Do you need me to reset the position of the unplaced
+          boulders?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 7, 17 Oui
-          - 7, 18 Non
+        - - 7, 17 Yes
+          - 7, 18 No
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 7, 17 Yes
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMTkgOltuYW1lPUFlcnVuXTpPSywgesOpIHBhcnRpICE=
+        - 7, 19 :[name=Aerun]:Alrighty, lessgo!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -879,25 +873,24 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 7, 18 No
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMjAgOltuYW1lPUFlcnVuXTpQYXMgZGUgc291Y2ksIHJldmllbnMgbWUgdm9pciBzaSB0dSB0J2VzIGNvaW5jw6lcRSAh
+        - 7, 20 :[name=Aerun]:No problem, come back if you're stuck!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMjEgOltuYW1lPUFlcnVuXTpTaW5vbiwgdHUgcGV1eCB0b3V0IHNpbXBsZW1lbnQgcXVpdHRlciBjZXQgw6l0YWdlIGV0IHJldmVuaXIsIMOnYSBmZXJhIGxhIG3Dqm1lIGNob3NlLg==
+        - 7, 21 :[name=Aerun]:Else, you can exit this floor and come back, it'll do
+          the same thing.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMjIgOltuYW1lPUFlcnVuXTpQZXRpdCByYXBwZWwgY2VwZW5kYW50IDogdW4gcm9jaGV0IHBsYWPDqSBlc3QgdW4gcm9jaGVyIHF1aSBuZSBzZSByw6lpbml0aWFsaXNlcmEgcGFzICE=
+        - '7, 22 :[name=Aerun]:Just a quick reminder: a boulder placed is a boulder
+          that won''t reset!'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4065,26 +4058,25 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMjMgQm9uam91ciBqZXVuZSBNYWtlci4gQXByw6hzIHVuIHJ1ZGUgZW50cmHDrm5lbWVudCBxdWUgamUgbWUgc3VpcyBpbXBvc8OpLCBqZSBzdWlzIG1haW50ZW5hbnQgY2FwYWJsZSBkZSBncmF2aXIgZGVzIG1vbnRhZ25lcyDDoCBtYWlucyBudWVzLCBhbG9ycyBxdWUgdG91cyBwZW5zYWl0IGNlbGEgaW1wb3NzaWJsZS4=
+        - 7, 23 Hello, young Maker.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMjQgSmUgc3VpcyBtYWludGVuYW50IGNhcGFibGUgZCdlbnNlaWduZXIgY2VjaSDDoCBxdWljb25xdWUgcyd5IGludMOpcmVzc2UsIHF1ZWxxdWUgc29pdCBsYSBtb3JwaG9sb2dpZS4=
+        - 7, 24 Now, I can teach this to anyone or anything interested, whatever their
+          morphology.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMjUgSmUgc291aGFpdGUgdGUgcGFydGFnZXIgbW9uIHNhdm9pciwgb3UgZHUgbW9pbnMsIGxlIHBhcnRhZ2VyIMOgIGwndW4gZGUgdGVzIFBva8OpbW9uLg==
+        - 7, 25 I wish to share my wisdom with you, or at the very least, to one of
+          your Pokémon.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMjYgU2VyYWlzLXR1IGludMOpcmVzc8OpXEUgZCdhcHByZW5kcmUgRXNjYWxhZGUgw6AgdW4gZGUgdGVzIFBva8OpbW9uID8=
+        - 7, 26 Would you be interested in having me teach Rock Climb to one of your
+          Pokémon?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4102,8 +4094,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMjcgw4AgcXVlbCBQb2vDqW1vbiB2ZXV4LXR1IGwnZW5zZWlnbmVyID8=
+        - 7, 27 To which Pokémon should I teach it?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4202,8 +4193,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMjggSWwgc2VtYmxlcmFpdCBxdWUgdG9uIFtQT0tFXSBjb25uYWlzc2UgZMOpasOgIEVzY2FsYWRlLi4u
+        - 7, 28 It seems like your [POKE] already knows Rock Climb...
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4221,8 +4211,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMjkgQWxvcnMgZW5zZWlnbm9ucyBFc2NhbGFkZSDDoCB0b24gW1BPS0VdLg==
+        - 7, 29 Alright, I'll teach Rock Climb to your [POKE].
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4242,7 +4231,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 7, 30 Ton [POKE] pourra maintenant gravir les pentes d'escalades !
+        - 7, 30 Your [POKE] can now climb the rocky slopes!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4268,8 +4257,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMzEgSmUgY29tcHJlbmRzLi4uIEVzY2FsYWRlciBzYW5zIHByb3RlY3Rpb24sIMOnYSBwZXV0IGZhaXJlIHBldXIu
+        - 7, 31 I understand... Rock climbing without any protective gear might be
+          too scary.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4297,8 +4286,8 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMzIgSmUgY29tcHJlbmRzLi4uIEVzY2FsYWRlciBzYW5zIHByb3RlY3Rpb24sIMOnYSBwZXV0IGZhaXJlIHBldXIu
+        - 7, 32 I understand... Rock climbing without any protective gear might be
+          too scary.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4729,7 +4718,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 7, 33 Vei-veinard !
+        - 7, 33 Chan-chansey!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4932,8 +4921,7 @@ events:
         code: 249
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          NywgMzQgTGV2ZWluYXJkIHNvaWduZSB2b3RyZSDDqXF1aXBlLltXQUlUIDkwXQ==
+        - 7, 34 Chansey heals your team.[WAIT 90]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map008.rxdata.yml
+++ b/Data/Map008.rxdata.yml
@@ -322,19 +322,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMCBKJ2FpIHZ1IHVuZSBwaWVycmUgY29sb3LDqWUgZGFucyBsZSBjb2luIGlsIHkgYSBwYXMgbG9uZ3RlbXBzLi4u
+        - 8, 0 I saw a colorful stone not long ago...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 1 Mais pas moyen de la retrouver !
+        - 8, 1 But I can't find it anymore!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMiBQZXV0LcOqdHJlIHF1ZSBxdWVscXUndW4gbCdhIHLDqWN1cMOpcsOpZSBhdmFudCBtb2kuLi4=
+        - 8, 2 Maybe somebody picked it before I could...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -388,43 +386,40 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 3 Cette lueur dans ton sac...
+        - 8, 3 This light in your bag...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgNCBKZSBsJ2FpIGFwZXLDp3VlIGF1c3NpIGlsIHkgYSBxdWVscXVlcyBqb3VycyAh
+        - 8, 4 That's the light I saw the other day!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgNSBDJ2VzdCBkb25jIHRvaSBxdWkgYSB0cm91dsOpIGxhIHBpZXJyZSBxdWUgamUgY2hlcmNoZSBwYXJ0b3V0ICE=
+        - 8, 5 So, you're the one who picked the stone I was looking for everywhere!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 6 Bah... Tu voudras jamais me la donner...
+        - 8, 6 Eh... You won't give it to me, right?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 8, 7 Aucune chance
-          - 8, 8 Tu peux rêver
+        - - 8, 7 No chance
+          - 8, 8 You can dream on it
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Aucune chance
+        - 8, 7 No chance
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgOSBFaCAhIFBhcyBiZXNvaW4gZCfDqnRyZSBkw6lzYWdyw6lhYmxlLi4u
+        - 8, 9 Huh! No need to be this rude...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -434,13 +429,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          VHUgcGV1eCByw6p2ZXI=
+        - 8, 8 You can dream on it
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 10 Tu te moques de moi en plus ?
+        - 8, 10 You're mocking me too?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -453,19 +447,17 @@ events:
         code: 404
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMTEgU2kgdHUgYXMgcsOpdXNzaSDDoCBsYSB0cm91dmVyLi4u
+        - 8, 11 If you were able to find it...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMTIgUGV1dC3DqnRyZSBxdSdpbCB5IGVuIGEgZCdhdXRyZXMgIQ==
+        - 8, 12 Then maybe there is more to find!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 13 Je vais intensifier mes recherches.
+        - 8, 13 I'm going to intensify my research.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -520,19 +512,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMTQgU2kgdHUgYXMgcsOpdXNzaSDDoCBsYSB0cm91dmVyLi4u
+        - 8, 14 If you were able to find it...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMTUgUGV1dC3DqnRyZSBxdSdpbCB5IGVuIGEgZCdhdXRyZXMgIQ==
+        - 8, 15 Then maybe there is more to find!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 16 Je vais intensifier mes recherches.
+        - 8, 16 I'm going to intensify my research.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -593,7 +583,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 17 Vei-veinard !
+        - 8, 17 Chan-chansey!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -796,8 +786,7 @@ events:
         code: 249
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMTggTGV2ZWluYXJkIHNvaWduZSB2b3RyZSDDqXF1aXBlLltXQUlUIDkwXQ==
+        - 8, 18 Chansey heals your team.[WAIT 90]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1621,8 +1610,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 19 Comment vais-je faire pour ramasser ces cendres mais sans me salir
-          les mains..?
+        - 8, 19 How can I collect all these ashes without getting my hands dirty...?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1660,8 +1648,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMjAgSmUgcGV1eCB0J2FpZGVyIFxmW2pldW5lIGRlbW9pc2VsbGXCp2pldW5lIGhvbW1lXSA/
+        - 8, 20 Can I help you, young \f[lady§man]?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1671,44 +1658,40 @@ events:
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMjIgVCdlcyBpbnTDqXJlc3PDqVxFIHBhciBjZXR0ZSBoaXN0b2lyZSBkZSBjZW5kcmUgPyBFaCBiaWVuIMOpY291dGUsIGMnZXN0IHNpbXBsZSA6IGxlIHZvbGNhbiBhcnRpZmljaWVsIHF1aSBhIMOpdMOpIGluc3RhbGzDqSBkYW5zIGNldCDDqXRhZ2UgcHJvamV0dGUgZGVzIGNlbmRyZXMu
+        - 8, 22 You're interested by this "collecting ashes" thing I mumbled?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 23 Ces cendres, plus lourdes que l'air, tombent et s'attachent aux herbes,
-          leur donnant une teinte grisatre.
+        - 8, 23 These ashes, heavier than air, fall and stick to grass, giving those
+          a grayish tint.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 24 Ces cendres sont super utiles, aussi bien pour ceux qui savent quoi
-          faire de leurs dix doigts, mais aussi pour des scientifiques comme moi !
+        - 8, 24 They are are very useful to those you can use all their fingers, but
+          also to scientists like me!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMjUgU2V1bGVtZW50IHZvaWzDoCwgamUgZMOpdGVzdGUgbWUgc2FsaXIgbGVzIG1haW5zLi4uIExpdHTDqXJhbGVtZW50LiBKZSBuZSBwZXV4IHJpZW4gdG91Y2hlciBxdWkgcG91cnJhaXQgZW5jcmFzc2VyIG1lcyBiZWxsZXMgcGV0aXRlcyBtaW1pbmVzLg==
+        - '8, 25 But here''s the thing: I hate to get my hands dirty. Literally.'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMjYgVHUgbSdhcyBsJ2FpciBkJ8OqdHJlIHF1ZWxxdSd1biBkZSBzZXJ2aWFibGUsIGplIHRlIHByb3Bvc2UgZG9uYyB1biBkZWFsICE=
+        - 8, 26 You seem like a helpful fellow, so here's the deal!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMjcgVHUgbWUgcmFtYXNzZXMgc3VmZmlzYW1tZW50IGRlIGNlbmRyZSwgZXQgamUgdGUgZG9ubmUgY2V0dGUgam9saWUgcGllcnJlIHF1ZSBqJ2FpIHRyb3V2w6kgZW4gaGF1dCBkdSB2b2xjYW4u
+        - 8, 27 You bring me back enough ash, and I'll give you this nice stone I
+          found on the top of the volcano.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMjggSWwgbWUgc2VtYmxlIHF1J29uIGFwcGVsbGUgw6dhIHVuZSBQaWVycmUgSW5zb2xpdGUgPw==
+        - 8, 28 I believe it's called an Intriguing Stone?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1718,14 +1701,13 @@ events:
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMzAgQ29tbWVudCDDp2EgZWxsZSBhIMOpdMOpIGluc3RhbGzDqWUgaWNpIHBvdXIgdG9pID8gSGV5LCBwcmVtaWVyIGFycml2w6ksIHByZW1pZXIgc2VydmkgISBTaSB0dSBsYSB2ZXV4LCByYW3DqG5lIHRvaSBhdmVjIHN1ZmZpc2FtbWVudCBkZSBzdWllICE=
+        - 8, 30 What do you mean it was installed there for you?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMzEgUmFtw6huZSBtb2kgbCfDqXF1aXZhbGVudCBkZSBjZSBxdSdpbCB5IGEgc3VyIGNldCDDqXRhZ2UgZXQgamUgZG9ubmUgbGEgUGllcnJlLiBUaWVucywgamUgdGUgZG9ubmUgbW9uIFNhYyBkZSBTdWllLCB0dSBwb3VycmFzIHJhbmdlciBsZXMgw6ljaGFudGlsbG9ucyBkZWRhbnMu
+        - 8, 31 Bring back the equivalent of what's currently on this floor and I'll
+          give you the stone.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1790,8 +1772,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMzIgT2ggISBKZSB2b2lzIHF1ZSBsZSBjb21wdGUgZXN0IGJvbiAhIENob3NlIHByb21pc2UsIGNob3NlIGR1ZSwgdm9pbMOgIGxhIHBpZXJyZSAh
+        - 8, 32 Oh! I see you have the right amount!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1815,14 +1796,13 @@ events:
         code: 122
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMzMgU2kgdHUgYXMgZGUgbGEgc3VpZSByZXN0YW50ZSwgamUgcGV1eCDDqXZlbnR1ZWxsZW1lbnQgdGUgbGEgcmFjaGV0ZXIsIGjDqXNpdGUgcGFzIMOgIHJldmVuaXIgbWUgdm9pciAh
+        - 8, 33 If you have any remaining soot, I can eventually buy it from you,
+          so don't hesitate to come see me back!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMzQgSmUgdGUgbGEgcmFjaMOodGVyYWkgYXUgdGF1eCBkZSAxMDAgc3VpZXMgcG91ciAyMDAwJC4=
+        - 8, 34 I'll buy 100 soot for 2000$.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1841,8 +1821,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMzUgLi4uIFR1IG4nYXMgY2xhaXJlbWVudCBwYXMgYXNzZXogZGUgc3VpZSwgbMOgLiBBbGxleiBob3AsIHJldG91cm5lcy15ICE=
+        - 8, 35 ... You clearly lack some soot.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1904,8 +1883,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMzYgSmUgdm9pcyBxdWUgdHUgYXMgc3VmZmlzYW1tZW50IGRlIHN1aWUuIEplIHRlIHJhY2jDqHRlIMOnYSBkZSBzdWl0ZSAh
+        - 8, 36 I see you have enough soot.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1924,8 +1902,8 @@ events:
         code: 122
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMzcgU2kgdHUgYXMgZGUgbGEgc3VpZSByZXN0YW50ZSwgamUgcGV1eCDDqXZlbnR1ZWxsZW1lbnQgdGUgbGEgcmFjaGV0ZXIsIGjDqXNpdGUgcGFzIMOgIHJldmVuaXIgbWUgdm9pciAh
+        - 8, 37 If you have any soot remaining, I can eventually buy it from you,
+          so don't hesitate to come see me back!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1938,14 +1916,13 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMzggUXVlbCBwbGFpc2lyIGRlIG5lIHBhcyBhdm9pciDDoCBzZSBzYWxpciBsZXMgbWFpbnMgcG91ciByw6ljdXDDqXJlciBkdSBtYXTDqXJpZWwgc2NpZW50aWZpcXVlICE=
+        - 8, 38 What a pleasure it is to keep my hands clean while collecting scientific
+          material.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgMzkgQXUgY2FzIG/DuSB0dSBhdXJhaXMgb3VibGnDqSwgamUgdGUgcmFjaMOodGUgMTAwIHN1aWVzIHBvdXIgMjAwMCQuIEV0IGFjdHVlbGxlbWVudCwgdHUgbidlbiBhcyBwYXMgYXNzZXouIFJldmllbnMgbWUgdm9pciBxdWFuZCB0dSBhdXJhcyBsZSBjb21wdGUgIQ==
+        - 8, 39 In case you forgot, I buy 100 soot for 2000$.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2004,13 +1981,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 40 J'adore marcher sur cette flaque boueuse avec mes bottes.
+        - 8, 40 I like to step on this muddy puddle with my boots.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgNDEgQ2Ugbidlc3QgcGFzIGNvbW1lIGxhIGJvdWUgZGUgbMOgLWJhcywgZGFucyBsYXF1ZWxsZSBvbiBzJ2VuZm9uY2UgZW4gdW4gaW5zdGFudCAh
+        - 8, 41 It's not like the mud over there, in which you sink in an instant!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2065,14 +2041,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgNDIgSidlc3NhaWUgZGUgY29sbGVjdGVyIGRlIGxhIHN1aWUgcG91ciBsZSBiaW5vY2xhcmQsIGzDoCBoYXV0Lg==
+        - 8, 42 I'm trying to collect soot for the speccy four-eyes over there.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgNDMgTWFpcyBhdHRyYXBlciBsZXMgY2VuZHJlcyDDoCBtYWlucyBudWVzLCDDp2EgbidhIHBhcyBsJ2FpciB0csOocyBlZmZpY2FjZSAh
+        - 8, 43 But trying to catch ash bare-handed is definitely not effective at
+          all!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2127,12 +2102,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 44 Chut !
+        - 8, 44 Shush!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 45 J'essaie d'attraper un Rapion sauvage, ne les fais pas fuir !
+        - 8, 45 I'm trying to catch a wild Skorupi, don't make them flee!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2191,18 +2166,17 @@ events:
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OCwgNDcgSmUgc3VpcyBlbiBwbGVpbmUgbcOpZGl0YXRpb24gcG91ciBhZmbDu3RlciBtZXMgbXVzY2xlcy4=
+        - 8, 47 I'm in full meditation mode to hone my muscles.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 48 La chaleur insoutenable endurcit mon mental.
+        - 8, 48 The unbearable heat toughens my mind.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 8, 49 Ne vient pas troubler mon exercice, je te prie.
+        - 8, 49 Don't disturb my exercise, please.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map009.rxdata.yml
+++ b/Data/Map009.rxdata.yml
@@ -339,7 +339,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 9, 0 Vei-veinard !
+        - 9, 0 Chan-chansey!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -542,8 +542,7 @@ events:
         code: 249
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgMSBMZXZlaW5hcmQgc29pZ25lIHZvdHJlIMOpcXVpcGUuW1dBSVQgOTBd
+        - 9, 1 Chansey heals your team.[WAIT 90]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1296,12 +1295,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 9, 2 Moooomaarrr !
+        - 9, 2 Frooooooss!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 9, 3 Le Momartik vous attaque !
+        - 9, 3 The Froslass attacks you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1379,8 +1378,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgNCBMZSBNb21hcnRpayBzZSBtb3F1ZSBkZSB2b3VzIGV0IHZhcXVlIMOgIHNlcyBvY2N1cGF0aW9ucy4=
+        - 9, 4 The Froslass mocks you and goes back to its business.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1400,8 +1398,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgNSBMZSBNb21hcnRpayBkaXNwYXJhw650IGxlIHRlbXBzIGRlIHJlZ2FnbmVyIHNlcyBmb3JjZXMuLi4gSWwgcmV2aWVuZHJhIHByb2JhYmxlbWVudCBkYW5zIHF1ZWxxdWVzIG1pbnV0ZXMgPw==
+        - 9, 5 The Froslass disappears to regain its strenghts.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1437,8 +1434,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgNiBWb3VzIGF2ZXogY2FwdHVyw6kgbGUgTW9tYXJ0aWsgISBJbCBuZSBoYW50ZXJhIHBsdXMgbGVzIGxpZXV4IGltcHVuw6ltZW50ICE=
+        - 9, 6 You caught the Froslass!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1662,25 +1658,22 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgNyBMZSByb2NoZXIgZXN0IGVudmVsb3Bww6kgZGUgZ2xhY2Uu
+        - 9, 7 The rock is covered with a thick layer of ice.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Il est glacial au toucher.
+        - It's very cold to the touch.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgOCBVbmUgY2VydGFpbmUgZXNww6hjZSBkZSBQb2vDqW1vbiBwb3VycmFpdCBcY1s1XcOpdm9sdWVyIMOgIHByb3hpbWl0w6lcY1swXS4=
+        - 9, 8 A certain species of Pokémon could \c[5]evolve around it\c[0].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgOSBNYWlzIGlsIHNlbWJsZXJhaXQgcXUnb24gbmUgbGEgdHJvdXZlIHBhcyBzdXIgY2V0dGUgw45sZS4uLg==
+        - 9, 9 But it seems like it can't be found on this Island...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1748,25 +1741,22 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgMTAgTGUgcm9jaGVyIGVzdCBlbnZlbG9wcMOpIGRlIGdsYWNlLg==
+        - 9, 10 The rock is covered with a thick layer of ice.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Il est glacial au toucher.
+        - It's very cold to the touch.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgMTEgVW5lIGNlcnRhaW5lIGVzcMOoY2UgZGUgUG9rw6ltb24gcG91cnJhaXQgXGNbNV3DqXZvbHVlciDDoCBwcm94aW1pdMOpXGNbMF0u
+        - 9, 11 A certain species of Pokémon could \c[5]evolve around it\c[0].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgMTIgTWFpcyBpbCBzZW1ibGVyYWl0IHF1J29uIG5lIGxhIHRyb3V2ZSBwYXMgc3VyIGNldHRlIMOObGUuLi4=
+        - 9, 12 But it seems like it can't be found on this Island...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1817,14 +1807,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgMTMgSWwgZmFpdCBzYWNyw6ltZW50IGZyb2lkIGljaSAh
+        - 9, 13 It's very chilly here!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgMTQgRW4gcGx1cywgaidhaSBsJ2ltcHJlc3Npb24gZCfDqnRyZSBjb25zdGFtbWVudCBvYnNlcnbDqS4uLg==
+        - 9, 14 And with that, I'm under the impression I'm constantly observed...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1879,20 +1867,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgMTUgTGEgcG91ZHJldXNlIGVzdCBkZSBzdXBlciBxdWFsaXTDqSBwb3VyIHNraWVyICE=
+        - 9, 15 The powder snow is top quality to ski!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 9, 16 En revanche, je ne m'aventurerai pas sur la \c[5]glace\c[0] juste
-          en-dessous...
+        - 9, 16 On the other hand, I won't try to go on this \c[5]ice\c[0] just below...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OSwgMTcgVW5lIGZvaXMgbGFuY8OpLCBpbXBvc3NpYmxlIGRlIHMnYXJyw6p0ZXIgIQ==
+        - 9, 17 Once you've started, it's impossible to stop!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map010.rxdata.yml
+++ b/Data/Map010.rxdata.yml
@@ -621,20 +621,18 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDAgQ2V0dGUgcGlzdGUgY3ljbGFibGUgZXN0IGVuIHBlbnRlICEgQydlc3Qgw6AgZGlyZSBxdWUgc2kgdHUgbmUgYm91Z2VzIHBhcyBwYXIgdG9pLW3Dqm1lLCBvdSBxdWUgdHUgbidhcHB1aWVzIHBhcyBzdXIgdGEgdG91Y2hlIEIsIHR1IGRlc2NlbmRyYXMgZW4gY29udGludSAh
+        - 10, 0 This Cycling Road is on a slope.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDEgRCdhaWxsZXVycywgdW5lIGZvcmNlIG9ic2N1cmUgZXQgaW5zb25kYWJsZSBub3VzIGVtcMOqY2hlIGQnYWxsZXIgZGVzc3VzIHNpIG5vdXMgbmUgc29tbWVzIHBhcyBzdXIgdW4gdsOpbG8uLi4=
+        - 10, 1 Also, an obscure and unfathomable force keeps anyone from going on
+          it without a bike...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDIgRW5jb3JlIHVuIGNvdXAgZGUgY2VzIHNhdGFuw6lzIGTDqXZlbG9wcGV1cnMgIQ==
+        - 10, 2 Surely these damn developers have something to do with that!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -685,13 +683,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDMgT2ggYmllbiBqb3XDqSwgdHUgbSdhcyB0cm91dsOpICEgQXUgY2FzIG/DuSB0dSBuZSBzYXVyYWlzIHBhcyBwb3VycXVvaSBqZSBzdWlzIGzDoCwgYydlc3QgcG91ciBtb250cmVyIHF1ZSB0dSBwZXV4IHJvdWxlciBzdXIgbGEgYmFycmUgcXVpIGVzdCBjb25zaWTDqXLDqWUgcGFyIGxlIHN5c3TDqG1lIGNvbW1lIHVuIHBvbnQgZXQgcGFzc2VyIGF1IGRlc3N1cyBkZSBtb2ksIGV0IHR1IG5lIHBvdXJyYXMgcGFzIG5vbiBwbHVzIG1lIHBhcmxlciAh
+        - 10, 3 Oh, well done, you found me!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 10, 4 Essaye, tu verras !
+        - 10, 4 Try it and you'll see!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -846,8 +843,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDUgVm91cyBuZSBwb3V2ZXogcGFzIGFjY8OpZGVyIMOgIGxhIFBpc3RlIEN5Y2xhYmxlIMOgIHBpZWQsIHZveW9ucyAh
+        - 10, 5 You can't access the Cycling Road on foot, of course!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1049,8 +1045,8 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDYgSWwgbmUgZmF1dC5bV0FJVCAyMF0uW1dBSVQgMjBdLiBqYW1haXMuW1dBSVQgMjBdLltXQUlUIDIwXS4gcydhcnLDqnRlci5bV0FJVCAyMF0uW1dBSVQgMjBdLiBkZSBww6lkYWxlciAh
+        - 10, 6 You must.[WAIT 20].[WAIT 20]. never.[WAIT 20].[WAIT 20]. stop.[WAIT
+          20].[WAIT 20]. pedaling!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1171,12 +1167,12 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 10, 7 J'adore me laisser emporter par la vitesse !
+        - 10, 7 I really enjoy letting myself go with the speed!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 10, 8 Mais pour remonter la pente, il faut forcer sur les cuisses...
+        - 10, 8 But to get back on the slope, you must strain your legs a lot...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2086,14 +2082,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDkgVHUgcGV1eCBlc2NhbGFkZXIgY2VzIGdyb3Mgcm9jaGVycyBlbiBzYXV0YW50IGRlc3N1cyBhdmVjIHVuIFxjWzVdVsOpbG8gQ3Jvc3NcY1swXS4=
+        - 10, 9 You can climb these big boulders by jumping on them with an \c[5]Acro
+          Bike\c[0].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDEwIFNpIHR1IGZhaXMgdW5lIHJvdWUgYXJyacOocmUgZXQgcXVlIHR1IHJlc3RlcyBzdXIgcGxhY2UsIHR1IHZhcyB0ZSBtZXR0cmUgw6Agc2F1dGlsbGVyICE=
+        - 10, 10 If you do a wheelie and stay still, you'll start bunny hopping!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2144,14 +2139,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDExIExlcyB0cmVtcGxpbnMgZW4gcGllcnJlIHF1ZSB0dSB2b2lzIGzDoCB0ZSBwZXJtZXR0ZW50IGRlIHNhdXRlciBzdXBlciBsb2luIGVuIHbDqWxvLg==
+        - 10, 11 The rocky ramps you see over there make you jump very far with your
+          bike.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDEyIFNpIHR1IGwnZW1wcnVudGVzIMOgIGdyYW5kZSB2aXRlc3NlLCB0dSBpcmFzIGVuY29yZSBwbHVzIGxvaW4gIQ==
+        - 10, 12 If you take it at high speed, you'll go even further!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2205,14 +2199,14 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDEzIEonYWkgdnUgdW4gdHlwZSBzdXBlciBmb3J0IGVuIFZUVCBmcmFuY2hpciBsZXMgcmFtcGVzIGJsYW5jaGVzIGluc3RhbGzDqWVzIMOgIG5vdHJlIGdhdWNoZS4=
+        - 10, 13 I saw a skillful dude with a mountain bike crossing these white ramps
+          installed on our left.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDE0IElsIHJlYm9uZGlzc2FpdCBzdXIgc29uIFxjWzVdVsOpbG8gQ3Jvc3NcY1swXSBldCBzYXV0YWl0IGQndW5lIHJhbXBlIMOgIGwnYXV0cmUgY29tbWUgdW4gYWNyb2JhdGUgIQ==
+        - 10, 14 He was bouncing on his \c[5]Acro Bike\c[0] and jumped from one ramp
+          to another like an acrobat!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2266,14 +2260,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDE1IEplIG1hbnF1ZSBkJ2FjY8OpbMOpcmF0aW9uIGF2ZWMgbWEgYsOpY2FuZSBwb3VyIGZyYW5jaGlyIGNlcyBjb3Vsw6llcyBkZSBib3VlLi4u
+        - 10, 15 I lack some acceleration with my hog to cross these mudslide...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDE2IFNpIHNldWxlbWVudCBqJ2F2YWlzIHVuIFxjWzVdVsOpbG8gQ291cnNlXGNbMF0gIQ==
+        - 10, 16 If only I had a \c[5]Mach Bike\c[0]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2407,18 +2399,18 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          dHJhaW5lcl9leWVfc2VxdWVuY2UoIjEwLCAyOCBIZXAsIHRvaSwgbMOgICEiLCBleWVfYmdtOiAnYXVkaW8vYmdtL1Nwb3R0ZWQgLSBUb3VnaCBHdXkub2dnJyk=
+        - 'trainer_eye_sequence("10, 28 Hey, you there!", eye_bgm: ''audio/bgm/Spotted
+          - Tough Guy.ogg'')'
         indent: 0
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 10, 17 Je te rassure, je ne suis pas un Dresseur.
+        - 10, 17 Don't worry, I'm not a Trainer.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 10, 18 Je veux juste m'assurer que tu kiffes ta descente !
+        - 10, 18 I just wanted to make sure you're feelin' it!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2478,7 +2470,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 10, 19 Rares sont ceux qui comprennent le vrai plaisir de la piste !
+        - 10, 19 Rare are those who really understand the thrills of the Road!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2893,8 +2885,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDIwIFZvdXMgbmUgcG91dmV6IHBhcyBhY2PDqWRlciDDoCBsYSBQaXN0ZSBDeWNsYWJsZSDDoCBwaWVkLCB2b3lvbnMgIQ==
+        - 10, 20 You can't access the Cycling Road on foot, of course!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2975,14 +2966,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDIxIFNhbHV0IGpldW5lIFZUVGlzdGUgISBJY2ksIGxlIHbDqWxvLCBjJ2VzdCBvYmxpZ2F0b2lyZSAhIFRlbGxlbWVudCBvYmxpZ2F0b2lyZSBxdSdpbCB2YSBtw6ptZSB0J2VuIGZhbGxvaXIgZGV1eCBwb3VyIGFycml2ZXIgYXUgYm91dCBkdSBwYXJjb3VycyAh
+        - 10, 21 Hello young mountain biker!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDIyIFRpZW5zLCBwcmVuZHMgY2V1eC1sw6AsIGplIG1lIGJhbGFkZSB0b3Vqb3VycyBhdmVjIGRlcyB2w6lsb3MgZGUgcmVjaGFuZ2VzIHBvdXIgbWVzIHbDqWxvcyBkZSByZWNoYW5nZXMsIGF1IGNhcyBvw7kgaWxzIG1lIGZlcmFpZW50IGTDqWZhdXQgIQ==
+        - 10, 22 Here, take these, I'm always bringing spare bikes for my spare bikes,
+          in case they fail me.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2997,20 +2987,19 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDIzIFBvdXIgaW5mbyA6IGxlIFbDqWxvIGRlIENvdXJzZSBlc3QgbGUgcGx1cyByYXBpZGUgZGVzIGRldXggZXQgdGUgcGVybWV0dHJhIGRlIHBhc3NlciBjZXJ0YWlucyBvYnN0YWNsZXMgcXVpIHJlcXVpw6hyZW50IHVuZSB2aXRlc3NlIMOpbGV2w6llLg==
+        - 10, 23 For your information, the Mach Bike is the fastest of the two and
+          will allow you to cross obstacles that require a high speed.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDI0IExlIFbDqWxvIENyb3NzLCBsdWksIGVzdCBwbHVzIGxlbnQsIG1haXMgdHUgcGV1eCBmYWlyZSBkZXMgdHJpY2tzIGRlIGZvdSBhdmVjLCBldCBwYXNzZXIgY2VydGFpbnMgb2JzdGFjbGVzIHF1aSB0ZSByZXF1acOocmVudCBkZSBsJ2FnaWxpdMOpICE=
+        - 10, 24 The Acro Bike is slower, but you can do some sick tricks with it,
+          and cross some obstacles that require agility!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDI1IEFsbGV6LCDDqWNsYXRlIHRvaSBiaWVuICE=
+        - 10, 25 Well, go have fun now!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3061,8 +3050,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDI2IFknYSBwYXMgw6AgZGlyZSwgbGVzIEJpa2UgUGFyayBuYXR1cmVscyBjJ2VzdCBsZSBtdXN0Lg==
+        - 10, 26 No need to say, the Bike Parks sure are the thing.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3873,8 +3861,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTAsIDI3IFZvdXMgbmUgcG91dmV6IHBhcyBhY2PDqWRlciDDoCBsYSBQaXN0ZSBDeWNsYWJsZSDDoCBwaWVkLCB2b3lvbnMgIQ==
+        - 10, 27 You can't access the Cycling Road on foot, of course!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map011.rxdata.yml
+++ b/Data/Map011.rxdata.yml
@@ -11060,7 +11060,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 0 Il n'est plus possible d'activer l'interrupteur...
+        - 11, 0 The switch can't be triggered anymore...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -11379,7 +11379,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 1 Il n'est plus possible d'activer l'interrupteur...
+        - 11, 1 The switch can't be triggered anymore...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -11764,7 +11764,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 2 Il n'est plus possible d'activer l'interrupteur...
+        - 11, 2 The switch can't be triggered anymore...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -14387,7 +14387,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 3 Eh !
+        - 11, 3 Hey, you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -14398,7 +14398,7 @@ events:
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 4 Viens voir...
+        - 11, 4 Come here...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -14443,31 +14443,28 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDUgTmUgbGUgcsOpcMOodGUgcGFzIHRyb3AsIG1haXMuLi4=
+        - 11, 5 Between you and me...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Je suis une ancienne de la Team Rocket.
+        - I'm a former Team Rocket member.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDYgSifDqXRhaXMgZW4gY2hhcmdlIGRlIGxhIHPDqWN1cml0w6kgZGFucyBsYSBwbHVwYXJ0IGRlIG5vcyBwbGFucXVlcy4=
+        - 11, 6 I was in charge of security in most of our hideouts.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDcgUXVhbmQgbGUgZ3JvdXBlIGEgw6l0w6kgZGlzc291dCwgaidhaSByw6ljdXDDqXLDqSB1biBtYXggZGUgbWF0w6lyaWVsLg==
+        - 11, 7 When the group fell apart, I packed as much stuff as I could.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDggTGVzIGdhcnMgZGUgbGEgVG91ciBvbnQgYWNjZXB0w6kgcXVlIGplIGNvbnRpbnVlIG1lcyBleHDDqXJpZW5jZXMgbcOpY2FuaXF1ZXMgaWNpLg==
+        - 11, 8 The Tower Staff allowed me to carry on with my mechanical experiments
+          here.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -14530,19 +14527,18 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDkgU2kgdHUgcGFydmllbnMgw6AgbWUgcmV0cm91dmVyIHRvdXQgYXUgYm91dCBkZSBjZSBwYXJjb3VycywgamUgdCdvZmZyaXJhaSB1biB0cnVjIHN5bXBhICE=
+        - 11, 9 If you manage to reach me at the end of this maze, I'll give you something
+          nice!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDEwIEplIGwnYWkgcGlxdcOpIMOgIHVuIG5pZ2F1ZCBxdWkgYXVyYWl0IG1pZXV4IGZhaXQgZGUgcGx1cyBmYWlyZSBhdHRlbnRpb24gw6Agc2VzIHBvY2hlcyAh
+        - 11, 10 I stole it from an idiot who'd done better to check their pockets!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Niark, niark !
+        - Hehe!
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -14585,7 +14581,7 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 11 Commence par ici.
+        - 11, 11 Start here.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -14608,8 +14604,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDEyIFF1YW50IMOgIG1vaS4uLiBKZSB0J2F0dGVuZHMgYXUgYm91dCAh
+        - 11, 12 As for me... I'll wait for you at the end!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -14959,19 +14954,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDEzIEFoYWggISBCaWVuIGpvdcOpLCB0dSB0J2VuIGVzIGJpZW4gdGlyw6lcRS4=
+        - 11, 13 Ahah! Well done, you did a good job.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 14 Chose promise, chose due...
+        - 11, 14 As promised...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDE1IEplIG4nZW4gYXVyYWlzIGF1Y3VuZSB1dGlsaXTDqSwgZGUgdG91dGUgbWFuacOocmUu
+        - 11, 15 I'll never have any use for it anyway.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -14981,14 +14974,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 16 Tu peux farfouiller dans le \c[5]code de mes machines\c[0] si tu
-          le souhaites.
+        - 11, 16 You can rummage in my \c[5]machines' events\c[0] if you want to.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDE3IEMnZXN0IGFzc2V6IGNvbXBsZXhlLCBtYWlzIMOnYSBwZXJtZXQgZGUgY3LDqWVyIGRlcyBlbmRyb2l0cyBzdXBlciBjb29sICE=
+        - 11, 17 It's quite complex, but you can create very cool puzzles with it!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -15042,14 +15033,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 18 Tu peux farfouiller dans le \c[5]code de mes machines\c[0] si tu
-          le souhaites.
+        - 11, 18 You can rummage in my \c[5]machines' events\c[0] if you want to.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDE5IEMnZXN0IGFzc2V6IGNvbXBsZXhlLCBtYWlzIMOnYSBwZXJtZXQgZGUgY3LDqWVyIGRlcyBlbmRyb2l0cyBzdXBlciBjb29sICE=
+        - 11, 19 It's quite complex, but you can create very cool puzzles with it!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -15100,19 +15089,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDIwIElsIHkgYSB1biBtZXNzYWdlIMOpY3JpdCDDoCBjw7R0w6kgZCd1biBib3V0b24uLi4=
+        - 11, 20 There is a message next to a button...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDIxICJQb3VyIHLDqWluaXRpYWxpc2VyIGxlIGxldmllciB2ZXJ0LCBjbGlxdWV6IHN1ciBjZSBib3V0b24uIg==
+        - 11, 21 "To reset the green switch, press the button."
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 22 C'est plus fort que vous, vous cliquez sur le bouton.
+        - 11, 22 You can't resist the urge to press the button.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -15200,8 +15187,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTEsIDI0IFZvdXMgbifDqnRlcyBwbHVzIGJsb3F1w6ku
+        - 11, 24 You are not stuck anymore.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -15221,7 +15207,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 11, 25 Il ne se passe rien.
+        - 11, 25 Nothing happens.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map012.rxdata.yml
+++ b/Data/Map012.rxdata.yml
@@ -683,45 +683,42 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 'choice(26, 6, "12, 14 1: Hall de la Tour",'
+        - 'choice(26, 6, "12, 14 1: Tower Hall",'
         indent: 0
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"12, 15 2: Laboratoire",'
+        - '"12, 15 2: Laboratory",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          IjEyLCAxNiAzOiBCaWJsaW90aMOocXVlIiw=
+        - '"12, 16 3: Library",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"12, 17 4: Studio photo",'
+        - '"12, 17 4: Photo Studio",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"12, 18 5: Casino",'
+        - '"12, 18 5: Game Corner",'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"12, 19 Retour")'
+        - '"12, 19 Return")'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDAgTm91cyBzb21tZXMgYWN0dWVsbGVtZW50IMOgIGwnw6l0YWdlIFx2WzEwM10u
+        - 12, 0 We are currently on floor \v[103].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          w4AgcXVlbCBzeXN0w6htZSB2b3VsZXotdm91cyBhbGxlciA/
+        - Which System may I take you to?
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -759,8 +756,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDEgTm91cyBzb21tZSBkw6lqw6Agw6AgY2V0IMOpdGFnZS4=
+        - 12, 1 We are already on that floor?!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -792,12 +788,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 12, 2 Certainement.
+        - 12, 2 Certainly.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Nous descendons.
+        - Elevator going down.
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -907,12 +903,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 12, 3 Certainement.
+        - 12, 3 Certainly.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Nous montons.
+        - Elevator going up.
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1143,8 +1139,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDQgUHJlbWllciDDqXRhZ2UgOiBIYWxsIGRlIGxhIFRvdXIu
+        - 12, 4 The first floor has the Main Hall.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1166,8 +1161,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDUgRGV1eGnDqG1lIMOpdGFnZSA6IExhYm9yYXRvaXJlLg==
+        - 12, 5 The second floor has the Laboratory.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1189,8 +1183,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDYgVHJvaXNpw6htZSDDqXRhZ2UgOiBCaWJsaW90aMOocXVlLg==
+        - 12, 6 The third floor has the Library.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1212,8 +1205,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDcgUXVhdHJpw6htZSDDqXRhZ2UgOiBTdHVkaW8gcGhvdG8u
+        - 12, 7 The fourth floor has the Photo Studio.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1235,8 +1227,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDggQ2lucXVpw6htZSDDqXRhZ2UgOiBDYXNpbm8u
+        - 12, 8 The fifth floor has the Game Corner.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1387,8 +1378,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDkgUHJlbWllciDDqXRhZ2UgOiBIYWxsIGRlIGxhIFRvdXIu
+        - 12, 9 The first floor has the Main Hall.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1410,8 +1400,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDEwIERldXhpw6htZSDDqXRhZ2UgOiBMYWJvcmF0b2lyZS4=
+        - 12, 10 The second floor has the Laboratory.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1433,8 +1422,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDExIFRyb2lzacOobWUgw6l0YWdlIDogQmlibGlvdGjDqHF1ZS4=
+        - 12, 11 The third floor has the Library.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1456,8 +1444,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDEyIFF1YXRyacOobWUgw6l0YWdlIDogU3R1ZGlvIHBob3RvLg==
+        - 12, 12 The fourth floor has the Photo Studio.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1479,8 +1466,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTIsIDEzIENpbnF1acOobWUgw6l0YWdlIDogQ2FzaW5vLg==
+        - 12, 13 The fifth floor has the Game Corner.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map013.rxdata.yml
+++ b/Data/Map013.rxdata.yml
@@ -322,31 +322,29 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDAgOltuYW1lPVByb2YuIE9ybWVdOlRpZW5zLCBib25qb3VyIGpldW5lIFxmW0RyZXNzZXVzZcKnRHJlc3NldXJdICE=
+        - 13, 0 :[name=Professor Elm]:Hi, young Trainer!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          VHUgdG9tYmVzIMOgIHBpYy4=
+        - This is perfect timing.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEgOltuYW1lPVByb2YuIE9ybWVdOk1vbiBhbWksIE0uIFBva8OpbW9uLCB2aWVudCDDoCBsJ2luc3RhbnQgZGUgbSdlbnZveWVyIHVuIMWSdWYu
+        - 13, 1 :[name=Professor Elm]:My dear friend, Mr. Pokémon, just sent me this
+          Egg.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIgOltuYW1lPVByb2YuIE9ybWVdOk1hbGhldXJldXNlbWVudCwgamUgc3VpcyBibG9xdcOpIGRhbnMgY2UgTGFib3JhdG9pcmUsIGV0IHNpIGplIGxlIGdhcmRlLCBpbCByaXNxdWUgZGUgbmUgcGFzIMOpY2xvcmUgZGUgc2l0w7R0Li4u
+        - 13, 2 :[name=Professor Elm]:Unfortunately, I'm stuck in this Laboratory,
+          and if I were to keep it, I'm afraid it wouldn't hatch soon...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 3 :[name=Prof. Orme]:Tu veux bien t'en occuper, dis ?
+        - 13, 3 :[name=Professor Elm]:Could you look after it, please?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -364,12 +362,12 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 4 :[name=Prof. Orme]:Merveilleux !
+        - 13, 4 :[name=Professor Elm]:Wonderful!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Prends-en bien soin.
+        - Take good care of it.
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -407,8 +405,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDUgXGNbMThdXE5bMV0gcmXDp29pdCBsJ8WSdWYgZGUgbGEgcGFydCBkdSBQcm9mZXNzZXVyIE9ybWUgISBbV0FJVCAxNTBd
+        - 13, 5 \c[18]\N[1] received an \c[27]Egg \c[18]from Professor Elm![WAIT 150]
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -438,20 +435,19 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDYgOltuYW1lPVByb2YuIE9ybWVdOlBvdXIgZG9ubmVyIHVuIMWSdWYgZGUgUG9rw6ltb24sIGlsIHN1ZmZpdCBkJ3V0aWxpc2VyIGxhIGNvbW1hbmRlIFxjWzVdImFkZF9lZ2coey4uLn0pIlxjWzBdLg==
+        - 13, 6 :[name=Professor Elm]:To give a Pokémon Egg, just use the \c[5]"add_egg({...})"\c[0]
+          command.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDcgOltuYW1lPVByb2YuIE9ybWVdOlR1IHBldXggcmVudHJlciB0b3V0IHVuIHRhcyBkJ2luZm9ybWF0aW9ucyDDoCBsJ2ludMOpcmlldXIgZGVzIGFjY29sYWRlcywgY29tbWUgbCdJRCBkdSBQb2vDqW1vbiwgc2VzIHN0YXRpc3RpcXVlcywgc2VzIGF0dGFxdWVzLi4u
+        - 13, 7 :[name=Professor Elm]:You can enter a lot of informations in braces,
+          like the ID of the Pokémon, its stats, its moves...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDggOltuYW1lPVByb2YuIE9ybWVdOkplIHRyb3V2ZSBsZXMgxZJ1ZnMgZGUgUG9rw6ltb24gZmFzY2luYW50cyAh
+        - 13, 8 :[name=Professor Elm]:Pokémon Eggs are fascinating, aren't they?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -477,8 +473,8 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDkgOltuYW1lPVByb2YuIE9ybWVdOlF1ZWwgZG9tbWFnZS4uLiBJbCBwZXV0IGNvbnRlbmlyIHVuIFBva8OpbW9uIHJhcmUsIHR1IHNhaXMgIQ==
+        - 13, 9 :[name=Professor Elm]:What a shame... It could contain a rare Pokémon,
+          you know!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -531,7 +527,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 10 :[name=Prof. Orme]:Oh, c'est toi.
+        - 13, 10 :[name=Professor Elm]:Oh, it's you.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -547,14 +543,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDExIDpbbmFtZT1Qcm9mLiBPcm1lXTpJbCBuJ2EgcGFzIGVuY29yZSDDqWNsb3Qu
+        - 13, 11 :[name=Professor Elm]:It hasn't hatched yet.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEyIDpbbmFtZT1Qcm9mLiBPcm1lXTpBcHBhcmVtbWVudCwgbWFyY2hlciBhdmVjIHVuIMWSdWYgbCdhaWRlIMOgIGxlIGZhaXJlIMOpY2xvcmUgIQ==
+        - 13, 12 :[name=Professor Elm]:Apparently, walking with an Egg helps it hatch!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -572,14 +566,12 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEzIDpbbmFtZT1Qcm9mLiBPcm1lXTpXYW91aCAhIFVuIEF6dXJpbGwgZXN0IHNvcnRpIGRlIGwnxZJ1Zi4=
+        - 13, 13 :[name=Professor Elm]:Wow! Azurill came out of the Egg.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE0IDpbbmFtZT1Qcm9mLiBPcm1lXTpJbCBwZXV0IMOpdm9sdWVyIGVuIHVuIFBva8OpbW9uIHRyw6hzIHB1aXNzYW50Lg==
+        - 13, 14 :[name=Professor Elm]:It can evolve into a strong Pokémon.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -638,8 +630,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE1IDpbbmFtZT1Qcm9mLiBPcm1lXTpKZSB0cm91dmUgbGVzIMWSdWZzIGRlIFBva8OpbW9uIGZhc2NpbmFudHMgIQ==
+        - 13, 15 :[name=Professor Elm]:Pokémon Eggs are fascinating, aren't they?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -690,19 +681,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 16 Bonjour, jeune Maker !
+        - 13, 16 Hello, young Maker!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3IE9uIG0nYXBwZWxsZSBsZSBTcMOpY2lhbGlzdGUgZGVzIG5vbXMu
+        - 13, 17 I am the official Name Rater!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE4IFZldXgtdHUgcmVub21tZXIgdW4gUG9rw6ltb24gZGUgdG9uIMOpcXVpcGUgPw==
+        - 13, 18 Want me to rate the nicknames of your Pokémon?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -720,8 +709,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5IFF1ZWwgUG9rw6ltb24gdmV1eC10dSBxdWUgamUgcmVub21tZSA/
+        - 13, 19 Which Pokémon's nickname should I critique?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -788,8 +776,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIwIE1haXMgZW5maW4sIHR1IHBldXggcGFzIHJlbm9tbWVyIHVuIMWSdWYsIGMnZXN0IGJpZW4gY29ubnUgIQ==
+        - 13, 20 Now, now. That is merely an Egg! An Egg can go by no other name!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -833,8 +820,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIxIEhtLCBbUE9LRV0sIHR1IGRpcyA/IEMnZXN0IHVuIG5vbSBpbnTDqXJlc3NhbnQsIG1haXMgamUgcGVuc2UgcXUnb24gcGV1dCB0cm91dmVyIG1pZXV4Lg==
+        - 13, 21 [POKE], is it? Hmm... That is a decent nickname!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -881,7 +867,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 22 Mais enfin ! Tu te moques de moi ?
+        - 13, 22 It looks no different from before?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -899,7 +885,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 23 C'est beaucoup plus original, tu ne trouves pas ?
+        - 13, 23 It is a better name than before, isn't it? Good for you!"
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -948,8 +934,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDI0IEplIHJlc3RlIGzDoCwgc2kgdHUgY2hhbmdlcyBkJ2F2aXMu
+        - 13, 24 Ah, good. I see. Do come visit again if you change your mind.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1008,14 +993,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDI1IEplIHBldXggdG91dCB0ZSBkaXJlIHN1ciBsZSB0eXBlIGRlIGxhIHB1aXNzYW5jZSBjYWNow6llIGRlIHRvbiDDqXF1aXBlLg==
+        - 13, 25 I’ll tell you what type your Pokémon’s Hidden Power will be.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDI2IEMnZXN0IG1hIHB1aXNzYW5jZSBjYWNow6llIMOgIG1vaS4=
+        - 13, 26 My own hidden power lets me do that.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1120,8 +1103,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDI3IFNpIGNlIFBva8OpbW9uIGFwcHJlbmFpdCBbTU9WRV0sIGNlIHNlcmFpdCB1bmUgY2FwYWNpdMOpIGRlIHR5cGUgW1BPV0VSXS4=
+        - 13, 27 If this Pokémon were to learn [MOVE], the move’s type would be [POWER].
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1177,8 +1159,8 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDI4IFNpIHR1IGNoYW5nZXMgZCdhdmlzLCBmYWlzLWxlIG1vaSBzYXZvaXIsIGV0IGplIG1ldHRyYWkgbWEgcHVpc3NhbmNlIGNhY2jDqWUgw6AgdG9uIHNlcnZpY2Uu
+        - 13, 28 If you want to know, ask me, and I’ll activate my hidden power for
+          you.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1237,18 +1219,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 29 Oui-hi-hi !
+        - 13, 29 Woo-hoo-hoo!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDMwIEplIHBldXggaW1pdGVyIGxlIGNyaSBkZSBuJ2ltcG9ydGUgcXVlbCBQb2vDqW1vbiAh
+        - 13, 30 I can mimic any Pokémon's cry!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Youpi-li-pou !
+        - Yahoo-dee-lah!
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1321,8 +1302,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDMxIElsIHZhIGZhbGxvaXIgYXR0ZW5kcmUgdW4gcGV1IGF2YW50IHF1ZSBqZSBwdWlzc2UgaW1pdGVyIGNlIFBva8OpbW9uLi4u
+        - 13, 31 You'll have to wait a bit more before I can mimic this Pokémon's
+          cry...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1593,7 +1574,7 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 32 C'est le cri de [POKE] ! Oui-hi-hi ![WAIT 50]
+        - 13, 32 That's the cry of \c[1][POKE]\c[0]! Woo-hoo-hoo![WAIT 50]
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1617,8 +1598,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDMzIFF1ZWxsZSBkb3VjZSBtw6lsb2RpZSAh
+        - 13, 33 What a nice melody!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1803,38 +1783,33 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDM0IEFoICEgVGUgdm9pbMOgICE6W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 34 There you are!:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDM1IExlIFN0YWZmIG5vdXMgYSBwcsOpdmVudSBxdWUgdHUgdmllbmRyYWlzLjpbbmFtZT1Qcm9mLiBTZWtvXTo=
+        - '13, 35 The Staff members told us you''d come.:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDM2IFR1IGFzIHB1IGV4cGxvcmVyIHVuIHBldSBsJ8OObGUgPzpbbmFtZT1Qcm9mLiBTZWtvXTo=
+        - '13, 36 Were you able to explore the Island a little?:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDM3IFR1IGFzIGTDuyByZW5jb250cmVyIHRvdXRlIHVuZSB2YXJpw6l0w6kgZGUgUG9rw6ltb24uOltuYW1lPVByb2YuIFNla29dOg==
+        - '13, 37 You must have seen a whole variety of Pokémon.:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDM4IE1haXMgISBJbCBzZW1ibGVyYWl0IHF1J29uIGFpdCBjb21wbMOodGVtZW50IG91Ymxpw6kgZGUgdGUgZG9ubmVyIHVuIFBva8OpZGV4ICE6W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 38 Wait! It looks like we forgot to give you a Pokédex!:[name=Professor
+          Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDM5IExhaXNzZS1tb2kgcsOpZ2xlciDDp2EuLi46W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 39 Let me handle this...:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1900,26 +1875,26 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDQwIFxjWzE4XVxOWzFdIHJlw6dvaXQgbGUgUG9rw6lkZXggZGUgbGEgcGFydCBkdSBQcm9mLiBTZWtvICEgW1dBSVQgMTIwXQ==
+        - 13, 40 \c[18]\N[1] received the \c[27]Pokédex \c[18]from Professor Birch![WAIT
+          120]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDQxIEMnZXN0IHVuIG91dGlsIHRyw6hzIHBlcmZvcm1hbnQgcXVpIHRlIHBlcm1ldHRyYSBkZSBjb2xsZWN0ZXIgdW4gdGFzIGQnaW5mb3JtYXRpb25zIHN1ciBsZXMgUG9rw6ltb24gcXVlIHR1IHJlbmNvbnRyZXMuOltuYW1lPVByb2YuIFNla29dOg==
+        - '13, 41 It''s a high-tech tool that automatically collects a bunch of data
+          on Pokémon you''ve seen or caught.:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDQyIE4naMOpc2l0ZSBwYXMgw6AgdmVuaXIgbWUgdm9pciDDoCBtb24gYnVyZWF1IHBvdXIgcXVlIGplIGwnw6l2YWx1ZS46W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 42 Feel free to come to my desk to show me your Pokédex.:[name=Professor
+          Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDQzIFF1aSBzYWl0LCBqZSBwb3VycmFpcyBwZXV0LcOqdHJlIHQnb2ZmcmlyIHF1ZWxxdWUgY2hvc2UgZCdpbnTDqXJlc3NhbnQuLi46W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 43 Who knows, I could offer you something interesting...:[name=Professor
+          Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2080,13 +2055,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 44 Un lave-linge.
+        - 13, 44 It’s a washing machine.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          SWwgZXN0IMOpcXVpcMOpIGQndW4gw6l0cmFuZ2UgbW90ZXVyLg==
+        - It has an odd-shaped motor on it.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2117,8 +2091,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDQ1IFZvdWxlei12b3VzIGZhaXJlIHNvcnRpciBNb3Rpc21hIGRlIHNhIFBva8OpYmFsbCA/
+        - 13, 45 Do you want to let Rotom out of its Poké Ball?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2240,12 +2213,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 46 Oh ? On dirait que [POKE] veut entrer dans le moteur.
+        - 13, 46 Oh? [POKE] appears as if it wants to go into the motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 47 Le laisser entrer dans le moteur ?
+        - 13, 47 Allow it to enter the motor?
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2309,8 +2282,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDQ4IFtQT0tFXSBlc3QgZW50csOpIGRhbnMgbGUgbW90ZXVyLg==
+        - 13, 48 [POKE] entered the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2330,8 +2302,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDQ5IFtQT0tFXSByZW5vbmNlIG1hbGdyw6kgbHVpIMOgIGVudHJlciBkYW5zIGxlIG1vdGV1ciBkdSB2ZW50aWxhdGV1ci4uLg==
+        - 13, 49 [POKE] reluctantly gave up on entering the washing machine’s motor...
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2363,7 +2334,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 50 [POKE] reprend sa forme d'origine.
+        - 13, 50 [POKE] returned to its original form.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2423,19 +2394,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 51 Oh ? On dirait que [POKE] veut entrer dans le moteur.
+        - 13, 51 Oh? [POKE] appears as if it wants to go into the motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 52 Le laisser entrer dans le moteur ?
+        - 13, 52 Allow it to enter the motor?
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
         - - "\\t[11,27]"
           - "\\t[11,28]"
-          - 13, 53 Rappeler
+          - 13, 53 Recall
         - 2
         indent: 4
         code: 102
@@ -2493,8 +2464,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDU0IFtQT0tFXSBlc3QgZW50csOpIGRhbnMgbGUgbW90ZXVyLg==
+        - 13, 54 [POKE] entered the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2514,8 +2484,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDU1IFtQT0tFXSByZW5vbmNlIG1hbGdyw6kgbHVpIMOgIGVudHJlciBkYW5zIGxlIG1vdGV1ciBkdSB2ZW50aWxhdGV1ci4uLg==
+        - 13, 55 [POKE] reluctantly gave up on entering the rotary fan’s motor...
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2530,7 +2499,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Rappeler
+        - 13, 53 Recall
         indent: 4
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2550,7 +2519,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 56 [POKE] est sorti du moteur.
+        - 13, 56 [POKE] emerged from the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2670,8 +2639,7 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDU3IMOHYSBuZSBmb25jdGlvbm5lcmEgcGFzIGF2ZWMgY2UgUG9rw6ltb24u
+        - 13, 57 That Pokémon can’t enter a motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2822,14 +2790,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDU4IFVuIGZvdXIgw6AgbWljcm8tb25kZXMu
+        - 13, 58 It’s a microwave oven.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          SWwgZXN0IMOpcXVpcMOpIGQndW4gw6l0cmFuZ2UgbW90ZXVyLg==
+        - It has an odd-shaped motor on it.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2860,8 +2826,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDU5IFZvdWxlei12b3VzIGZhaXJlIHNvcnRpciBNb3Rpc21hIGRlIHNhIFBva8OpYmFsbCA/
+        - 13, 59 Do you want to let Rotom out of its Poké Ball?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2983,12 +2948,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 60 Oh ? On dirait que [POKE] veut entrer dans le moteur.
+        - 13, 60 Oh? [POKE] appears as if it wants to go into the motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 61 Le laisser entrer dans le moteur ?
+        - 13, 61 Allow it to enter the motor?
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3052,8 +3017,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDYyIFtQT0tFXSBlc3QgZW50csOpIGRhbnMgbGUgbW90ZXVyLg==
+        - 13, 62 [POKE] entered the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3073,8 +3037,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDYzIFtQT0tFXSByZW5vbmNlIG1hbGdyw6kgbHVpIMOgIGVudHJlciBkYW5zIGxlIG1vdGV1ciBkdSB2ZW50aWxhdGV1ci4uLg==
+        - 13, 63 [POKE] reluctantly gave up on entering the rotary fan’s motor...
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3106,7 +3069,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 64 [POKE] reprend sa forme d'origine.
+        - 13, 64 [POKE] returned to its original form.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3166,19 +3129,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 65 Oh ? On dirait que [POKE] veut entrer dans le moteur.
+        - 13, 65 Oh? [POKE] appears as if it wants to go into the motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 66 Le laisser entrer dans le moteur ?
+        - 13, 66 Allow it to enter the motor?
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
         - - "\\t[11,27]"
           - "\\t[11,28]"
-          - 13, 67 Rappeler
+          - 13, 67 Recall
         - 2
         indent: 4
         code: 102
@@ -3236,8 +3199,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDY4IFtQT0tFXSBlc3QgZW50csOpIGRhbnMgbGUgbW90ZXVyLg==
+        - 13, 68 [POKE] entered the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3257,8 +3219,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDY5IFtQT0tFXSByZW5vbmNlIG1hbGdyw6kgbHVpIMOgIGVudHJlciBkYW5zIGxlIG1vdGV1ciBkdSB2ZW50aWxhdGV1ci4uLg==
+        - 13, 69 [POKE] reluctantly gave up on entering the rotary fan’s motor...
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3273,7 +3234,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Rappeler
+        - 13, 67 Recall
         indent: 4
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -3314,7 +3275,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 70 [POKE] est sorti du moteur.
+        - 13, 70 [POKE] emerged from the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3413,8 +3374,7 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDcxIMOHYSBuZSBmb25jdGlvbm5lcmEgcGFzIGF2ZWMgY2UgUG9rw6ltb24u
+        - 13, 71 That Pokémon can’t enter a motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3565,13 +3525,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 72 Une tondeuse.
+        - 13, 72 It’s a lawn mower.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          RWxsZSBlc3Qgw6lxdWlww6llIGQndW4gw6l0cmFuZ2UgbW90ZXVyLg==
+        - It has an odd-shaped motor on it.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3602,8 +3561,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDczIFZvdWxlei12b3VzIGZhaXJlIHNvcnRpciBNb3Rpc21hIGRlIHNhIFBva8OpYmFsbCA/
+        - 13, 73 Do you want to let Rotom out of its Poké Ball?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3725,12 +3683,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 74 Oh ? On dirait que [POKE] veut entrer dans le moteur.
+        - 13, 74 Oh? [POKE] appears as if it wants to go into the motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 75 Le laisser entrer dans le moteur ?
+        - 13, 75 Allow it to enter the motor?
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3789,8 +3747,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDc2IFtQT0tFXSBlc3QgZW50csOpIGRhbnMgbGUgbW90ZXVyLg==
+        - 13, 76 [POKE] entered the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3810,8 +3767,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDc3IFtQT0tFXSByZW5vbmNlIG1hbGdyw6kgbHVpIMOgIGVudHJlciBkYW5zIGxlIG1vdGV1ciBkdSB2ZW50aWxhdGV1ci4uLg==
+        - 13, 77 [POKE] reluctantly gave up on entering the rotary fan’s motor...
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3843,7 +3799,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 78 [POKE] reprend sa forme d'origine.
+        - 13, 78 [POKE] returned to its original form.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3903,19 +3859,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 79 Oh ? On dirait que [POKE] veut entrer dans le moteur.
+        - 13, 79 Oh? [POKE] appears as if it wants to go into the motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 80 Le laisser entrer dans le moteur ?
+        - 13, 80 Allow it to enter the motor?
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
         - - "\\t[11,27]"
           - "\\t[11,28]"
-          - 13, 81 Rappeler
+          - 13, 81 Recall
         - 2
         indent: 4
         code: 102
@@ -3973,8 +3929,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDgyIFtQT0tFXSBlc3QgZW50csOpIGRhbnMgbGUgbW90ZXVyLg==
+        - 13, 82 [POKE] entered the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3994,8 +3949,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDgzIFtQT0tFXSByZW5vbmNlIG1hbGdyw6kgbHVpIMOgIGVudHJlciBkYW5zIGxlIG1vdGV1ciBkdSB2ZW50aWxhdGV1ci4uLg==
+        - 13, 83 [POKE] reluctantly gave up on entering the rotary fan’s motor...
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4010,7 +3964,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Rappeler
+        - 13, 81 Recall
         indent: 4
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4051,7 +4005,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 84 [POKE] est sorti du moteur.
+        - 13, 84 [POKE] emerged from the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4150,8 +4104,7 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDg1IMOHYSBuZSBmb25jdGlvbm5lcmEgcGFzIGF2ZWMgY2UgUG9rw6ltb24u
+        - 13, 85 That Pokémon can’t enter a motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4302,14 +4255,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDg2IFVuIHLDqWZyaWfDqXJhdGV1ci4=
+        - 13, 86 It’s a refrigerator.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          SWwgZXN0IMOpcXVpcMOpIGQndW4gw6l0cmFuZ2UgbW90ZXVyLg==
+        - It has an odd-shaped motor on it.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -4340,8 +4291,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDg3IFZvdWxlei12b3VzIGZhaXJlIHNvcnRpciBNb3Rpc21hIGRlIHNhIFBva8OpYmFsbCA/
+        - 13, 87 Do you want to let Rotom out of its Poké Ball?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4463,12 +4413,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 88 Oh ? On dirait que [POKE] veut entrer dans le moteur.
+        - 13, 88 Oh? [POKE] appears as if it wants to go into the motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 89 Le laisser entrer dans le moteur ?
+        - 13, 89 Allow it to enter the motor?
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4532,8 +4482,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDkwIFtQT0tFXSBlc3QgZW50csOpIGRhbnMgbGUgbW90ZXVyLg==
+        - 13, 90 [POKE] entered the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4553,8 +4502,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDkxIFtQT0tFXSByZW5vbmNlIG1hbGdyw6kgbHVpIMOgIGVudHJlciBkYW5zIGxlIG1vdGV1ciBkdSB2ZW50aWxhdGV1ci4uLg==
+        - 13, 91 [POKE] reluctantly gave up on entering the rotary fan’s motor...
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4586,7 +4534,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 92 [POKE] reprend sa forme d'origine.
+        - 13, 92 [POKE] returned to its original form.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4646,19 +4594,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 93 Oh ? On dirait que [POKE] veut entrer dans le moteur.
+        - 13, 93 Oh? [POKE] appears as if it wants to go into the motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 94 Le laisser entrer dans le moteur ?
+        - 13, 94 Allow it to enter the motor?
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
         - - "\\t[11,27]"
           - "\\t[11,28]"
-          - 13, 95 Rappeler
+          - 13, 95 Recall
         - 2
         indent: 4
         code: 102
@@ -4716,8 +4664,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDk2IFtQT0tFXSBlc3QgZW50csOpIGRhbnMgbGUgbW90ZXVyLg==
+        - 13, 96 [POKE] entered the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4737,8 +4684,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDk3IFtQT0tFXSByZW5vbmNlIG1hbGdyw6kgbHVpIMOgIGVudHJlciBkYW5zIGxlIG1vdGV1ciBkdSB2ZW50aWxhdGV1ci4uLg==
+        - 13, 97 [POKE] reluctantly gave up on entering the rotary fan’s motor...
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4753,7 +4699,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Rappeler
+        - 13, 95 Recall
         indent: 4
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4794,7 +4740,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 98 [POKE] est sorti du moteur.
+        - 13, 98 [POKE] emerged from the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4893,8 +4839,7 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDk5IMOHYSBuZSBmb25jdGlvbm5lcmEgcGFzIGF2ZWMgY2UgUG9rw6ltb24u
+        - 13, 99 That Pokémon can’t enter a motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5045,13 +4990,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 100 Un ventilateur.
+        - 13, 100 It’s a rotary fan.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          SWwgZXN0IMOpcXVpcMOpIGQndW4gw6l0cmFuZ2UgbW90ZXVyLg==
+        - It has an odd-shaped motor on it.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -5082,8 +5026,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEwMSBWb3VsZXotdm91cyBmYWlyZSBzb3J0aXIgTW90aXNtYSBkZSBzYSBQb2vDqWJhbGwgPw==
+        - 13, 101 Do you want to let Rotom out of its Poké Ball?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5205,12 +5148,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 102 Oh ? On dirait que [POKE] veut entrer dans le moteur.
+        - 13, 102 Oh? [POKE] appears as if it wants to go into the motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 103 Le laisser entrer dans le moteur ?
+        - 13, 103 Allow it to enter the motor?
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5243,8 +5186,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEwNCBbUE9LRV0gZXN0IGVudHLDqSBkYW5zIGxlIG1vdGV1ci4=
+        - 13, 104 [POKE] entered the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5306,8 +5248,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEwNSBbUE9LRV0gcmVub25jZSBtYWxncsOpIGx1aSDDoCBlbnRyZXIgZGFucyBsZSBtb3RldXIgZHUgdmVudGlsYXRldXIuLi4=
+        - 13, 105 [POKE] reluctantly gave up on entering the rotary fan’s motor...
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5344,7 +5285,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 106 [POKE] reprend sa forme d'origine.
+        - 13, 106 [POKE] returned to its original form.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5408,19 +5349,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 107 Oh ? On dirait que [POKE] veut entrer dans le moteur.
+        - 13, 107 Oh? [POKE] appears as if it wants to go into the motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 108 Le laisser entrer dans le moteur ?
+        - 13, 108 Allow it to enter the motor?
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
         - - "\\t[11,27]"
           - "\\t[11,28]"
-          - 13, 109 Rappeler
+          - 13, 109 Recall
         - 2
         indent: 4
         code: 102
@@ -5447,8 +5388,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDExMCBbUE9LRV0gZXN0IGVudHLDqSBkYW5zIGxlIG1vdGV1ci4=
+        - 13, 110 [POKE] entered the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5499,8 +5439,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDExMSBbUE9LRV0gcmVub25jZSBtYWxncsOpIGx1aSDDoCBlbnRyZXIgZGFucyBsZSBtb3RldXIgZHUgdmVudGlsYXRldXIuLi4=
+        - 13, 111 [POKE] reluctantly gave up on entering the rotary fan’s motor...
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5515,7 +5454,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Rappeler
+        - 13, 109 Recall
         indent: 4
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5535,7 +5474,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 112 [POKE] est sorti du moteur.
+        - 13, 112 [POKE] emerged from the motor.
         indent: 5
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5670,8 +5609,7 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDExMyDDh2EgbmUgZm9uY3Rpb25uZXJhIHBhcyBhdmVjIGNlIFBva8OpbW9uLg==
+        - 13, 113 That Pokémon can’t enter a motor.
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6205,14 +6143,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDExNCBNb3Rpc21hIGEgdW5lIHJlbWFycXVhYmxlIGFwdGl0dWRlIMOgIGludMOpZ3JlciBjZXJ0YWlucyBtb3RldXJzLg==
+        - 13, 114 Remarkably, Rotom has the ability to enter and merge with special
+          motors.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDExNSBTYSBjYXBhY2l0w6kgw6AgZnVzaW9ubmVyIGF2ZWMgdG91dGVzIHNvcnRlcyBkJ2FwcGFyZWlscyBlc3QgZmFzY2luYW50ZSAh
+        - 13, 115 Fascinating how it can integrate all kinds of machines!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6228,8 +6165,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDExNiBPaCwgbWFpcyBqZSB2b2lzIHF1ZSB0dSBlbiBwb3Nzw6hkZXMgdW4gIQ==
+        - 13, 116 Oh, I see you have one with you!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6250,14 +6186,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDExNyBJbCBhIG3Dqm1lIHVuZSBmb3JtZSBzcMOpY2lhbGUgIQ==
+        - 13, 117 It even has a special form!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDExOCBKZSB2b2lzIHF1ZSB0dSBtYcOudHJpc2VzIHRvdXQgY2UgcXUnaWwgeSBhIMOgIHNhdm9pciBzdXIgY2UgbWVydmVpbGxldXggUG9rw6ltb24gcXUnZXN0IE1vdGlzbWEu
+        - 13, 118 It looks like you master everything there is to know about this
+          wonderful Pokémon.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6270,8 +6205,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDExOSBUdSBkZXZyYWlzIGFsbGVyIGpldGVyIHVuIMWTaWwgYXV4IG1hY2hpbmVzIHNpdHXDqWVzIGRlcnJpw6hyZSBtb2kgIQ==
+        - 13, 119 You should take a look at the devices behind me!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6292,14 +6226,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEyMCBKJ2FpIGVudGVuZHUgZGlyZSBxdSdvbiBwb3V2YWl0IGVuIHRyb3V2ZXIgZGFucyB1biBkw6liYXJyYXMgc2l0dcOpIGF1IHNvdXMtc29sIGRlIGxhIFRvdXIuLi4=
+        - 13, 120 I heard you could find one in a storage room located under the Tower...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEyMSBNYWlzIGNvbW1lbnQgeSBhY2PDqWRlciA/
+        - 13, 121 But I don't know how to get there...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6359,25 +6291,23 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 122 Je suis un grand fan de Porygon et de toute sa famille !
+        - 13, 122 I'm a big fan of Porygon and its family!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEyMyBKJ2FpIG3Dqm1lIGVudGVuZHUgZGlyZSBxdSdpbHMgcHLDqWbDqXJhaWVudCDDqnRyZSBzdG9ja8OpcyBkYW5zIGxlIFBDIHF1ZSBkZSByZXN0ZXIgYXZlYyBsZXVyIERyZXNzZXVyLi4u
+        - 13, 123 I heard they sometimes prefered to be kept in the Storage System
+          rather than with their Trainer...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEyNCBUdSBhcyB1biBQb3J5Z29uIG91IHVuIFBva8OpbW9uIGRlIHNhIGZhbWlsbGUgZGFucyB0b24gUEMsIHRvaSA/
+        - 13, 124 Do you have a Porygon or one of its evolution in your PC?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          SmUgcGV1eCBsZSB2w6lyaWZpZXIgYXZlYyBcY1s1XSIkc3RvcmFnZS5hbnlfcG9rZW1vbj8iXGNbMF0u
+        - I can check with \c[5]"$storage.any_pokemon?"\c[0].
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -6394,7 +6324,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 125 Super ! Il doit s'y sentir super bien.
+        - 13, 125 Amazing! It must feel at ease.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6407,7 +6337,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 126 Hmm... Dommage.
+        - 13, 126 Hmm... Too bad.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6473,20 +6403,17 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEyNyBKZSBzdWlzIHVuIGZvdSBkZXMgUG9rw6ltb24gY2hyb21hdGlxdWVzICE=
+        - 13, 127 I'm a Shinies fanatic!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEyOCBUdSBzYWlzLCBjZSBzb250IGNlcyBQb2vDqW1vbiBxdWkgb250IHVuZSBjb3VsZXVyIGluaGFiaXR1ZWxsZS4=
+        - 13, 128 You know, shiny Pokémon have an unusual coloration.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEyOSBUdSBlbiBhcyBkw6lqw6AgYXR0cmFww6kgdW4gPw==
+        - 13, 129 Have you ever caught one?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6593,17 +6520,17 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 130 Oh ! Magnifique !
+        - 13, 130 Oh! Splendid!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Ton [POKE] est si beau !
+        - Your [POKE] is breathtaking!
         indent: 3
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 131 Dis...[WAIT 60] Tu ne voudrais pas me le donner ?
+        - 13, 131 Look...[WAIT 60] Would you give it to me?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6613,12 +6540,12 @@ events:
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 133 Non ?
+        - 13, 133 No?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 134 Tant pis...
+        - 13, 134 Too bad...
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6631,8 +6558,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEzNSBIdW0uLi4gSmUgbSd5IGNvbm5haXMgdHLDqHMgYmllbiBlbiBQb2vDqW1vbiBjaHJvbWF0aXF1ZXMsIGV0IHRvbiBbUE9LRV0gbidlbiBlc3QgcGFzIHVuLg==
+        - 13, 135 Hmm... I know a lot about shiny Pokémon and your [POKE] isn't one
+          of them.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6681,20 +6608,19 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEzNiBDZSBzb250IGRlcyBQb2vDqW1vbiB0csOocyByYXJlcyDDoCB0cm91dmVyLCBlbiBlZmZldC4uLg==
+        - 13, 136 These Pokémon are quite rare, indeed...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEzNyBEJ2FpbGxldXJzLCBqJ2FpIGTDqWNvdXZlcnQgdW5lIHRlY2huaXF1ZSBpbnTDqXJlc3NhbnRlIHBvdXIgZW4gZMOpYnVzcXVlciBwbHVzIGZhY2lsZW1lbnQu
+        - 13, 137 Speaking of which, I discovered a very interesting technic to flush
+          them out easily.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEzOCBTaSB0dSBww6pjaGVzIGRlcyBQb2vDqW1vbiDDoCBsYSBjaGHDrm5lLCBzYW5zIGJvdWdlciBkZSB0b24gc3BvdCwgbGVzIGNoYW5jZXMgZGUgZmVycmVyIHVuIFBva8OpbW9uIGNocm9tYXRpcXVlIGF1Z21lbnRlbnQgcHJvZ3Jlc3NpdmVtZW50Lg==
+        - 13, 138 If you chain-fish Pokémon, without moving from your spot, chances
+          to catch a shiny Pokémon will progressively increase.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6758,8 +6684,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDEzOSBBbG9ycywgY29tbWVudCBzZSBwYXNzZSBsYSBjb21wbMOpdGlvbiBkZSB0b24gUG9rw6lkZXggPzpbbmFtZT1Qcm9mLiBTZWtvXTo=
+        - '13, 139 So, how’s your Pokédex coming along?:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6775,19 +6700,19 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE0MCBKZSBwZXV4IGZhY2lsZW1lbnQgdsOpcmlmaWVyIGxlIG5vbWJyZSBkZSBQb2vDqW1vbiB2dXMgb3UgYXR0cmFww6lzIGdyw6JjZSBhdXggXGNbNV12YXJpYWJsZXMgMiBldCAzXGNbMF0uOltuYW1lPVByb2YuIFNla29dOg==
+        - '13, 140 I can easily check the number of Pokémon you''ve seen or caught
+          with the \c[5]variables 2 and 3\c[0].:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 141 Hm, voyons voir...
+        - 13, 141 Hmm, let's see...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          VHUgYXMgdnUgXHZbMl0gUG9rw6ltb24gZXQgdHUgZW4gYXMgY2FwdHVyw6kgXHZbM10gITpbbmFtZT1Qcm9mLiBTZWtvXTo=
+        - 'You''ve seen \v[2] Pokémon, and you''ve caught \v[3] Pokémon!:[name=Professor
+          Birch]:'
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -6826,19 +6751,18 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE0MiBJbmNyb3lhYmxlICEgVHUgYXMgdnUgcGx1cyBkZSA0MCBQb2vDqW1vbiBkaWZmw6lyZW50cyBkYW5zIGxhIFRvdXIgIVtXQUlUIDQwMF06W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 142 Excellent! You''ve seen more than 40 Pokémon on the Island![WAIT
+          400]:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE0MyBUdSBhcyB1biB0YWxlbnQgY2VydGFpbiBwb3VyIGTDqWJ1c3F1ZXIgZGVzIFBva8OpbW9uICE6W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 143 You seem to be good at collecting Pokémon!:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '13, 144 Comme promis, je te remets ma Pierre Insolite.:[name=Prof. Seko]:'
+        - '13, 144 As promised, here''s my Intriguing Stone.:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6848,8 +6772,8 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE0NSBUdSBtZSBzZXJhaXMgZCd1bmUgYWlkZSBjZXJ0YWluZSBkYW5zIG1hIHLDqWdpb24gbmF0YWxlLCDDoCBIb2Vubi4uLjpbbmFtZT1Qcm9mLiBTZWtvXTo=
+        - '13, 145 You''d help me a lot in my home region, in Hoenn...:[name=Professor
+          Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6900,14 +6824,14 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE0NiBUdSBhcyBkZSBwbHVzIGVuIHBsdXMgZGUgUG9rw6ltb24gZW5yZWdpc3Ryw6lzICEgQ29udGludWUgY29tbWUgw6dhICFbV0FJVCAyMDBdOltuYW1lPVByb2YuIFNla29dOg==
+        - '13, 146 Your Pokédex is really filling up. Keep up the good work![WAIT
+          200]:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE0NyBRdWFuZCB0dSBhdXJhcyB2dSBwbHVzIGRlIDQwIFBva8OpbW9uIGRpZmbDqXJlbnRzLCBqZSB0J29mZnJpcmFpIHVuZSBQaWVycmUgSW5zb2xpdGUgITpbbmFtZT1Qcm9mLiBTZWtvXTo=
+        - '13, 147 When you''ve seen at least 40 different Pokémon, I''ll give you
+          an Intriguing Stone!:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6947,14 +6871,14 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '13, 148 Tu ne manques pas de ressources ! Tu m''impressionnes vraiment
-          ![WAIT 240]:[name=Prof. Seko]:'
+        - '13, 148 Wow, you''ve gotten so far...! I''ve got high expectations for
+          you![WAIT 240]:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE0OSBDZXJ0YWluZXMgZXNww6hjZXMgZGUgUG9rw6ltb24gc2Vyb250IHBsdXMgZmFjaWxlcyDDoCByZW5jb250cmVyIGVuIGNvbWJhdHRhbnQgZGVzIERyZXNzZXVycyAhOltuYW1lPVByb2YuIFNla29dOg==
+        - '13, 149 Don''t forget some Trainers have rare Pokémon, too!:[name=Professor
+          Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6994,14 +6918,14 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE1MCBBaCwgdHUgcHJvZ3Jlc3NlcyBiaWVuICEgVG9uIFBva8OpZGV4IHByZW5kIHVuZSBib25uZSB0b3VybnVyZSAhW1dBSVQgMjQwXTpbbmFtZT1Qcm9mLiBTZWtvXTo=
+        - '13, 150 You''re getting good at this! Your Pokédex is coming together![WAIT
+          240]:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE1MSBOJ291YmxpZSBwYXMgcXVlIGNlcnRhaW5lcyBlc3DDqGNlcyBkZSBQb2vDqW1vbiBwZXV2ZW50IMOpdm9sdWVyLCBtYWlzIGF1c3NpIGZhaXJlIGRlcyDFknVmcyAhOltuYW1lPVByb2YuIFNla29dOg==
+        - '13, 151 You know some Pokémon can evolve, but also lay Eggs!:[name=Professor
+          Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7038,14 +6962,13 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE1MiBFc3NhaWUgZGUgbWFyY2hlciBkYW5zIGxlcyBoYXV0ZXMgaGVyYmVzIHBvdXIgcmVuY29udHJlciBkZXMgUG9rw6ltb24gIVtXQUlUIDIwMF06W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 152 Look for Pokémon in grassy areas![WAIT 200]:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE1MyBMYSBUb3VyIHJlZ29yZ2UgZCdlbnZpcm9ubmVtZW50cyB2YXJpw6lzLCB0dSBwb3VycmFzIHJlbmNvbnRyZXIgZGVzIHRvbm5lcyBkJ2VzcMOoY2VzIGRlIFBva8OpbW9uLjpbbmFtZT1Qcm9mLiBTZWtvXTo=
+        - '13, 153 The Island is filled with a variety of environments, you''ll encounter
+          tons of Pokémon species.:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7108,8 +7031,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE1NCBUdSB2ZXV4IHF1ZSBqJ8OpdmFsdWUgw6Agbm91dmVhdSB0b24gUG9rw6lkZXggPzpbbmFtZT1Qcm9mLiBTZWtvXTo=
+        - '13, 154 Do you want to show me your Pokédex again?:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7125,13 +7047,13 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 155 Hm, voyons voir...
+        - 13, 155 Hmm, let's see...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          VHUgYXMgdnUgXHZbMl0gUG9rw6ltb24gZXQgdHUgZW4gYXMgY2FwdHVyw6kgXHZbM10gITpbbmFtZT1Qcm9mLiBTZWtvXTo=
+        - 'You''ve seen \v[2] Pokémon, and you''ve caught \v[3] Pokémon!:[name=Professor
+          Birch]:'
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -7170,8 +7092,8 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE1NiBEw6ljb3V2cmlyIGRlIG5vdXZlYXV4IFBva8OpbW9uIGRldmllbnQgcGx1cyBjb21wbGlxdcOpLCBuJ2VzdC1jZSBwYXMgP1tXQUlUIDIwMF06W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 156 Discovering new Pokémon is getting harder, isn''t it?[WAIT 200]:[name=Professor
+          Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7206,8 +7128,8 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE1NyBUdSBhcyBkw6ljaWTDqW1lbnQgdW4gZG9uICEgSmUgc3VpcyBpbXByZXNzaW9ubsOpICFbV0FJVCAyMDBdOltuYW1lPVByb2YuIFNla29dOg==
+        - '13, 157 You definitely have a gift! I''m actually impressed![WAIT 200]:[name=Professor
+          Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7242,20 +7164,18 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '13, 158 C''est tout bonnement hallucinant ! Tu les as TOUS vus ![WAIT 400]:[name=Prof.
-          Seko]:'
+        - '13, 158 It''s simply mind-boggling! You''ve seen the ALL![WAIT 400]:[name=Professor
+          Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE1OSBKZSBuJ2Fycml2ZSBtw6ptZSBwYXMgw6AgY29tcHJlbmRyZSBjb21tZW50IHR1IGFzIHB1IGZhaXJlLi4uOltuYW1lPVByb2YuIFNla29dOg==
+        - '13, 159 I don''t even understand how you made it...:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE2MCBKJ2VuIHZpZW5zIHByZXNxdWUgw6AgZXNww6lyZXIgcXVlIHR1IGFzIHRyaWNow6kuLi46W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 160 It almost makes me think you''ve cheated...:[name=Professor Birch]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7319,14 +7239,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE2MSBUdSBhcyB2dSB0b3VzIGxlcyBQb2vDqW1vbiBkZSBsJ8OObGUuLi46W25hbWU9UHJvZi4gU2Vrb106
+        - '13, 161 You''ve seen all the Pokémon on the Island...:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE2MiBKZSBuJ2FpIHZyYWltZW50IHBsdXMgcmllbiDDoCB0J2FwcHJlbmRyZSAhOltuYW1lPVByb2YuIFNla29dOg==
+        - '13, 162 I''ve got nothing to teach you anymore!:[name=Professor Birch]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7377,26 +7295,23 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 163 On m'interdit d'utiliser mon Iguolta ici car cela pourrait endommager
-          les appareils...
+        - 13, 163 I'm not allowed to use my Heliolisk here because it could damage
+          the equipment...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE2NCBJbCBlc3QgcGFydGljdWxpZXIgY2FyIGonYWkgcsOpdXNzaSDDoCBsdWkgYXBwcmVuZHJlIGwnYXR0YXF1ZSBMYW5jZS1GbGFtbWVzICE=
+        - 13, 164 It's a bit special because I taught it Flamethrower!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE2NSDDh2EgdG9tYmUgYmllbiwgY2FyIGVuIHBsdXMgZGUgw6dhIGlsIGVzdCByb3VnZSBjb21tZSBsZSBmZXUu
+        - 13, 165 That suits it perfectly because it's red as fire.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE2NiDDh2EgdGUgZGlyYWl0IGRlIHQnZW4gb2NjdXBlciDDoCBtYSBwbGFjZSA/
+        - 13, 166 Would you train it for me?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7414,7 +7329,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 167 T'es au top !
+        - 13, 167 So cool!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7443,7 +7358,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 168 \c[18]\N[1] obtient Iguolta ! [WAIT 240]
+        - 13, 168 \c[18]\N[1] received \c[27]Heliolisk\c[18]![WAIT 240]
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7486,8 +7401,8 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE2OSBCb24sIGonYWkgdW4gcGV1IHRyaWNow6kgY2FyIGonYWkgdXRpbGlzw6kgbGEgY29tbWFuZGUgXGNbNV0iYWRkX3NwZWNpZmljX3Bva2Vtb24iXGNbMF0sIHF1aSBtZSBwZXJtZXQgZGUgZ8OpbsOpcmVyIHVuIFBva8OpbW9uIGF2ZWMgdG91dGVzIHNvcnRlcyBkZSBwYXJhbcOodHJlcy4=
+        - 13, 169 I cheated a bit by using the command \c[5]"add_specific_pokemon"\c[5],
+          which allows me to create a Pokémon with a lot of parameters.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7508,8 +7423,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3MCBKJ2FpbWVyYWlzIG5lIHBhcyBhdm9pciDDoCBtJ2VuIGTDqWJhcnJhc3NlciBhdXRyZW1lbnQuLi4=
+        - 13, 170 I wish I didn't have to get rid of it any other way...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7562,14 +7476,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3MSBKJ2VzcMOocmUgcXVlIHR1IHQnb2NjdXBlcyBiaWVuIGRlIG1vbiBiZWF1IFNtYXVnLg==
+        - 13, 171 I hope you take good care of my pretty Smaug.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3MiBCb24sIGonYWkgdW4gcGV1IHRyaWNow6kgY2FyIGonYWkgdXRpbGlzw6kgbGEgY29tbWFuZGUgXGNbNV0iYWRkX3NwZWNpZmljX3Bva2Vtb24iXGNbMF0sIHF1aSBtJ2EgcGVybWlzIGRlIGxlIGfDqW7DqXJlciBhdmVjIHRvdXRlcyBzb3J0ZXMgZGUgcGFyYW3DqHRyZXMu
+        - 13, 172 I cheated a bit by using the command \c[5]"add_specific_pokemon"\c[5],
+          which allows me to create a Pokémon with a lot of parameters.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7700,26 +7613,24 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3MyBCb25qb3VyICEgSmUgdm9pcyBxdWUgbGEgbWFjaGluZSDDoCBjw7R0w6kgZGUgbW9pIHQnaW50cmlndWVzLi4uOltuYW1lPVByb2YuIFNvcmJpZXJdOg==
+        - '13, 173 Hello! I can see you''re intrigued by that machine right there...:[name=Professor
+          Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3NCBDb21tZSB0dSBwZXV4IGxlIHZvaXIsIGVsbGUgY29udGllbnQgMyBQb2vDqWJhbGxzLjpbbmFtZT1Qcm9mLiBTb3JiaWVyXTo=
+        - '13, 174 As you can see, it displays 3 Poké Balls.:[name=Professor Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3NSBDaGFjdW5lIHJlbmZlcm1lIHVuIFBva8OpbW9uIGFzc2V6IHNww6ljaWFsLjpbbmFtZT1Qcm9mLiBTb3JiaWVyXTo=
+        - '13, 175 Each one contains a special Pokémon.:[name=Professor Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3NiBDaG9pc2lzIGNlbHVpIHF1ZSB0dSBwcsOpZsOocmVzLCBqZSB0ZSBsJ29mZnJlICE6W25hbWU9UHJvZi4gU29yYmllcl06
+        - '13, 176 Chose the one you like best, I''ll give it to you!:[name=Professor
+          Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8015,8 +7926,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3NyBcY1sxOF1VdGlsaXNleiBsZXMgZmzDqGNoZXMgZGlyZWN0aW9ubmVsbGVzIHBvdXIgc8OpbGVjdGlvbm5lciB1bmUgUG9rw6liYWxsLg==
+        - 13, 177 \c[18]Use the direction buttons to select a Poké Ball.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8491,8 +8401,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3OCBUdSB2ZXV4IE1pbmlkcmFjbywgbGUgUG9rw6ltb24gRHJhZ29uID8=
+        - 13, 178 Do you want Dratini, the Dragon Pokémon?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8719,8 +8628,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE3OSBUdSB2ZXV4IEVtYnJ5bGV4LCBsZSBQb2vDqW1vbiBQZWF1cGllcnJlID8=
+        - 13, 179 Do you want Larvitar, the Rock Skin Pokémon?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8947,8 +8855,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE4MCBUdSB2ZXV4IFRhcnNhbCwgbGUgUG9rw6ltb24gU2VudGltZW50ID8=
+        - 13, 180 Do you want Ralts, the Feeling Pokémon?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9536,8 +9443,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE4MSBJbCByZXN0ZSBkZXV4IFBva8OpYmFsbCBsYWlzc8OpZXMgcGFyIGxlIFByb2YuIFNvcmJpZXIu
+        - 13, 181 There are two Poké Balls left by Professor Rowan.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9589,7 +9495,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 182 C'est vide...
+        - 13, 182 It's empty...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9640,7 +9546,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 183 C'est vide...
+        - 13, 183 It's empty...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9969,26 +9875,24 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE4NCA6W25hbWU9UHJvZi4gU29yYmllcl06Qm9uam91ciAhIEplIHZvaXMgcXVlIGxhIG1hY2hpbmUgw6AgY8O0dMOpIGRlIG1vaSB0J2ludHJpZ3Vlcy4uLg==
+        - '13, 184 Hello! I can see you''re intrigued by that machine right there...:[name=Professor
+          Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE4NSA6W25hbWU9UHJvZi4gU29yYmllcl06Q29tbWUgdHUgcGV1eCBsZSB2b2lyLCBlbGxlIGNvbnRpZW50IDMgUG9rw6liYWxscy4=
+        - '13, 185 As you can see, it displays 3 Poké Balls.:[name=Professor Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE4NiA6W25hbWU9UHJvZi4gU29yYmllcl06Q2hhY3VuZSByZW5mZXJtZSB1biBQb2vDqW1vbiBhc3NleiBzcMOpY2lhbC4=
+        - '13, 186 Each one contains a special Pokémon.:[name=Professor Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE4NyA6W25hbWU9UHJvZi4gU29yYmllcl06Q2hvaXNpcyBjZWx1aSBxdWUgdHUgcHLDqWbDqHJlcywgamUgdGUgbCdvZmZyZSAh
+        - '13, 187 Chose the one you like best, I''ll give it to you!:[name=Professor
+          Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10044,8 +9948,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE4OCA6W25hbWU9UHJvZi4gU29yYmllcl06SmUgdCdlbiBwcmllLCBjaG9pc2lzIHVuZSBQb2vDqWJhbGwgcGFybWkgbGVzIHBsYWPDqWVzIGRhbnMgbGEgbWFjaGluZS4=
+        - '13, 188 Please choose a Poké Ball on the machine.:[name=Professor Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10090,32 +9993,33 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE4OSA6W25hbWU9UHJvZi4gU29yYmllcl06Sidlc3DDqHJlIHF1ZSBsZSBQb2vDqW1vbiBxdWUgdHUgYXMgY2hvaXNpIGRldmllbmRyYSB1biB2cmFpIHBhcnRlbmFpcmUu
+        - '13, 189 I hope the Pokémon you chose will become a true partner.:[name=Professor
+          Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5MCA6W25hbWU9UHJvZi4gU29yYmllcl06TGEgbWFjaGluZSBxdWUgdHUgYXMgdXRpbGlzw6llIHV0aWxpc2UgZGUgbm9tYnJldXggc3lzdMOobWVzIHBvdXIgZm9uY3Rpb25uZXIu
+        - '13, 190 The device you used works thanks to numerous systems.:[name=Professor
+          Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5MSA6W25hbWU9UHJvZi4gU29yYmllcl06VG91dCBkJ2Fib3JkLCBsZXMgZGlmZsOpcmVudGVzIGFuaW1hdGlvbnMgc29udCBqb3XDqWVzIGdyw6JjZSDDoCBkZXMgZmljaGllcnMgXGNbNV1naWZcY1swXSwgcXVlIFBva8OpbW9uU0RLIHN1cHBvcnRlLg==
+        - 13, 191 First of all, the animations are played using \c[5]gif\c[0] files,
+          which PokémonSDK supports.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5MiA6W25hbWU9UHJvZi4gU29yYmllcl06RW5zdWl0ZSwgbGEgZ2VzdGlvbiBkZXMgYm91dG9ucyBlc3QgcsOpYWxpc8OpZSBlbiB1dGlsaXNhbnQgdW5lIFxjWzVdbG9vcFxjWzBdIGV0IGRlcyBcY1s1XXZhcmlhYmxlc1xjWzBdLg==
+        - '13, 192 Then, the inputs are managed with a \c[5]loop\c[0] and \c[5]variables\c[0].:[name=Professor
+          Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5MyA6W25hbWU9UHJvZi4gU29yYmllcl06TGUgdG91dCBlc3QgZCdhZmZpY2hlciBsZXMgYm9ubmVzIGltYWdlcyBhdSBib24gbW9tZW50LCBldCBkZSBuZSBwYXMgb3VibGllciBsJ3V0aWxpc2F0aW9uIGRlcyBcY1s1XWxhYmVsc1xjWzBdIHBvdXIgbmF2aWd1ZXIgYXUgc2VpbiBkZSBsJ8OpdsOobmVtZW50Lg==
+        - '13, 193 The key is to display the right pictures at the right time, and
+          don''t forget to use \c[5]labels\c[0] to navigate through your event.:[name=Professor
+          Rowan]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10166,14 +10070,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5NCA6W25hbWU9TMOpb106SidhaSB0cm91dsOpIGNlIFBva8OpbW9uIHJpZ29sbyBkYW5zIGxhIENhdmVybmUgcm9jYWlsbGV1c2Uu
+        - '13, 194 I found this funny Pokémon in the Rocky Cavern.:[name=Bill]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5NSA6W25hbWU9TMOpb106SmUgc3VpcyBwbHV0w7R0IGJyYW5jaMOpIHByb2dyYW1tYXRpb24gcXVlIGNvbWJhdHMgUG9rw6ltb24sIGRvbmMgamUgdmV1eCBiaWVuIHRlIGxlIGRvbm5lci4=
+        - '13, 195 I''m more into programming rather than battling, so I can give
+          it to you.:[name=Bill]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10197,8 +10100,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5NiBcY1sxOF1cTlsxXSBvYnRpZW50IFRpYyBkZSBsYSBwYXJ0IGRlIEzDqW8gISBbV0FJVCAyNDBd
+        - 13, 196 \c[18]\N[1] received \c[27]Klink \c[18]from Bill![WAIT 240]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10214,8 +10116,8 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5NyA6W25hbWU9TMOpb106Q29tbWUgaidhaSB1dGlsaXPDqSBcY1s1XSJzdG9yZV9wb2tlbW9uIlxjWzBdLCBjZSBUaWMgYSDDqXTDqSBzdG9ja8OpIGRpcmVjdGVtZW50IGRhbnMgdG9uIFBDICE=
+        - '13, 197 As I used \c[5]"store_pokemon"\c[0], this Klink was directly stored
+          into your PC!:[name=Bill]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10266,14 +10168,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5OCA6W25hbWU9TMOpb106QWxvcnMsIGNvbW1lbnQgc2UgcG9ydGUgbGUgVGljIHF1ZSBqZSB0J2FpIGRvbm7DqSA/
+        - '13, 198 Tell me, how is Klink doing?:[name=Bill]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDE5OSA6W25hbWU9TMOpb106Q29tbWUgaidhaSB1dGlsaXPDqSBcY1s1XSJzdG9yZV9wb2tlbW9uIlxjWzBdLCBjZSBUaWMgYSDDqXTDqSBzdG9ja8OpIGRpcmVjdGVtZW50IGRhbnMgdG9uIFBDICE=
+        - '13, 199 As I used \c[5]"store_pokemon"\c[0], this Klink was directly stored
+          into your PC!:[name=Bill]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10427,25 +10328,23 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIwMCBMZXMgw6lxdWlwZXMgZHUgTGFib3JhdG9pcmUgbSdvbnQgYXBwZWzDqSBwb3VyIGxlcyBkw6liYXJyYXNzZXIgZGVzIFBva8OpbW9uIEluc2VjdGUgcXVpIHZpZW5uZW50IGdyaWdub3RlciBsZXMgY8OiYmxlcyDDqWxlY3RyaXF1ZXMu
+        - 13, 200 The Laboratory staff called me to get rid of all those Bug Pokémon
+          nibbling the power cables.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIwMSBNYWlzIGplIG5lIHNhaXMgbcOqbWUgcGx1cyBxdW9pIGZhaXJlIGRlIHRvdXMgY2V1eCBxdWUgaidhdHRyYXBlICE=
+        - 13, 201 But I don't even know what to do with all of those I catch!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Je te les donne si tu veux.
+        - I can give them to you if you want.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIwMiDDh2EgdGUgZGl0IHVuIFBva8OpbW9uIEluc2VjdGUgZ3JhdG9zID8=
+        - 13, 202 Would you like a free Bug Pokémon?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10482,7 +10381,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 203 \c[18]\N[1] obtient Chenipan ! [WAIT 240]
+        - 13, 203 \c[18]\N[1] received \c[27]Caterpie\c[18]![WAIT 240]
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10509,20 +10408,19 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIwNCBKJ2FpIHV0aWxpc8OpIGxhIGNvbW1hbmRlIFxjWzVdImFkZF9wb2tlbW9uIlxjWzBdLCBxdWkgYWpvdXRlIHNpbXBsZW1lbnQgdW4gUG9rw6ltb24gw6AgdG9uIMOpcXVpcGUsIHNhbnMgdGUgcHJvcG9zZXIgZGUgbGUgcmVub21tZXIu
+        - 13, 204 I used the command \c[5]"add_pokemon"\c[0], which simply adds a
+          Pokémon to your party, without asking you if you want to rename it.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIwNSBNYWlzIGplIGNyb2lzIHF1J2lsIHkgYSB1biBwYXB5IHF1aSBwZXV0IHJlbm9tbWVyIHRlcyBQb2vDqW1vbiBhdSBtaWxpZXUgZGUgY2V0dGUgcGnDqGNlLg==
+        - 13, 205 But I think there's an old man who can rename your Pokémon in the
+          middle of this room.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIwNiBOJ2jDqXNpdGUgcGFzIMOgIHZlbmlyIG1lIHJlcGFybGVyIHNpIHR1IGVuIHZldXggZCdhdXRyZXMsIGonZW4gYWkgdW4gc2FjcsOpIG5vbWJyZS4=
+        - 13, 206 Come ask me if you want some more, I have quite a few of them.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10537,7 +10435,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 207 Vraiment ? Je ne sais franchement plus quoi en faire...
+        - 13, 207 Oh, really? I honestly don't know what to do with them anymore...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10596,20 +10494,20 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 208 :[name=Prof. Chen]:Bonjour et bienvenue.[WAIT 10].[WAIT 10].[WAIT
-          10]
+        - '13, 208 Hello and welcome.[WAIT 10].[WAIT 10].[WAIT 10]:[name=Professor
+          Oak]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIwOSA6W25hbWU9UHJvZi4gQ2hlbl06UGFyZG9uLCBqJ2FpIGwnaGFiaXR1ZGUgZGUgbWUgcHLDqXNlbnRlciBkZSBsYSBtYW5pw6hyZSBhdXggbm91dmVhdXggRHJlc3NldXJzLi4u
+        - '13, 209 Sorry, I''m used to introduce myself this way to new Trainers...:[name=Professor
+          Oak]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIxMCA6W25hbWU9UHJvZi4gQ2hlbl06w4dhIHQnaW50w6lyZXNzZXJhaXQgcXVlIGplIHRlIHJlZmFzc2UgbW9uIGludHJvZHVjdGlvbiBlbiBlbnRpZXIgPw==
+        - '13, 210 Would like me to show you my introduction from the beginning?:[name=Professor
+          Oak]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10627,7 +10525,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 211 :[name=Prof. Chen]:Dans ce cas...
+        - '13, 211 Well then...:[name=Professor Oak]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10673,8 +10571,8 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIxMiA6W25hbWU9UHJvZi4gQ2hlbl06SmUgY29tcHJlbmRzLi4uIE4naMOpc2l0ZSBwYXMgw6AgdmVuaXIgbWUgdm9pciBzaSB0dSB2ZXV4IHRlIHJlbcOpbW9yZXIgdGVzIGTDqWJ1dHMgZW4gdGFudCBxdWUgRHJlc3NldXIu
+        - '13, 212 I understand... Please come see me if you want to relive your first
+          steps as a Trainer.:[name=Professor Oak]:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -10826,25 +10724,23 @@ events:
         code: 235
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIxMyBCaWVudmVudWUgZGFucyBsZSBtb25kZSBkZXMgUG9rw6ltb24gIQ==
+        - 13, 213 Welcome to the world of Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 214 Mon nom est Chen.
+        - 13, 214 My name is Oak.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIxNSBNYWlzIHRvdXQgbGUgbW9uZGUgbSdhcHBlbGxlIGxlIFByb2Zlc3NldXIgUG9rw6ltb24u
+        - 13, 215 But everyone calls me the Pokémon Professor.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIxNiBDZSBtb25kZS5bV0FJVCAxMF0uW1dBSVQgMTBdLltXQUlUIDMwXSBlc3QgcGV1cGzDqSBkZSBjcsOpYXR1cmVzIGFwcGVsw6llcyBQb2vDqW1vbi4=
+        - 13, 216 This world.[WAIT 10].[WAIT 10].[WAIT 30] is widely inhabited by
+          creatures known as Pokémon.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -11049,30 +10945,28 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIxNyBOb3VzLCBsZXMgaHVtYWlucywgdml2b25zIGF2ZWMgbGVzIFBva8OpbW9uLg==
+        - 13, 217 We humans live alongside Pokémon as friends.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 218 Il nous arrive de jouer ou de travailler ensemble.
+        - 13, 218 At times we play together, and at other times we work together.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIxOSBDZXJ0YWluZXMgcGVyc29ubmVzIHV0aWxpc2VudCBsZXMgUG9rw6ltb24gcG91ciBjb21iYXR0cmUgZXQgY3LDqWVudCB1biBsaWVuIHRyw6hzIGZvcnQgYXZlYyBldXgu
+        - 13, 219 Some people use their Pokémon to battle and develop closer bonds
+          with them.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 220 Moi ?
+        - 13, 220 Myself…
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIyMSBKZSBtZSBjb250ZW50ZSBkZSBmYWlyZSBkZXMgcmVjaGVyY2hlcywgcG91ciBxdWUgbm91cyBlbiBzYWNoaW9ucyBwbHVzIHN1ciBsZXMgUG9rw6ltb24u
+        - 13, 221 I study Pokémon as a profession.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -11096,23 +10990,22 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 222 Mais avant tout, parle-moi un peu de toi.
+        - 13, 222 Now, why don't you tell me a little bit about yourself?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIyMyBFcy10dSB1biBnYXLDp29uID8=
+        - 13, 223 Are you a boy?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Ou bien une fille ?
+        - Or are you a girl?
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Dis-moi tout...
+        - Won't you please tell me?
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -11694,7 +11587,7 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 224 C'est l'apparence qui te convient le mieux ?
+        - 13, 224 Is it the look that suits you best?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -11809,7 +11702,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 225 C'est l'apparence qui te convient le mieux ?
+        - 13, 225 Is it the look that suits you best?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -11950,14 +11843,14 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIyNiBNZXJ2ZWlsbGV1eCAhIFR1IGFzIGTDqWrDoCBkw6lmaW5pIHRvbiBhcHBhcmVuY2UgYXUgZMOpYnV0IGRlIGNldHRlIGTDqW1vLCBkb25jIGplIG5lIHZhaXMgcGFzIGxhIGNoYW5nZXIu
+        - 13, 226 Wonderful! Now, you already set your look at the beginning of this
+          demo, so I won't change it.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIyNyBUdSBwZXV4IGTDqWZpbmlyIGxlIGdlbnJlIGRlIHRvbiBwZXJzb25uYWdlIGF2ZWMgbGEgY29tbWFuZGUgXGNbNV0iJHRyYWluZXIuZGVmaW5lX2dlbmRlcihOKSJcY1swXS4=
+        - 13, 227 You can define the gender of your main player with \c[5]"$trainer.define_gender(N)"\c[0].\nReplace
+          "N" with "true" for a girl, and "false" for a boy.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -11968,26 +11861,27 @@ events:
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIyOCBKZSBuZSB0ZSBkZW1hbmRlcmFpIHBhcyB0b24gcHLDqW5vbSBub24gcGx1cywgbWFpcyBpbCBzdWZmaXQgZCd1dGlsaXNlciBsYSBjb21tYW5kZSBcY1s1XSJOYW1lIElucHV0IFByb2Nlc3NpbmciXGNbMF0gcG91ciBsZSBkw6lmaW5pci4=
+        - 13, 228 I won't ask your name either, but you just have to use the \c[5]"Name
+          Input Processing"\c[0] command to define it.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIyOSBMYSBjb21tYW5kZSBcY1s1XSIkdHJhaW5lci5uYW1lID0gJy4uLiciXGNbMF0gdGUgcGVybWV0IMOpZ2FsZW1lbnQgZGUgZMOpZmluaXIgbWFudWVsbGVtZW50IGxlIG5vbSBkdSBqb3VldXIu
+        - 13, 229 You can also use the \c[5]"$trainer.name = '...'"\c[0] command to
+          manually set your player's name.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIzMCBUb3V0ZXMgY2VzIGNvbW1hbmRlcyBzb250IGTDqWNyaXRlcyBkYW5zIGwnw6l2w6huZW1lbnQgZGUgZMOpcGFydCBkZSBsYSBkw6ltbywgc3VyIGxhIG1hcCBcY1s1XVN0YXJ0XGNbMF0u
+        - 13, 230 All these commands are described inside the first event of the demo,
+          on the map \c[5]Start\c[0].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIzMSBDb21tZSBjZXR0ZSBpbnRybyBlc3QgZ8OpbsOpcmFsZW1lbnQgbGUgcHJlbWllciDDqXbDqG5lbWVudCBkJ3VuIGpldSwgYydlc3QgZG9uYyB1bmUgYm9ubmUgb2NjYXNpb24gZCdpbml0aWFsaXNlciBjZXJ0YWluZXMgbcOpY2FuaXF1ZXMgOiBsZSBzeXN0w6htZQ==
+        - '13, 231 And as this introduction usually is the first event of a game,
+          it is a good place to initialize some features: day/night system, berries,
+          shadows under the events...'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -11998,19 +11892,17 @@ events:
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIzMiBNYWlzIHRyw6p2ZSBkZSBiYXZhcmRhZ2VzICEgRmluaXNzb25zLWVuIGzDoC4=
+        - 13, 232 Enough of this chatter! Let's end it there.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTMsIDIzMyBOJ2jDqXNpdGUgcGFzIMOgIG1lIHJlcGFybGVyIHNpIHR1IHZldXggcmV2b2lyIGNldHRlIHPDqXF1ZW5jZS4=
+        - 13, 233 Don't hesitate to talk to me if you want to see this sequence again.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 13, 234 En attendant, bonne chance pour ton aventure, jeune Maker !
+        - 13, 234 In the meantime, good luck with your adventure, young Maker!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map014.rxdata.yml
+++ b/Data/Map014.rxdata.yml
@@ -342,8 +342,8 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDAgTm90ZSA6IGlsIGVzdCBwb3NzaWJsZSBkJ2FmZmljaGVyIGxhIGZlbsOqdHJlIGRlIG1lc3NhZ2UgYWlsbGV1cnMgc3VyIGwnw6ljcmFuIChoYXV0LCBtaWxpZXUsIGJhcywgZ2F1Y2hlLCBkcm9pdGUsIGNvb3Jkb25uw6llcyBwZXJzb25uYWxpc8OpZXMuLi4pIGF2ZWMgbGEgY29tbWFuZGU=
+        - '14, 0 Note: you can display messages on other parts of the screen (top,
+          middle, bottom, left, right, custom coordinates...) with "\c[5]position_overwrite\c[0]".'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -399,8 +399,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDEgQmllbnZlbnVlIGRhbnMgbGEgQmlibGlvdGjDqHF1ZSBkZSBsYSBUb3VyICE=
+        - 14, 1 Welcome to the Tower's Library!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -420,7 +419,7 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '14, 2 :[lookto=9]:Sur votre gauche : des livres...'
+        - '14, 2 :[lookto=9]:On your left: books...'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -430,13 +429,13 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 3 :[lookto=8]:Et sur votre droite aussi !
+        - 14, 3 :[lookto=8]:And on your right too!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDQgOltsb29rdG89MTFdOkdyw6JjZSDDoCBsYSBjb21tYW5kZSBcY1s1XVtsb29rdG9dIFxjWzBdamUgcGV1eCB2b3VzIGZhaXJlIHJlZ2FyZGVyIHZlcnMgbidpbXBvcnRlIHF1ZWwgw6l2w6huZW1lbnQgIQ==
+        - 14, 4 :[lookto=11]:Thanks to \c[5]"[lookto=N]"\c[0], I can make you look
+          towards any event!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -497,19 +496,18 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDUgQm9uam91ciBcblsxXSwgc295ZXogXGZbbGHCp2xlXSBiaWVudmVudVxFIMOgIGxhIEJpYmxpb3Row6hxdWUgZGUgbGEgVG91ciAh
+        - 14, 5 Hello \N[1]! You're the \f[heroine§hero] of this demo!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 6 J'affiche votre nom en utilisant \c[5]\\n[1]\c[0] dans mon message.
+        - 14, 6 I can display your name by putting \c[5]"\\n[1]"\c[0] in my message.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDcgRCdhaWxsZXVycywgamUgbSdhZGFwdGUgw6Agdm90cmUgZ2VucmUgYXZlYyBcY1s1XVxcRVxjWzBdIHBvdXIgYWpvdXRlciB1biAiRSIgw6AgbGEgZmluIGQndW4gbW90LCBldCBhdmVjIFxjWzVdXFxmW0bCp01dXGNbMF0gcG91ciBhZmZpY2hlciBkZXV4IG1vdHMgZGlmZsOpcmVudHMgZW4gZm9uY3Rpb24g
+        - 14, 7 By the way, I can adapt to your gender with \c[5]"\\f[F§M]"\c[0] to
+          display two different words depending on the appearance you chose.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -535,14 +533,12 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDggSmUgY29ubmFpcyBhdXNzaSBsZXMgbm9tcyBkZSB2b3MgUG9rw6ltb24gIQ==
+        - 14, 8 I know the names of your Pokémon as well!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDkgUGFyIGV4ZW1wbGUsIGVuIHByZW1pw6hyZSBwbGFjZSBkZSB2b3RyZSDDiXF1aXBlLCB2b3VzIGF2ZXogXHBbMV0u
+        - 14, 9 For instance, the first Pokémon of your Party is \c[27]\p[1]\c[0].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -612,19 +608,19 @@ events:
         code: 122
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 10 Bonjour ! Je vois que vous avez \v[26]$.
+        - 14, 10 Hello! I can see you currently have \v[26]$.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDExIEplIGxlIHNhaXMgZ3LDomNlIMOgIGxhIGZvbmN0aW9uIFxjWzVdXFx2Wy4uLl1cY1swXSwgcXVpIHBlcm1ldCBkJ2FmZmljaGVyIHVuZSB2YXJpYWJsZSBhdSBzZWluIGQndW4gbWVzc2FnZS4=
+        - 14, 11 I know it thanks to the \c[5]"\\v[...]"\c[0] command, that displays
+          a variable inside a message.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDEyIEVuIGwnb2NjdXJyZW5jZSwgaidhaSByZW5kdSBsYSB2YXJpYWJsZSB0ZW1wb3JhaXJlIDI2IMOpZ2FsZSDDoCBsYSBzb21tZSBkJ2FyZ2VudCBxdWUgdm91cyBwb3Nzw6lkZXou
+        - 14, 12 In this case, I made the temporary variable 26 equal to the money
+          you have.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -644,14 +640,14 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDEzIFxnTWFpcyBqZSBwZXV4IGF1c3NpIGFmZmljaGVyIHZvdHJlIGFyZ2VudCBkYW5zIHVuZSBmZW7DqnRyZSBzw6lwYXLDqWUsIGNvbW1lIGljaSwgZW4gw6ljcml2YW50IFxjWzVdIlxcZyIgXGNbMF1uJ2ltcG9ydGUgb8O5IGRhbnMgbW9uIG1lc3NhZ2Uu
+        - 14, 13 \gBut I can also display it on a separate window, like that, by writing
+          \c[5]"\\g"\c[0] anywhere in my message.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDE0IEVuZmluLCB0b3V0IMOnYSBlc3QgYmllbiBpbnV0aWxlIGljaSBwdWlzcXVlIGxlcyBsaXZyZXMgc29udCBlbXBydW50YWJsZXMgZ3JhdHVpdGVtZW50ICE=
+        - 14, 14 Well, this is completely useless here because you can rent all the
+          books for free!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -746,50 +742,46 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 15 Je cherche un livre sur la \c[2]c\c[6]o\c[3]u\c[4]l\c[1]e\c[5]u\c[7]r\c[0].
-          C'est fou tout ce qu'on peut faire avec la fonction \c[5]"\\c[...]" \c[0]!
+        - 14, 15 I'm looking for a book about \c[2]r\c[6]a\c[3]i\c[4]n\c[1]b\c[5]o\c[7]w\c[0]s.
+          Crazy what you can do with \c[5]"\\c[...]"\c[0]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDE2IFR1IHBldXggY29sb3JlciB0b3VzIHRlcyB0ZXh0ZXMgdHLDqHMgbGlicmVtZW50Lg==
+        - 14, 16 You can color your text in many ways.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDE3IEMnZXN0IGxlIGZpY2hpZXIgXGNbNV0iX2NvbG9ycy5wbmciXGNbMF0gcXVpIHNlIHRyb3V2ZSBkYW5zIGxlIGRvc3NpZXIgV2luZG93c2tpbnMgcXVpIGfDqHJlIHRvdXQgw6dhLg==
+        - 14, 17 Everything is managed in the \c[5]"_colors.png"\c[0] file located
+          in the Windowskins folder.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDE4IExhIHByZW1pw6hyZSBsaWduZSBjb3JyZXNwb25kIMOgIGxhIGNvdWxldXIgZGVzIGNvbnRvdXJzLg==
+        - 14, 18 The first line is for the colors of outlines (not very functional...).
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDE5IExhIGxpZ25lIGR1IG1pbGlldSBjb3JyZXNwb25kIMOgIGxhIGNvdWxldXIgZHUgdGV4dGUu
+        - 14, 19 The middle line is for the colors of the text.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDIwIEV0IGxhIHRyb2lzacOobWUgbGlnbmUgY29ycmVzcG9uZCDDoCBsYSBjb3VsZXVyIGRlIGwnb21icmUgIQ==
+        - 14, 20 And the third line is for the colors of the shadows!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDIxIFxjWzI1XVNpIGonw6ljcmlzICJcXGNbMjVdIiBkYW5zIG1vbiB0ZXh0ZSwgw6dhIHZhIGRvbmMgcHJlbmRyZSBsZXMgY291bGV1cnMgZGUgbGEgMjZlIGNvbG9ubmUgKHBhcmNlIHF1J29uIGNvbW1lbmNlIMOgIGNvbXB0ZXIgw6AgcGFydGlyIGRlIDApLg==
+        - 14, 21 \c[25]If I write "\\c[25]" in my text, it will take the colors of
+          the 26th column (we're starting at 0).
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDIyIEV0IHR1IHBldXggcmFqb3V0ZXIgYXV0YW50IGRlIGNvbG9ubmVzIMOgIHRvbiBmaWNoaWVyIFxjWzVdIl9jb2xvcnMucG5nIlxjWzBdIHF1ZSB0dSB2ZXV4IHRhbnQgcXVlIHR1IHJlc3BlY3RlcyBsZSBmb3JtYXQu
+        - 14, 22 You can add as many columns as you want in your \c[5]"_colors.png"\c[0]
+          file as long as you respect the format.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -865,26 +857,23 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 23 Tiens, ton sac contient une Poche \img[pocket-keys,picture]Objets
-          Rares !
+        - 14, 23 Oh, your Bag has a \img[pocket-keys,picture]Key Items Pocket!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDI0ICBcaW1nWzcxMyxpY29uXSBFbGxlIGVzdCB0csOocyBwcmF0aXF1ZSBwb3VyIHJhbmdlciB1bmU=
+        - 14, 24  \img[713,icon]It is perfect to store a
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          wqDCoMKgwqDCoMKgwqDCoMKgwqDCoMKgwqBCaWN5bGV0dGUsIHBhciBleGVtcGxlLg==
+        - "             Bike, for instance."
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDI1IFR1IGFzIHZ1LCBncsOiY2Ugw6AgXGNbNV1cXGltZ1suLi5dXGNbMF0sIGplIHBldXggYWZmaWNoZXIgZGVzIGltYWdlcyBkYW5zIG1lcyBtZXNzYWdlcywgZXQgZWxsZXMgcGV1dmVudCBwcm92ZW5pciBkZSBkaWZmw6lyZW50cyBzb3VzLWRvc3NpZXJzICE=
+        - 14, 25 Did you see it? Thanks to \c[5]"\\img[...]"\c[0], I can display pictures
+          in a message, and they even can come from subfolders!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -953,14 +942,14 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDI2IDpbbmFtZT1QaWVycmUgUm9jaGFyZDtmYWNlPTE2MCxzdGV2ZW5fc21hXTpDb21tZSBqZSBzdWlzIHVuZSB2cmFpZSBjw6lsw6licml0w6ksIGonYWkgbGUgZHJvaXQgw6AgdW4gYWZmaWNoYWdlIGRlIG1vbiBub20gZXQgZGUgbW9uIHBvcnRyYWl0ICE=
+        - 14, 26 :[name=Steven Stone;face=160,steven_sma]:Since I'm a real celebrity,
+          my messages display my name and my portrait!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDI3IDpbbmFtZT1QaWVycmUgUm9jaGFyZDtmYWNlPTE2MCxzdGV2ZW5fc21hXTpQb3VyIMOnYSwgaid1dGlsaXNlIFxjWzVdW25hbWU9Li4uXSBcY1swXWV0IFxjWzVdW2ZhY2VdIFxjWzBdIGRhbnMgbW9uIG1lc3NhZ2Uu
+        - 14, 27 :[name=Steven Stone;face=160,steven_sma]:To do that, I use \c[5]"[name=...]"\c[0]
+          and \c[5]"[face]"\c[0] in my message.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -976,8 +965,8 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDI4IDpbbmFtZT1QaWVycmUgUm9jaGFyZMKgO2ZhY2U9MTYwLHN0ZXZlbl9zbWFdOkQnYWlsbGV1cnMsIHBvdXIgZW5jb3JlIHBsdXMgZGUgY2xhc3NlLCBqZSBwZXV4IG3Dqm1lIGF2b2lyIHVuIHdpbmRvd3NraW4gZGlmZsOpcmVudCBwb3VyIG1vbiBub20u
+        - 14, 28 :[name=Steven Stone ;face=160,steven_sma]:By the way, to be even
+          more classy, I can even have a different windowskin for my name.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1028,8 +1017,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDI5IEonYWkgdHJvdXbDqSB1bmUgc3VwZXIgZm9uY3Rpb24gcG91ciBhZmZpY2hlciB1biBwbGFuIGRlIGwnZW5kcm9pdCBvw7kgb24gc2UgdHJvdXZlIGF1IHNlaW4gbcOqbWUgZCd1biBtZXNzYWdlwqAhIFJlZ2FyZGUuLi4=
+        - 14, 29 I found a great command to display the map of the location you're
+          in within a message! Take a look...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1074,26 +1063,23 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDMwIDpbY2l0eT1jaXR5L2xpYnJhcnldOlxjWzE4XUJpYmxpb3Row6hxdWU=
+        - 14, 30 :[city=city/library]:\c[18]Library
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          T8O5IGxlcyBsaXZyZXMgdm91cyBhcHByZW5uZW50IMOgIGxlcyDDqWNyaXJlLg==
+        - Where books teach you how to write them.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDMxIEMnZXN0IGdyw6JjZSDDoCBcY1s1XVtjaXR5PV0gXGNbMF1xdWUgamUgcGV1eCBhZmZpY2hlciBjZSBnZW5yZSBkJ2ltYWdlLCBjb3VwbMOpIGF2ZWMgdW4gY2hhbmdlbWVudCBkZSB3aW5kb3dza2luLg==
+        - 14, 31 It's thanks to \c[5]"[city=]"\c[0] that I can display this kind of
+          message, coupled with a change of windowskin.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDMyIEJvbiwgcG91ciBsYSBiaWJsaW90aMOocXVlLCBjZSBuJ2VzdCBwYXMgdHLDqHMgdXRpbGUuLi4=
+        - 14, 32 Well, it's not very useful for the library...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1174,8 +1160,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDMzIFxjWzE4XVF1aXogZGUgY3VsdHVyZSBnw6luw6lyYWxlLiBSw6ljb21wZW5zZSDDoCBsYSBjbMOpICE=
+        - 14, 33 \c[18]General knowledge test.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1230,19 +1215,18 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          Y2hvaWNlKDI2LCAtMSwgIlxcY1sxOF0wIiwgIlxcY1sxOF02IiwgIlxcY1sxOF0xMCIsICJcXGNbMThdMTUiLCAiMTQsIDExNyBcY1sxOF1BdXRhbnQgcXUnaWwgeSBlbiBhIGRlIGTDqWZpbmllcyIp
+        - choice(26, -1, "\\c[18]0", "\\c[18]6", "\\c[18]10", "\\c[18]15", "14, 117
+          \c[18]As many as defined")
         indent: 1
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '14, 34 \c[18]Question 1 :'
+        - '14, 34 \c[18]Question 1:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          Q29tYmllbiBkZSBjb3VsZXVycyBwZXV2ZW50IMOqdHJlIHV0aWxpc8OpZXMgcG91ciBjb2xvcmVyIHVuIHRleHRlID8=
+        - How many colors can you use to color a text?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1302,13 +1286,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDM1IFxjWzE4XUJvbm5lIHLDqXBvbnNlICFbV0FJVCA0MF0=
+        - 14, 35 \c[18]Correct![WAIT 40]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Question suivante.
+        - Next question.
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1321,24 +1304,23 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          Y2hvaWNlKDI2LCAtMSwgIjE0LCAxMTggXFxjWzE4XVBpZXJyZSBkJ0FyZ2VudGEiLCAiMTQsIDExOSBcXGNbMThdTGUgUHIuIFPDqWtvIiwgIjE0LCAxMjAgXFxjWzE4XUZhcmdhcyIsICIxNCwgMTIxIFxcY1sxOF1HdXptYSIs
+        - choice(26, -1, "14, 118 \c[18]Brock from Pewter City", "14, 119 \c[18]Pr.
+          Birch", "14, 120 \c[18]Kurt", "14, 121 \c[18]Guzma",
         indent: 1
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"14, 122 \\c[18]Pierre Rochard")'
+        - '"14, 122 \c[18]Steven Stone")'
         indent: 1
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '14, 36 \c[18]Question 2 :'
+        - '14, 36 \c[18]Question 2:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          UXVlbGxlIGPDqWzDqWJyaXTDqSBzZSB0cm91dmUgw6AgbGEgYmlibGlvdGjDqHF1ZSA/
+        - What celebrity can you find at the Library at the moment?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1373,13 +1355,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDM3IFxjWzE4XUJvbm5lIHLDqXBvbnNlICFbV0FJVCA0MF0=
+        - 14, 37 \c[18]Correct![WAIT 40]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Question suivante.
+        - Next question.
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1392,19 +1373,18 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - choice(26, -1, "14, 123 \\c[18]Goinfrex", "14, 124 \\c[18]Akwakwak", "14,
-          125\\c[18]Amagara", "14, 126\\c[18]Snubull", "14, 127 \\c[18]Miasmax")
+        - choice(26, -1, "14, 123 \c[18]Golduck", "14, 124 \c[18]Munchlax", "14, 125\\c[18]Amagara",
+          "14, 126\\c[18]Snubull", "14, 127 \c[18]Garbodor")
         indent: 1
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '14, 38 \c[18]Question 3 :'
+        - '14, 38 \c[18]Question 3:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          UXVlbCBQb2vDqW1vbiBlc3QgY2l0w6kgZGFucyB1bmUgcGhyYXNlIGRlIHZpcmVsYW5ndWUgPw==
+        - Which Pokémon is mentioned in a tongue twister sentence?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1439,13 +1419,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDM5IFxjWzE4XUJvbm5lIHLDqXBvbnNlICFbV0FJVCA0MF0=
+        - 14, 39 \c[18]Correct![WAIT 40]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Question suivante.
+        - Next question.
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1458,25 +1437,23 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 'choice(26, -1, "14, 128 \\c[18]Un Badge", "14, 129 \\c[18]Une Masalada",
-          "14, 130 \\c[18]Un Jus de Baie", "14, 131 \\c[18]Une Pierre Insolite", '
+        - 'choice(26, -1, "14, 128 \c[18]A Badge", "14, 129 \c[18]A Masalada", "14,
+          130 \c[18]A Berry Juice", "14, 131 \c[18]An Intriguing Stone", '
         indent: 1
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"14, 132 \\c[18]Une Queuramoloss")'
+        - '"14, 132 \c[18]A SlowpokeTail")'
         indent: 1
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDQwIFxjWzE4XURlcm5pw6hyZSBxdWVzdGlvbiA6
+        - '14, 40 \c[18]Last question:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          UXVlbCBvYmpldCBkb2l0LW9uIHRyb3V2ZXIgZGFucyBjaGFxdWUgbGlldSBkZSBjZXR0ZSBkw6ltbyA/
+        - What item must you find in each place of this Island?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1511,19 +1488,17 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDQxIFxjWzE4XUJvbm5lIHLDqXBvbnNlICFbV0FJVCA0MF0=
+        - 14, 41 \c[18]Correct![WAIT 40]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDQyIFxjWzE4XVZvdXMgYXZleiByw6lwb25kdSBjb3JyZWN0ZW1lbnQgw6AgdG91dGVzIGxlcyBxdWVzdGlvbnMsIGbDqWxpY2l0YXRpb25zICE=
+        - 14, 42 \c[18]You answered all the questions right, congratulations!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 'Voici votre prix :'
+        - 'Here is your prize:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1570,8 +1545,7 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDQzIFxjWzE4XU1hdXZhaXNlIHLDqXBvbnNlICEgUsOpZXNzYXllei5bV0FJVCA0MF0=
+        - 14, 43 \c[18]Wrong! Try again.[WAIT 40]
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1644,20 +1618,20 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDQ0IFxjWzE4XVZvdXMgYXZleiBkw6lqw6AgcsOpcG9uZHUgYXUgcXVpei4gTWFpcyB2b2ljaSB1biByYXBwZWwgOiBcY1sxNV0iY2hvaWNlKFgsIFksICIxIiwgIjIiLi4uKSIgXGNbMThdcGVybWV0IGQnYWZmaWNoZXIgdW4gY2hvaXggYXZlYyBwbHVzIGRlIHF1YXRyZSBvcHRpb25zLg==
+        - '14, 44 \c[18]You already answered the quiz. Here''s a reminder: \c[15]"choice(X,
+          Y, "1", "2"...)"\c[18] displays a choice with more than four options.'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          WCBlc3QgbGUgbnVtw6lybyBkZSBsYSB2YXJpYWJsZSBxdWkgc2VyYSB1dGlsaXPDqWUgcGFyIGxhIGNvbW1hbmRlIDsgWSBlc3QgbGUgbm9tYnJlIGQnb3B0aW9ucyA7IGxlcyBjaGlmZnJlcyBlbnRyZSBndWlsbGVtZXRzIHNvbnQgbGVzIG9wdGlvbnMgcXVpIHNlcm9udCBhZmZpY2jDqWVzLg==
+        - X is the number of the variable used by the command ; Y is the number of
+          options ; the numbers in quotation marks are the different options.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          UHVpcywgcG91ciBjaGFxdWUgb3B0aW9uLCBpbCBjb252aWVudCBkZSBjcsOpZXIgdW5lIGJyYW5jaGUgY29uZGl0aW9ubmVsbGUgcXVpIHbDqXJpZmllcmEgbGEgdmFsZXVyIGRlIGxhIHZhcmlhYmxlIGNob2lzaWUgOiAxID0gb3B0aW9uIDEsIGV0IGFpbnNpIGRlIHN1aXRlLg==
+        - 'Then for each option, you must create a conditional branch checking the
+          value of the chosen variable : 1 = option 1, and so on.'
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1723,8 +1697,8 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDQ1IFR1IHNhdmFpcyBxdSdvbiBwZXV0IGFmZmljaGVyIGxhIGZlbsOqdHJlIGRlIGNob2l4IGFpbGxldXJzIHF1J2VuIGJhcyDDoCBkcm9pdGUgPw==
+        - 14, 45 Did you know you can display the choice window somewhere else than
+          on the bottom right?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1742,7 +1716,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 46 Ah, moi qui pensais t'apprendre quelque chose...
+        - 14, 46 Oh... I thought I could teach you something.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1769,8 +1743,7 @@ events:
         code: 121
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDQ3IFBvdXIgw6dhLCBpbCBmYXV0IFxjWzVdYWN0aXZlciBsJ2ludGVycnVwdGV1ciAyNlxjWzBdLiBDZXR0ZSBpbmZvcm1hdGlvbiB0J2Egw6l0w6kgdXRpbGUgPw==
+        - 14, 47 To do that, you need to \c[5]trigger switch number 26\c[0].
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1788,7 +1761,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 48 Ravi que ce soit le cas !
+        - 14, 48 Glad I could help!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1810,8 +1783,8 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDQ5IENvbW1lbnQgw6dhID8gU2kgdHUgbmUgbGUgc2F2YWlzIHBhcyBldCBxdWUgbWFpbnRlbmFudCB0dSBsZSBzYWlzLCBjJ2VzdCBxdWUgw6dhIHQnYSDDqXTDqSB1dGlsZSwgbm9uID8=
+        - 14, 49 What? If you didn't know and now you do, it must have been useful,
+          right?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1831,32 +1804,32 @@ events:
         code: 404
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDUwIFBhciBhaWxsZXVycywgdHUgcGV1eCB0b3V0IMOgIGZhaXQgaW5zw6lyZXIgZGVzIGNvdWxldXJzIGRhbnMgdGVzIGNob2l4LCBjb21tZSBkYW5zIG4naW1wb3J0ZSBxdWVsIG1lc3NhZ2UsIGF2ZWMgXGNbNV1cXGNbLi4uXVxjWzBdLg==
+        - 14, 50 By the way, you can insert colors within your choices, like in any
+          other message, with \c[5]"\\c[...]"\c[0].
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDUxIEplIGNyb2lzIHF1ZSBsZSBwZXRpdCBwZXJjaMOpIHN1ciB1biBlc2NhYmVhdSBqdXN0ZSBhdS1kZXNzdXMgZGUgbm91cyBlbiBzYWl0IHBhcyBtYWwgw6AgY2Ugc3VqZXQu
+        - 14, 51 I think the kid perched on a stepladder right above us knows quite
+          a lot on the matter.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Saisissant, n'est-ce pas ?
+        - Fascinating, right?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 14, 52 \c[1]Fantastique !
-          - 14, 53 \c[2]Époustouflant !
+        - - 14, 52 \c[1]Fantastic!
+          - 14, 53 \c[2]Mind-blowing!
         - 0
         indent: 1
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - "\\c[1]Fantastique !"
+        - 14, 52 \c[1]Fantastic!
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -1871,8 +1844,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          XGNbMl3DiXBvdXN0b3VmbGFudCAh
+        - 14, 53 \c[2]Mind-blowing!
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2347,19 +2319,19 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 54 Appuyez sur \k[X] pour ouvrir le menu.
+        - 14, 54 Press \k[X] to open the menu.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDU1IENlIG1lc3NhZ2UgdXRpbGlzZSBcY1s1XVxca1suLi5dIFxjWzBdcG91ciBhZmZpY2hlciB1bmUgdG91Y2hlIGRlIG1hbmnDqHJlIGR5bmFtaXF1ZS4=
+        - 14, 55 This message uses \c[5]"\\k[...]"\c[0] to display a key in a dynamic
+          way.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          QWluc2ksIGxhIGJvbm5lIHRvdWNoZSBzZXJhIHRvdWpvdXJzIGFmZmljaMOpZSwgbcOqbWUgc2kgbGUgam91ZXVyIGEgY2hhbmfDqSBsJ2F0dHJpYnV0aW9uIGRlIHNlcyB0b3VjaGVzIG91IHF1J2lsIHV0aWxpc2UgdW5lIG1hbmV0dGUu
+        - Doing so, the correct key will always be displayed, even if the player changed
+          their inputs or is using a controler.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2410,7 +2382,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 56 C'est vide...
+        - 14, 56 It's empty...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2468,8 +2440,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDU3IExlcyDDqXRhZ8OocmVzIHNvbnQgcmVtcGxpZXMgZGUgbGl2cmVzIHN1ciBsZXMgUG9rw6ltb24u
+        - 14, 57 The shelves are filled with books about Pokémon.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2535,8 +2506,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDU4IExlcyDDqXRhZ8OocmVzIHNvbnQgcmVtcGxpZXMgZGUgbGl2cmVzIHN1ciBsZXMgUG9rw6ltb24u
+        - 14, 58 The shelves are filled with books about Pokémon.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2595,8 +2565,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDU5IExlcyDDqXRhZ8OocmVzIHNvbnQgcmVtcGxpZXMgZGUgbGl2cmVzIHN1ciBsZXMgUG9rw6ltb24u
+        - 14, 59 The shelves are filled with books about Pokémon.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2654,8 +2623,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDYwIExlcyDDqXRhZ8OocmVzIHNvbnQgcmVtcGxpZXMgZGUgbGl2cmVzIHN1ciBsZXMgUG9rw6ltb24u
+        - 14, 60 The shelves are filled with books about Pokémon.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2714,8 +2682,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDYxIEMnZXN0IGxhIGRvY3VtZW50YXRpb24gZGUgUG9rw6ltb24gU0RLICE=
+        - 14, 61 It's PokémonSDK's documentation!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2773,7 +2740,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 62 Il y a des tonnes de livres sur le langage Ruby.
+        - 14, 62 There are tons of books about the Ruby language.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2832,7 +2799,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 63 C'est une collection de livres sur le design graphique.
+        - 14, 63 It's a book collection about graphic design.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2883,7 +2850,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 64 C'est un recueil de virelangues.
+        - 14, 64 It's a repository on tongue twisters.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3156,7 +3123,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 65 C'est une pile d'ouvrages portant sur le pixel art.
+        - 14, 65 A pile of publications about pixel art.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3207,7 +3174,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 66 C'est une pile d'ouvrages sur l'event-making.
+        - 14, 66 A pile of publications about event-making.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3258,8 +3225,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDY3IElsIHkgYSB1biBncm9zIGxpdnJlIGludGl0dWzDqSAiVmFkZW1lY3VtIGR1IGNoZWYgZGUgUHJvamV0IiwgcGFyIEFlcnVuLg==
+        - 14, 67 There is a big book named "Vademecum of the Project Manager", by
+          Aerun.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3310,8 +3277,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDY4IElsIHkgYSB1bmUgYnJvY2h1cmUgcG91c3Npw6lyZXVzZSBpbnRpdHVsw6llICJMZXMgZmFuZ2FtZXMgZXQgbGUgZHJvaXQiLCBwYXIgU2lyTWFsby4=
+        - 14, 68 There is a dusty manual titled "Fangames and Law", by SirMalo.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3369,8 +3335,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDY5IExlcyDDqXRhZ8OocmVzIHNvbnQgcmVtcGxpZXMgZGUgbGl2cmVzIHN1ciBsZXMgUG9rw6ltb24u
+        - 14, 69 The shelves are filled with books about Pokémon.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3436,8 +3401,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDcwIExlcyDDqXRhZ8OocmVzIHNvbnQgcmVtcGxpZXMgZGUgbGl2cmVzIHN1ciBsZXMgUG9rw6ltb24u
+        - 14, 70 The shelves are filled with books about Pokémon.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3524,12 +3488,12 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 71 \gC'est un Distributeur.
+        - 14, 71 It's a vending machine.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Quelle boisson vous fait envie ?
+        - Which drink would you like?
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3537,7 +3501,7 @@ events:
         - - "\\t[12,30] : 200$"
           - "\\t[12,31] : 300$"
           - "\\t[12,32] : 350$"
-          - 14, 72 Rien, merci
+          - 14, 72 Nothing, thanks
         - 4
         indent: 0
         code: 102
@@ -3572,12 +3536,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 73 Clang !\g
+        - 14, 73 Clang!\g
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 74 Une bouteille d'\t[12,30] vient de tomber.\g
+        - 14, 74 A bottle of \t[12,30] dropped down.\g
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3595,18 +3559,17 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '14, 75 Obtenu : \t[12,30].[WAIT 80]\g'
+        - '14, 75 Received: \t[12,30].[WAIT 80]\g'
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 76 \n[1] met \t[12,30]
+        - 14, 76 \n[1] put the \t[12,30] bottle
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          ZGFucyBsYSBQb2NoZSBcaW1nW3BvY2tldC1tZWRpY2luZSxwaWN0dXJlXU3DqWRpY2FtZW50cy5cZw==
+        - in the \img[pocket-medicine,picture]Medicine pocket.\g
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3629,7 +3592,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 77 Vous n'avez pas assez d'argent.
+        - 14, 77 Not enough money...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3675,12 +3638,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 78 Clang !\g
+        - 14, 78 Clang!\g
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 79 Une bouteille de \t[12,31] vient de tomber.\g
+        - 14, 79 A bottle of \t[12,31] dropped down.\g
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3698,18 +3661,17 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '14, 80 Obtenu : \t[12,31].[WAIT 80]\g'
+        - '14, 80 Received: \t[12,31].[WAIT 80]\g'
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 81 \n[1] met \t[12,31]
+        - 14, 81 \n[1] put the \t[12,31] bottle
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          ZGFucyBsYSBQb2NoZSBcaW1nW3BvY2tldC1tZWRpY2luZSxwaWN0dXJlXU3DqWRpY2FtZW50cy5cZw==
+        - in the \img[pocket-medicine,picture]Medicine pocket.\g
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3732,7 +3694,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 82 Vous n'avez pas assez d'argent.
+        - 14, 82 Not enough money...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3778,12 +3740,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 83 Clang !\g
+        - 14, 83 Clang!\g
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 84 Une canette de \t[12,32] vient de tomber.\g
+        - 14, 84 A can of \t[12,32] dropped down.\g
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3801,18 +3763,17 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '14, 85 Obtenu : \t[12,32].[WAIT 80]\g'
+        - '14, 85 Received: \t[12,32].[WAIT 80]\g'
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 86 \n[1] met \t[12,32]
+        - 14, 86 \n[1] put the \t[12,32] can
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          ZGFucyBsYSBQb2NoZSBcaW1nW3BvY2tldC1tZWRpY2luZSxwaWN0dXJlXU3DqWRpY2FtZW50cy5cZw==
+        - in the \img[pocket-medicine,picture]Medicine pocket.\g
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3835,7 +3796,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 87 Vous n'avez pas assez d'argent.
+        - 14, 87 Not enough money...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3853,7 +3814,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - Rien, merci
+        - 14, 72 Nothing, thanks
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -3926,8 +3887,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDg4IElsIHkgYSB0b3V0ZSB1bmUgY29sbGVjdGlvbiBkZSBtYW5nYXMgcG9ydGFudCBzdXIgdW4gRHJlc3NldXIgYWNjb21wYWduw6kgZCd1biBUw6p0YXJ0ZSwgZCd1biBCdWxiaXphcnJlIGV0IGQndW4gUGlrYWNodS4=
+        - 14, 88 There is a complete collection of mangas about a Trainer and his
+          partners Poliwhirl, Bulbasaur and Pikachu.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3993,8 +3954,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDg5IElsIHkgYSB0b3V0ZSB1bmUgY29sbGVjdGlvbiBkZSBtYW5nYXMgcG9ydGFudCBzdXIgdW4gRHJlc3NldXIgYWNjb21wYWduw6kgZCd1biBUw6p0YXJ0ZSwgZCd1biBCdWxiaXphcnJlIGV0IGQndW4gUGlrYWNodS4=
+        - 14, 89 There is a complete collection of mangas about a Trainer and his
+          partners Poliwhirl, Bulbasaur and Pikachu.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4083,15 +4044,15 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDkwIExhIGdyb3NzZSBob3Jsb2dlIGF1IG1pbGlldSBkZSBsYSBiaWJsaW90aMOocXVlIHBlcm1ldCBkZSBjb25uYcOudHJlIGwnaGV1cmUgw6AgdG91dCBtb21lbnQuIFBhciBleGVtcGxlLCBpbCBlc3QgYWN0dWVsbGVtZW50IFtIT1VSXS4=
+        - 14, 90 The big clock in the middle of the Library gives me the hour at any
+          time of the day. For instance, it's currently [HOUR].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '14, 91 Si je peux te l''affirmer avec autant d''aplomb, c''est parce que
-          la \c[5]commande text.set_variable\c[0] me permet de stocker une variable
-          et de la retranscrire '
+        - 14, 91 If I can say it with such confidence, it's because the \c[5]"text.set_variable"\c[0]
+          command allows me to store a complex variable and to transcribe it inside
+          a message.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4101,8 +4062,8 @@ events:
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDkyIEplIHNhaXMgcXVlIFNpck1hbG8gcydlbiBzZXJ0IHNvdXZlbnQsIG5vdGFtbWVudCBsb3JzcXUnaWwgcydhZ2l0IGRlIGRvbm5lciBsZXVycyBwcmVtaWVycyBQb2vDqW1vbiBhdXggbm91dmVhdXggYXJyaXZhbnRzLg==
+        - 14, 92 I know SirMalo often uses it, especially when he gives their starter
+          Pokémon to newcomers.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4186,31 +4147,30 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDkzIFF1aSB2aWVudCBlbmNvcmUgbSdlbWLDqnRlciBhbG9ycyBxdWUgamUgc3VpcyBlbiB0cmFpbiBkZSBsaXJlID8=
+        - 14, 93 Who's annoying me while I'm reading?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 94 Comment ? Tu n'as pas bien entendu ce que je viens de dire ?
+        - 14, 94 What? You didn't hear what I just said?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDk1ICBDJ2VzdCBub3JtYWwsIGonYWkgdXRpbGlzw6kgbGEgdGVjaG5pcXVlIGR1IFxjWzVdYXV0b19za2lwIFxjWzBdcXVpIHBlcm1ldCDDoCB1biBtZXNzYWdlIGRlIHMnZWZmYWNlciBkw6hzIHF1J2lsIGEgZmluaSBkZSBzJ8OpY3JpcmUgIQ==
+        - 14, 95 That's normal, I used the \c[5]"auto_skip"\c[0] command, which closes
+          the message window as soon as the text is over.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDk2IFBvdXIgdGUgbGFpc3NlciB1biBwZXUgcGx1cyBkZSB0ZW1wcyBwb3VyIGxpcmUsIG4naMOpc2l0ZSBwYXMgw6AgbGEgY29tYmluZXIgYXZlYyBsYSBcY1s1XWZvbmN0aW9uIFtXQUlUXSBcY1swXSE=
+        - 14, 96 To give enough time to read the message, you can combine it with
+          the \c[5]"[WAIT]"\c[0] command!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDk3IEplIGNyb2lzIHF1ZSBsZSB0eXBlIMOgIGx1bmV0dGVzIGp1c3RlIMOgIGdhdWNoZSBlbiBzYWl0IHVuIHBldSBwbHVzIMOgIGNlIHN1amV0Lg==
+        - 14, 97 I believe the guy wearing glasses on our left knows more about this
+          subject.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4261,12 +4221,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 98 Une phrase de... virelangue ?
+        - 14, 98 A... tongue-twister sentence?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Mais qu'est-ce que c'est ?
+        - What the hell is that?
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -4322,18 +4282,17 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 99 J'essaie de passer le test, mais c'est super dur !
+        - 14, 99 I try to pass the test, but it's really hard!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 100 Tiens, je te laisse essayer.
+        - 14, 100 Here, give it a try.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          XGNbMTddSmUgdmFpcyBlbiBwcm9maXRlciBwb3VyIHJlZ2FyZGVyIHNlcyByw6lwb25zZXMuLi4=
+        - "\\c[28]I'm going to take this opportunity to look at his answers..."
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -4491,7 +4450,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 101 Je crois que je vais devoir potasser encore un peu...
+        - 14, 101 I think I'll need to cram a bit more...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4561,13 +4520,14 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 102 \spd[1]Akwakwak, quoique couard, couina narquoisement sans couac.
+        - 14, 102 \spd[1]How much lunch could a Munchlax munch if a Munchlax could
+          munch lunch?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDEwMyBKZSBsaXMgdW4gcmVjdWVpbCBkZSBwaHJhc2VzIGZyYW5jaGVtZW50IGNvbXBsaXF1w6llcyDDoCBwcm9ub25jZXIsIGFsb3JzIGondXRpbGlzZSBsYSBcY1s1XWZvbmN0aW9uIFxcc3BkW05dIFxjWzBdcG91ciBsZXMgbGlyZSBsZW50ZW1lbnQu
+        - 14, 103 I'm reading a collection of sentences that are quite hard to pronounce,
+          so I use the \c[5]"\\spd[N]\c[0]" command to read them slowly.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4628,8 +4588,7 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 104 Quel livre vais-je bien pouvoir emprunter[WAIT 15].[WAIT 15].[WAIT
-          15]. [WAIT 45] Hum ?
+        - 14, 104 Which book will I take[WAIT 15].[WAIT 15].[WAIT 15].[WAIT 45]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4675,14 +4634,14 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDEwNSBKJ2FpIGJlc29pbiBkZSB0ZW1wcyBwb3VyIHLDqWZsw6ljaGlyLCBhbG9ycyBqJ2luc8OocmUgXGNbNV0iW1dBSVQgTl0iXGNbMF0gZGFucyBtb24gbWVzc2FnZSBwb3VyIG1hcnF1ZXIgdW5lIHBhdXNlLg==
+        - 14, 105 I need time to think, so I insert \c[5]"[WAIT N]"\c[0] in my message
+          to take a break.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          Li4uIFBvdXJxdW9pID8gQydlc3QgcG91ciBsJ2V4ZW1wbGUsIGlsIGZhdXQgYmllbiDDqXZpZGVtbWVudCBsZSByZW1wbGFjZXIgcGFyIGxlIG5vbWJyZSBkZSBmcmFtZXMgw6AgYXR0ZW5kcmUgISA=
+        - "... Why N? It's an example, it must be replaced by the number of frames
+          to wait, of course!"
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -4774,30 +4733,28 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 106 :[align=center]:\s[b]Manuel :\s[r]
+        - 14, 106 :[align=center]:\s[b]Guide:\s[r]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Les fonctions de messages (1/2)
+        - Messages commands (1/2)
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDEwNyBBam91dGVyIFxjWzVdW2FsaWduPV0gXGNbMF0gZGFucyB1biBtZXNzYWdlIHBlcm1ldCBkZSBqdXN0aWZpZXIgbGUgdGV4dGUgw6AgZ2F1Y2hlIG91IMOgIGRyb2l0ZSwgb3UgZGUgbGUgY2VudHJlci4=
+        - 14, 107 Adding \c[5]"[align=]"\c[0] in a message justifies the text to the
+          left or to the right, or centers it.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDEwOCDCoA==
+        - '14, 108 '
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OlthbGlnbj1yaWdodF06RmluwqDCoMKg
+        - ":[align=right]:The end  "
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -4863,34 +4820,32 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 109 :[align=center]:\s[b]Manuel :\s[r]
+        - 14, 109 :[align=center]:\s[b]Guide:\s[r]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Les fonctions de messages (2/2)
+        - Messages commands (2/2)
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 110 La fonction \c[5]\\s[...] \c[0]permet de passer le texte en \s[b]gras
+        - 14, 110 The \c[5]"\\s[...]"\c[0] command puts the text in \s[b]bold\s[r]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - "\\s[r]ou en \\s[i]italique\\s[r]."
+        - or in \s[i]italic\s[r].
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDExMSDCoA==
+        - '14, 111 '
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          OlthbGlnbj1yaWdodF06RmluwqDCoMKg
+        - ":[align=right]:The end  "
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -4962,7 +4917,7 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 14, 113 :[align=center]:\^AAAAH !!!
+        - 14, 113 :[align=center]:\^AAAAH!!!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5013,8 +4968,7 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDExNCBUdSBtJ2FzIHLDqXZlaWxsw6kgZXQgZmFpdCBjcmllciBhbG9ycyBxdSdpbCBmYXV0IHJlc3RlciBzaWxlbmNpZXV4IGRhbnMgdW5lIGJpYmxpb3Row6hxdWUgIQ==
+        - 14, 114 You woke me up and made me scream while we're in a library!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5065,8 +5019,7 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTQsIDExNSBCb24sIG/DuSBlbiDDqXRhaXMtamUuLi4gW1dBSVQgNDVdQWgsIG91aSAhIFxzcGRbMV0iTCdBdHRhcXVlIELDomlsbGVtZW50IHJlbmQgbGUgUG9rw6ltb24gc29tbm8uLi4i
+        - 14, 115 So, where was I... [WAIT 45]Oh, yes!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map015.rxdata.yml
+++ b/Data/Map015.rxdata.yml
@@ -322,8 +322,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDAgSmUgcGV1eCBhcHByZW5kcmUgdW4gcGV0aXQgdG91ciDDoCB1biBQb2vDqW1vbiBxdWkgdGUgc3VpdC4=
+        - 15, 0 I can teach a little trick to following Pokémon.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -395,14 +394,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEgSWwgZmF1ZHJhaXQgcXUndW4gc2V1bCBQb2vDqW1vbiB0ZSBzdWl2ZS4uLg==
+        - 15, 1 But only one Pokémon would have to follow you...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDIgVHUgcGV1eCBkZW1hbmRlciBhdSBQb2vDqWZhbiBhc3NpcyBqdXN0ZSDDoCBkcm9pdGUgZGUgbW9kaWZpZXIgbGUgbm9tYnJlIGRlIFBva8OpbW9uIHF1aSB0ZSBzdWl2ZW50IGV0IHJldmVuaXIgbWUgdm9pciAh
+        - 15, 2 You can ask the Pokéfan seated on the right to change the number of
+          following Pokémon and come back!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -415,8 +413,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDMgUmVnYXJkZSB1biBwZXUgw6dhLg==
+        - 15, 3 Check that.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -456,8 +453,7 @@ events:
         code: 122
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDQgW1BPS0VdLCBmYWlzIHVuIHBhcyBlbiBhcnJpw6hyZSAh
+        - 15, 4 [POKE], do a backstep!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -501,7 +497,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 5 Maintenant, saute !
+        - 15, 5 Now, jump!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -575,8 +571,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDYgRXQgbWFpbnRlbmFudCwgZmFpcyB1biB0b3VyIHN1ciB0b2ktbcOqbWUgIQ==
+        - 15, 6 And now, do a spin!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -666,14 +661,12 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDcgVHLDqHMgYmllbiwgW1BPS0VdICE=
+        - 15, 7 Very good, [POKE]!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDggUmV2aWVucyBsw6Au
+        - 15, 8 Come back.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -726,14 +719,13 @@ events:
         code: 122
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDkgRXQgdm9pbMOgICE=
+        - 15, 9 Et voilà!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEwIE1vZGlmaWVyIGxhIFxjWzVddmFyaWFibGUgMjFcY1swXSBwZXJtZXQgZCdlZmZlY3R1ZXIgbGVzIGTDqXBsYWNlbWVudHMgbm9ybWFsZW1lbnQgYXBwbGlxdcOpcyBhdSBqb3VldXIgc3VyIGxlIFBva8OpbW9uIHPDqWxlY3Rpb25uw6ku
+        - 15, 10 By changing the \c[5]variable 21\c[0], you can apply the move routes
+          of the player to the selected Pokémon.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -754,8 +746,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDExIEFoLCBqZSB2b2lzIHF1ZSB0dSBwcsOpZsOocmVzIGdhcmRlciB0ZXMgUG9rw6ltb24gZGFucyBsZXVycyBQb2vDqWJhbGxzLi4u
+        - 15, 11 Oh, I see you prefer to keep your Pokémon inside their Poké Balls...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -829,8 +820,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEyIFVuZSBkaW9kZSB2ZXJ0ZSBwYXJjb3VydCBsJ8OpY3JhbiBkZSBsYSBtYWNoaW5lLg==
+        - 15, 12 A green light flashes across the screen.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -915,38 +905,36 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEzIExhIG1hY2hpbmUgc2l0dcOpZSBqdXN0ZSDDoCBjw7R0w6kgZGlzcG9zZSBkJ3VuIHBldGl0IMOpY3JhbiBhbmltw6ku
+        - 15, 13 The machine right there has a little animated screen.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDE0IEonYWkgaW5zdGFsbMOpIGxhIGNvbW1hbmRlIFxjWzVdImFuaW1hdGVfZnJvbV9jaGFyc2V0IlxjWzBdIGRlc3N1cyBwb3VyIGwnYW5pbWVyIHBsdXMgZmFjaWxlbWVudC4=
+        - 15, 14 I installed the \c[5]"animate_from_charset"\c[0] command on it to
+          animate it easily.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDE1IE9uIHBldXQgbCdpbnPDqXJlciBkaXJlY3RlbWVudCBkYW5zIGxlcyBjb25maWd1cmF0aW9ucyBkZSBtb3V2ZW1lbnQgZCd1biDDqXbDqG5lbWVudCwgbWFpcyBhdXNzaSBhdSBzZWluIGQndW4gw6l2w6huZW1lbnQgc8OpcGFyw6ku
+        - 15, 15 You can directly put it inside the autonomous movement settings of
+          an event, but also in a distinct event as well.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDE2IENldHRlIGNvbW1hbmRlIHBlcm1ldCBkJ2FuaW1lciB1bmUgb3UgcGx1c2lldXJzIGxpZ25lcyBkdSBjaGFyYWN0ZXIgZCd1biDDqXbDqG5lbWVudC4=
+        - 15, 16 Use this command to animate one or several lines of an event's character.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDE3IElsIHN1ZmZpdCBkJ2luZGlxdWVyIHF1ZWxsZXMgbGlnbmVzIGFuaW1lciwgZXQgbGEgZHVyw6llIHRvdGFsZSBkZSBsJ2FuaW1hdGlvbiAh
+        - 15, 17 You just need to indicate which lines to animate and the total duration
+          of the animation!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDE4IE9uIHBldXQgbcOqbWUgbGlyZSBsJ2FuaW1hdGlvbiBlbiBib3VjbGUgKFxjWzVdInJlcGVhdDogdHJ1ZSJcY1swXSkgb3Ugw6AgbCdlbnZlcnMgKFxjWzVdInJldmVyc2U6IHRydWUiXGNbMF0pLg==
+        - '15, 18 You can even loop the animation (\c[5]"repeat: true"\c[0]) or reverse
+          it (\c[5]"reverse: true"\c[0]).'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -997,14 +985,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDE5IEplIG0nZW50cmHDrm5lIHBvdXIgdW4gbWFyYXRob24u
+        - 15, 19 I'm training for a marathon.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDIwIE1vbiBDcmFkb3BhdWQgbWUgc3VpdCDDoCBsYSB0cmFjZSBjYXIgaWwgYSBsZSBcY1s1XW5hbWV0YWcgIltmb2xsb3c9SURdIlxjWzBdIGV0IHF1ZSBqJ2FpIG1pcyBtb24gSUQgZGVkYW5zLg==
+        - 15, 20 My Croagunk is following me because I put the \c[5]nametag "[follow=ID]"\c[0]
+          in its name and I filled in my ID.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1096,7 +1083,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 21 Cradooo !
+        - 15, 21 Croaaa!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1159,19 +1146,18 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 22 Salut !
+        - 15, 22 Hi!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          U2kgdHUgdmV1eCwgamUgcGV1eCBmYWlyZSBlbiBzb3J0ZSBxdWUgbGUgUG9rw6ltb24gcXVpIHRlIHN1aXQgbmUgc29pdCBwYXMgZm9yY8OpbWVudCBsZSBwcmVtaWVyIGRlIHRvbiDDqXF1aXBlLg==
+        - If you want, I can make it so the Pokémon that follows you isn't necessarily
+          the first in your Party.
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDIzIMOHYSB0ZSBkaXQgPw==
+        - 15, 23 Would you like me to?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1189,13 +1175,12 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 24 Laisse-moi juste changer un petit truc...[WAIT 60]
+        - 15, 24 Let me just change a little something...[WAIT 60]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          Vm9pbMOgICE=
+        - There it is!
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1223,8 +1208,7 @@ events:
         code: 122
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDI1IE1haW50ZW5hbnQsIHR1IG4nYXMgcXUnw6Agc8OpbGVjdGlvbm5lciBsZSBQb2vDqW1vbiBxdWUgdHUgdmV1eCBkaXJlY3RlbWVudCBkZXB1aXMgbGUgbWVudSBkJ8OpcXVpcGUu
+        - 15, 25 Now, you can simply select the Pokémon you want in your Party menu.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1239,8 +1223,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDI2IENoYWN1biBzZXMgcHLDqWbDqXJlbmNlcywgYXByw6hzIHRvdXQu
+        - 15, 26 Each to their own, after all.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1261,13 +1244,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 27 Le mode "Let's Go" ne te convient plus ?
+        - 15, 27 Tired of the "Let's Go" mode?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          SmUgcGV1eCBsZSBkw6lzYWN0aXZlciwgc2kgdHUgdmV1eC4=
+        - I can disable it, if you want.
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1285,13 +1267,13 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 28 C'est fait !
+        - 15, 28 Done!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          U2kgdHUgdmV1eCByw6lhY3RpdmVyIGxlcyBQb2vDqW1vbiBzdWl2ZXVycywgcmV2aWVucyBtZSB2b2lyLCBvdSB2YXMgcGFybGVyIGF1IFBva8OpZmFuIGp1c3RlIGVuIGZhY2UgZGUgbW9pLg==
+        - If you want to enable the followers, come see me or the Pokéfan just in
+          front of me.
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1344,8 +1326,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDI5IEMnZXN0IHF1YW5kIG3Dqm1lIHBsdXMgc3ltcGEgY29tbWUgw6dhICE=
+        - 15, 29 It's nicer this way, isn't it?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1412,13 +1393,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDMwIEonYW5hbHlzZSBsZXMgaGFiaXR1ZGVzIGRlIGTDqXBsYWNlbWVudCBkZXMgZ2Vucy4=
+        - 15, 30 I study people's travel habits.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 31 Je peux te suivre un moment ?
+        - 15, 31 Can I follow you for a while?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1436,32 +1416,30 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDMyIEplIHJlbWFycXVlIHR1IGVzIGTDqWrDoCBzdWl2aS4=
+        - 15, 32 I notice you're already followed.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDMzIFR1IHByw6lmw6hyZXMgZ2FyZGVyIHRlcyBQb2vDqW1vbiBkZWhvcnMgb3UgbGVzIHJhbmdlciA/
+        - 15, 33 Would you like to keep your Pokémon outside or recall them?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 15, 34 Les laisser dehors
-          - 15, 35 Les ranger
+        - - 15, 34 Keep outside
+          - 15, 35 Recall
         - 0
         indent: 1
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Les laisser dehors
+        - 15, 34 Keep outside
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 36 Ok !
+        - 15, 36 Ok!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1471,12 +1449,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Les ranger
+        - 15, 35 Recall
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 37 Ok !
+        - 15, 37 Ok!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1494,8 +1472,7 @@ events:
         code: 404
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDM4IEZhaXMgY29tbWUgc2kgamUgbifDqXRhaXMgcGFzIGzDoC4=
+        - 15, 38 Act like if I wasn't there.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1526,7 +1503,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 39 Je ne suis pas un type louche, je te jure !
+        - 15, 39 I'm not a weirdo, I swear!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1623,8 +1600,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDQwIEh1bS4uLiBUcsOocyBpbnTDqXJlc3NhbnQu
+        - 15, 40 Hmm... Very interesting.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1646,8 +1622,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDQxIEFoICEgSmUgbidhdXJhaXMgcGFzIGZhaXQgw6dhIGNvbW1lIMOnYS4=
+        - 15, 41 Oh! I wouldn't have done it that way.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1669,7 +1644,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 42 Fascinant !
+        - 15, 42 Fascinating!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1691,8 +1666,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDQzIFF1ZWwgZHLDtGxlIGRlIHRyYWplY3RvaXJlICE=
+        - 15, 43 What a funny trajectory!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1714,8 +1688,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDQ0IE9oID8gRmFpcyBjb21tZSBzaSBqZSBuJ8OpdGFpcyBwYXMgbMOgLg==
+        - 15, 44 Oh? Act like if I wasn't there.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1737,8 +1710,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDQ1IFBmaW91LCBxdWVsbGUgZm91bMOpZSAh
+        - 15, 45 Phew, what a stride!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1751,8 +1723,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDQ2IFR1IHZldXggcXUnb24gcydhcnLDqnRlIGzDoCA/
+        - 15, 46 Do you want to stop there?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1770,8 +1741,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDQ3IEplIHZhaXMgcmV0b3VybmVyIMOgIG1hIHBsYWNlIGFsb3JzLg==
+        - 15, 47 I'll go back to my spot, then.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1903,8 +1873,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDQ4IFN1cGVyLCBqJ2FpIGVuY29yZSBkZXMgbm90ZXMgw6AgcHJlbmRyZS4=
+        - 15, 48 Great, I still have notes to take!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2076,33 +2045,31 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDQ5IDpbbmFtZT1OdXJpIFl1cmldOkonYWltZSBiaWVuIHRyYcOubmVyIGRhbnMgY2V0IGVuZHJvaXQu
+        - '15, 49 I like hanging out in this place.:[name=Nuri Yuri]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDUwIDpbbmFtZT1OdXJpIFl1cmldOlNpIHR1IHLDqXBvbmRzIGJpZW4gw6AgdG91dGVzIG1lcyBxdWVzdGlvbnMsIGplIHQnb2ZmcmlyYWkgdW5lIGpvbGllIGJhYmlvbGUgIQ==
+        - '15, 50 If you answer all my questions, I''ll give you a pretty trinket!:[name=Nuri
+          Yuri]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDUxIDpbbmFtZT1OdXJpIFl1cmldOsOHYSB0ZSBkaXQgPw==
+        - '15, 51 Are you in?:[name=Nuri Yuri]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 15, 52 Allons-y !
-          - 15, 53 Une autre fois...
+        - - 15, 52 Let's go!
+          - 15, 53 Later...
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Allons-y !
+        - 15, 52 Let's go!
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2112,13 +2079,12 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '15, 54 :[name=Nuri Yuri]:Question 1 :'
+        - '15, 54 Question 1:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          UXVlbCBlc3QgbGUgbmFtZXRhZyBwb3VyIHN1cHByaW1lciBsJ29tYnJlIHNvdXMgdW4gw6l2w6huZW1lbnQgPw==
+        - 'What is the nametag to delete the shadows under an event?:[name=Nuri Yuri]:'
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2133,7 +2099,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - "$"
+        - 15, 55 $
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2146,13 +2112,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDU5IDpbbmFtZT1OdXJpIFl1cmldOk1hdXZhaXNlIHLDqXBvbnNlICE=
+        - 15, 59 Wrong!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2167,7 +2132,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - "*"
+        - 15, 56 *
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2180,13 +2145,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDYwIDpbbmFtZT1OdXJpIFl1cmldOk1hdXZhaXNlIHLDqXBvbnNlICE=
+        - 15, 60 Wrong!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2201,8 +2165,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - !binary |-
-          wqc=
+        - 15, 57 §
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2215,13 +2178,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDYxIDpbbmFtZT1OdXJpIFl1cmldOkJvbm5lIHLDqXBvbnNlICFbV0FJVCA0MF0=
+        - 15, 61 Correct![WAIT 40]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Question suivante.
+        - 'Next question.:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2231,7 +2193,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - "[no_shadow]"
+        - 15, 58 [no_shadow]
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2244,13 +2206,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDYyIDpbbmFtZT1OdXJpIFl1cmldOk1hdXZhaXNlIHLDqXBvbnNlICE=
+        - 15, 62 Wrong!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2273,28 +2234,27 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '15, 63 :[name=Nuri Yuri]:Question 2 :'
+        - '15, 63 Question 2:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          Q29tbWVudCBtb2RpZmllciBsYSBoYXV0ZXVyIGQndW4gw6l2w6huZW1lbnQgPw==
+        - 'How can you change the height of an event?:[name=Nuri Yuri]:'
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 15, 64 Boucle et "offset_screen_y"
+        - - 15, 64 With a loop and "offset_screen_y"
           - 15, 65 Nametag [fly]
-          - 15, 66 Commande Déplacer
-          - 15, 67 C'est impossible
+          - 15, 66 Set Move Route
+          - 15, 67 It's impossible
         - 0
         indent: 1
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Boucle et "offset_screen_y"
+        - 15, 64 With a loop and "offset_screen_y"
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2307,13 +2267,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDY4IDpbbmFtZT1OdXJpIFl1cmldOkJvbm5lIHLDqXBvbnNlICFbV0FJVCA0MF0=
+        - 15, 68 Correct![WAIT 40]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Question suivante.
+        - 'Next question.:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2323,7 +2282,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Nametag [fly]
+        - 15, 65 Nametag [fly]
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2336,13 +2295,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDY5IDpbbmFtZT1OdXJpIFl1cmldOk1hdXZhaXNlIHLDqXBvbnNlICE=
+        - 15, 69 Wrong!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2357,8 +2315,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - !binary |-
-          Q29tbWFuZGUgRMOpcGxhY2Vy
+        - 15, 66 Set Move Route
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2371,13 +2328,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDcwIDpbbmFtZT1OdXJpIFl1cmldOk1hdXZhaXNlIHLDqXBvbnNlICE=
+        - 15, 70 Wrong!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2392,7 +2348,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - C'est impossible
+        - 15, 67 It's impossible
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2405,12 +2361,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 71 :[name=Nuri Yuri]:Eh ! On n'est pas des feignasses ici !
+        - 15, 71 Hey! We're not slackers!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2433,13 +2389,12 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '15, 72 :[name=Nuri Yuri]:Question 3 :'
+        - '15, 72 Question 3:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          Q29tYmllbiBkJ2VudGl0w6lzIHBldXZlbnQgdGUgc3VpdnJlIGF1IG1heGltdW0gPw==
+        - 'How many entities can follow you at maximum?:[name=Nuri Yuri]:'
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2447,14 +2402,14 @@ events:
         - - 15, 73 1
           - 15, 74 2
           - 15, 75 6
-          - 15, 76 Plus de 6
+          - 15, 76 More than 6
         - 0
         indent: 1
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - '1'
+        - 15, 73 1
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2467,12 +2422,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 77 :[name=Nuri Yuri]:Un peu plus...
+        - 15, 77 A bit more...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2487,7 +2442,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - '2'
+        - 15, 74 2
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2500,13 +2455,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDc4IDpbbmFtZT1OdXJpIFl1cmldOk1hdXZhaXNlIHLDqXBvbnNlICE=
+        - 15, 78 Wrong!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2521,7 +2475,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - '6'
+        - 15, 75 6
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2534,13 +2488,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDc5IDpbbmFtZT1OdXJpIFl1cmldOk1hdXZhaXNlIHLDqXBvbnNlICE=
+        - 15, 79 Wrong!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2555,7 +2508,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - Plus de 6
+        - 15, 76 More than 6
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2568,13 +2521,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDgwIDpbbmFtZT1OdXJpIFl1cmldOkJvbm5lIHLDqXBvbnNlICFbV0FJVCA0MF0=
+        - 15, 80 Correct![WAIT 40]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Question suivante.
+        - 'Next question.:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2592,27 +2544,28 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '15, 81 :[name=Nuri Yuri]:Question 4 :'
+        - '15, 81 Question 4:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Comment faire pour que le follower bouge sans le joueur ?
+        - 'How can you set the route of a follower without having the player move?:[name=Nuri
+          Yuri]:'
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 15, 82 Lui demander
-          - 15, 83 Modifier la variable 21
-          - 15, 84 Commande Déplacer
-          - 15, 85 C'est impossible
+        - - 15, 82 Asking them
+          - 15, 83 Changing variable 21
+          - 15, 84 Set Move Route
+          - 15, 85 It's impossible
         - 0
         indent: 1
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Lui demander
+        - 15, 82 Asking them
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2625,12 +2578,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 86 :[name=Nuri Yuri]:N'importe quoi...
+        - 15, 86 What are you saying...?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2645,7 +2598,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Modifier la variable 21
+        - 15, 83 Changing variable 21
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2658,14 +2611,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDg3IDpbbmFtZT1OdXJpIFl1cmldOkJvbm5lIHLDqXBvbnNlICFbV0FJVCA0MF0=
+        - 15, 87 Correct![WAIT 40]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          VHUgYXMgcsOpcG9uZHUgw6AgbGEgcGVyZmVjdGlvbiAh
+        - 'You answered perfectly!:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2681,8 +2632,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - !binary |-
-          Q29tbWFuZGUgRMOpcGxhY2Vy
+        - 15, 84 Set Move Route
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2695,13 +2645,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDg4IDpbbmFtZT1OdXJpIFl1cmldOk1hdXZhaXNlIHLDqXBvbnNlICE=
+        - 15, 88 Wrong!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2716,7 +2665,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - C'est impossible
+        - 15, 85 It's impossible
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2729,13 +2678,12 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDg5IDpbbmFtZT1OdXJpIFl1cmldOk1hdXZhaXNlIHLDqXBvbnNlICE=
+        - 15, 89 Wrong!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Essaie encore...[WAIT 40]
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2758,7 +2706,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Une autre fois...
+        - 15, 53 Later...
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2816,8 +2764,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDkwIDpbbmFtZT1OdXJpIFl1cmldOkbDqWxpY2l0YXRpb25zICE=
+        - '15, 90 Congratulations! You answered all my questions.:[name=Nuri Yuri]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2828,13 +2775,13 @@ events:
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDkxIDpbbmFtZT1OdXJpIFl1cmldOkMnZXN0IHZyYWkgcXUnZWxsZXMgbifDqXRhaWVudCBwYXMgdHLDqHMgZHVyZXMsIG1haXMgw6dhIG1vbnRyZSBxdWUgdHUgYXMgYmllbiBwYXJsw6kgw6AgdG91dCBsZSBtb25kZSBpY2ku
+        - '15, 91 They weren''t super hard, but I can see you spoke to everybody in
+          this room.:[name=Nuri Yuri]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 92 :[name=Nuri Yuri]:Voici le fameux objet que je t'avais promis.
+        - '15, 92 Here''s the present I promised you.:[name=Nuri Yuri]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2844,14 +2791,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDkzIDpbbmFtZT1OdXJpIFl1cmldOklsIG1lIHNlbWJsZSBxdWUgYydlc3QgU2lyTWFsbyBxdWkgY29sbGVjdGlvbm5lIGNlcyBjYWlsbG91eCBiaXphcm/Dr2Rlcy4=
+        - '15, 93 I believe SirMalo collects these kind of odd rocks.:[name=Nuri Yuri]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 94 :[name=Nuri Yuri]:Tu devrais aller lui en parler dans le Hall de
-          la Tour !
+        - '15, 94 You should go talk to him in the Tower''s Hall!:[name=Nuri Yuri]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2902,14 +2847,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDk1IDpbbmFtZT1OdXJpIFl1cmldOklsIG1lIHNlbWJsZSBxdWUgYydlc3QgU2lyTWFsbyBxdWkgY29sbGVjdGlvbm5lIGNlcyBjYWlsbG91eCBiaXphcm/Dr2Rlcy4=
+        - '15, 95 I believe SirMalo collects these kind of odd rocks.:[name=Nuri Yuri]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 96 :[name=Nuri Yuri]:Tu devrais aller lui en parler dans le Hall de
-          la Tour !
+        - '15, 96 You should go talk to him in the Tower''s Hall!:[name=Nuri Yuri]:'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2960,8 +2903,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 97 Comme cette tasse n'a pas besoin d'apparence, son nom comporte le
-          nametag \c[5]"[sprite=off]"\c[0].
+        - 15, 97 As this mug doesn't need to have an event graphics, its name has
+          the nametag \c[5]"[sprite=off]"\c[0].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3410,31 +3353,29 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDk4IE1vbiBLaXJsaWEgcGV1dCB0w6lsw6lwb3J0ZXIgbGVzIG9iamV0cyBldCBsZXMgZ2VucyDDoCB2b2xvbnTDqSAh
+        - 15, 98 My Kirlia can teleport objects and people!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDk5IEMnZXN0IGdyw6JjZSDDoCBzb24gYXR0YXF1ZSBUw6lsw6lwb3J0LCBtYWlzIGF1c3NpIGdyw6JjZSDDoCBsYSBjb21tYW5kZSBcY1s1XSIkZ2FtZV9wbGF5ZXIubW92ZXRvIlxjWzBdLg==
+        - 15, 99 It's thanks to its move Teleport, but also with the \c[5]"$game_player.moveto"\c[0]
+          command.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEwMCBDb250cmFpcmVtZW50IMOgIGxhIGNvbW1hbmRlIGJhc2lxdWUgZGUgdMOpbMOpcG9ydGF0aW9uLCBcY1s1XSJtb3ZldG8iXGNbMF0gbmUgcsOpaW5pdGlhbGlzZSBwYXMgbGEgbWFwLCBuaSBsYSBtdXNpcXVlIGpvdcOpZS4=
+        - 15, 100 Unlike the basic warping command, \c[5]"moveto"\c[0] doesn't reinitialize
+          the map or the music.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 101 C'est donc pratique dans certains cas.
+        - 15, 101 It's quite handy in some situations.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEwMiBUdSB2ZXV4IGV4cMOpcmltZW50ZXIgcGFyIHRvaS1tw6ptZSA/
+        - 15, 102 Do you want to try it yourself?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3490,8 +3431,7 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEwMyBLaXJsaWEsIGF0dGFxdWUgVMOpbMOpcG9ydCAh
+        - 15, 103 Kirlia, use Teleport!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3544,8 +3484,7 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEwNSBLaXJsaWEgdXRpbGlzZSBUw6lsw6lwb3J0ICE=
+        - 15, 105 Kirlia uses \c[1]Teleport\c[0]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3740,7 +3679,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 106 T'aimes pas les sensations fortes ?
+        - 15, 106 Don't you like thrilling sensations?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4077,31 +4016,31 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 108 Bonjour !
+        - 15, 108 Hello!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEwOSBKJ2FpIGxlIFxjWzVdbmFtZXRhZyAkIFxjWzBdZGFucyBtb24gbm9tLCBkb25jIG1vbiBhcHBhcmVuY2UgcmVzdGUgbGEgbcOqbWUgc3VyIHRvdXRlcyBsZXMgcGFnZXMgcXVpIGNvbXBvc2VudCBtb24gw6l2w6huZW1lbnQu
+        - 15, 109 I've got the \c[5]nametag $\c[0] in my event's name, so my graphics
+          stay the same on all the pages of my event.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 110 Tu en penses quoi ?
+        - 15, 110 What do you think about that?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 15, 111 C'est pratique
-          - 15, 112 C'est utile
+        - - 15, 111 It's handy
+          - 15, 112 It's useful
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - C'est pratique
+        - 15, 111 It's handy
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4117,7 +4056,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - C'est utile
+        - 15, 112 It's useful
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4176,8 +4115,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDExMyBFaCBvdWkgISBDJ2VzdCBwcmF0aXF1ZSBwb3VyIG5lIHBhcyBhdm9pciDDoCBjb25maWd1cmVyIGwnYXBwYXJlbmNlIMOgIGNoYXF1ZSBmb2lzLg==
+        - 15, 113 It is! So you don't have to set the graphics each time.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4228,7 +4166,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 114 Eh oui ! C'est utile pour ne pas oublier une apparence sur une page...
+        - 15, 114 It is! So you won't forget to set the graphics on a page...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4285,20 +4223,17 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDExNSBKJ2FpIGRlbWFuZMOpIMOgIG1vbiBQb2vDqW1vbiBTcGVjdHJlIGRlIG1lIHJlbmRyZSB0cmFuc3BhcmVudCBjb21tZSBsdWkgIQ==
+        - 15, 115 I asked my Ghost Pokémon to make me half-transparent like him!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDExNiBKJ2FpIGF1c3NpIHV0aWxpc8OpIGxlIFxjWzVdbmFtZXRhZyDCp1xjWzBdIHBvdXIgc3VwcHJpbWVyIG1vbiBvbWJyZS4=
+        - 15, 116 I also used the \c[5]nametag §\c[0] to delete my shadow.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDExNyBDaGFuLW3DqSAh
+        - 15, 117 Sheesh!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4357,19 +4292,18 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDExOCBKZSB2b2lzIHF1ZSB0dSBhcyBhY3RpdsOpIGxlIG1vZGUgIkxldCdzIGdvIiBwb3VyIGxlcyBQb2vDqW1vbiBzdWl2ZXVycy4=
+        - 15, 118 I see you enabled the "Let's Go" mode for followers.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDExOSBTaSB0dSB2ZXV4IG1hbmlwdWxlciBsZXMgUG9rw6ltb24gc3VpdmV1cnMgZGUgbGEgdmVyc2lvbiBIR1NTLCBqZSB2YWlzIGRldm9pciBsZSBkw6lzYWN0aXZlciBkJ2Fib3JkLg==
+        - 15, 119 If you want to make some manipulations on followers based on the
+          HGSS versions, I need to disable it first.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Qu'en dis-tu ?
+        - Is it OK for you?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -4387,8 +4321,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEyMCBDJ2VzdCBub3TDqSAhIEplIGTDqXNhY3RpdmUgY2Ugc3lzdMOobWUgYWxvcnMu
+        - 15, 120 All right! I disable the system then.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4436,8 +4369,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEyMSBUcsOocyBiaWVuLg==
+        - 15, 121 Very fine.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4465,39 +4397,36 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEyMiBBbG9ycywgdGVzIFBva8OpbW9uIGFwcHLDqWNpZW50IGxldXIgYmFsYWRlID8=
+        - 15, 122 So, do your Pokémon enjoy the walk?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 123 Tu veux modifier quelque chose ?
+        - 15, 123 Do you want to change somehting?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 15, 124 Arrêter
-          - 15, 125 Modifier le nombre
-          - 15, 126 Rien
+        - - 15, 124 Stop
+          - 15, 125 Change the number
+          - 15, 126 Nothing
         - 3
         indent: 2
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - !binary |-
-          QXJyw6p0ZXI=
+        - 15, 124 Stop
         indent: 2
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 127 C'est toi qui vois.
+        - 15, 127 It's up to you.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEyOCBKZSBkw6lzYWN0aXZlIGwnXGNbNV1pbnRlcnJ1cHRldXIgMTlcY1swXSBkYW5zIGNlIGNhcy4=
+        - 15, 128 I put the \c[5]switch 19\c[0] on Off, then.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4523,33 +4452,32 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Modifier le nombre
+        - 15, 125 Change the number
         indent: 2
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 129 Plus on est de fous, plus on rit, hein !
+        - 15, 129 The more, the merrier, right?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEzMCBUdSB2ZXV4IHF1ZSBjb21iaWVuIGRlIFBva8OpbW9uIHRlIHN1aXZlbnQgPw==
+        - 15, 130 How many following Pokémon would you like?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 15, 131 Un
-          - 15, 132 Deux
-          - 15, 133 Trois
-          - 15, 134 Toute l'équipe
+        - - 15, 131 One
+          - 15, 132 Two
+          - 15, 133 Three
+          - 15, 134 The whole party
         - 0
         indent: 3
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Un
+        - 15, 131 One
         indent: 3
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4568,7 +4496,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Deux
+        - 15, 132 Two
         indent: 3
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4587,7 +4515,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Trois
+        - 15, 133 Three
         indent: 3
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4606,8 +4534,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - !binary |-
-          VG91dGUgbCfDqXF1aXBl
+        - 15, 134 The whole party
         indent: 3
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4634,7 +4561,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Rien
+        - 15, 126 Nothing
         indent: 2
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4655,8 +4582,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEzNSBUaWVucyAhIEplIHJlbWFycXVlIHF1ZSB0dSBnYXJkZXMgdGVzIFBva8OpbW9uIGRhbnMgbGV1cnMgUG9rw6liYWxscy4uLg==
+        - 15, 135 I notice you keep your Pokémon in their Poké Balls...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4666,8 +4592,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEzNiDDh2EgdGUgZGlyYWl0IHF1ZSBsZSBwcmVtaWVyIFBva8OpbW9uIGRlIHRvbiDDqXF1aXBlIHRlIHN1aXZlID8=
+        - 15, 136 Would you like to be followed by the first Pokémon in your Party?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4685,7 +4610,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 137 Fais-lui prendre un peu l'air !
+        - 15, 137 Enjoy the fresh air!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4706,14 +4631,14 @@ events:
         code: 122
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEzOCBKJ2FpIHNpbXBsZW1lbnQgYWN0aXbDqSBsJ1xjWzVdaW50ZXJydXB0ZXVyIDE5XGNbMF0gZXQgcGFzc8OpIGxhIFxjWzVddmFyaWFibGUgMTlcY1swXSBzdXIgMS4=
+        - 15, 138 I just enabled \c[5]switch 19\c[0] and set \c[5]variable 19\c[0]
+          to 1.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDEzOSBOJ291YmxpZSBwYXMgbGEgY29tbWFuZGUgXGNbNV1ZdWtpOjpGb2xsb3dNZS5zbWFydF9kaXNhYmxlIFxjWzBdIHBvdXIgYWN0aXZlciBvdSBkw6lzYWN0aXZlciBsZSBmb2xsb3ctbWUgZGUgbWFuacOocmUgaW50ZWxsaWdlbnRlLg==
+        - 15, 139 Don't forget the \c[5]Yuki::FollowMe.smart_disable \c[0] command
+          to enable or disable the follow-me system dynamically.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4728,7 +4653,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 140 S'ils y sont bien, c'est l'essentiel.
+        - 15, 140 If they're feeling good there, that's the main thing.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4803,7 +4728,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 141 Comme cette tasse n'a pas besoin d'apparence, son nom comporte le
+        - 15, 141 Since this mug's graphics are already on the tileset, it has the
           nametag \c[5]"[sprite=off]"\c[0].
         indent: 0
         code: 101
@@ -4855,25 +4780,23 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDE0MiBKJ2VudHJhw65uZSBtb24gQW5jaHdhdHQgcG91ciBxdSdpbCBsw6l2aXRlIGJpZW4gaGF1dC4=
+        - 15, 142 I train my Tynamo so that it levitates very high.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDE0MyBHcsOiY2Ugw6Agc29uIFRhbGVudCBMw6l2aXRhdGlvbiwgaWwgbidhIGF1Y3VuZSBmYWlibGVzc2UgIQ==
+        - 15, 143 With its Ability Levitate, it has no weakness!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDE0NCBMYSB0ZWNobmlxdWUgcGV1dCBwYXJhw650cmUgY29tcGxleGUsIG1haXMgc2kgdHUgbGlzIGJpZW4gbGVzIGNvbW1lbnRhaXJlcyBkZSBsJ8OpdsOobmVtZW50LCB0dSBjb21wcmVuZHJhcy4=
+        - 15, 144 The technic might look quite complex, but if you read the comments
+          in the event carrefully, you'll get it.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 145 Regarde bien.
+        - 15, 145 Check that.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4976,7 +4899,7 @@ events:
         code: 413
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 146 Bravo !
+        - 15, 146 Nice!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4996,7 +4919,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 147 Maintenant, redescend.
+        - 15, 147 Now, back down.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5075,13 +4998,12 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 148 C'est un travail de longue haleine.
+        - 15, 148 It's a long-term job.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTUsIDE0OSBMYSBjb21tYW5kZSBcY1s1XSJvZmZzZXRfc2NyZWVuX3kiXGNbMF0gY291cGzDqWUgw6AgdW5lIGJvdWNsZSBtJ2EgYmllbiBhaWTDqS4=
+        - 15, 149 The \c[5]"offset_screen_y"\c[0] coupled with a loop helped me well.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5137,7 +5059,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 15, 150 :[name=Anchwatt]:Chwatt, chwatt ![WAIT 50]
+        - 15, 150 :[name=Tynamo]:Namo, Namo![WAIT 50]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map016.rxdata.yml
+++ b/Data/Map016.rxdata.yml
@@ -617,7 +617,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 0 \N[1] trouve 25 jetons !
+        - 16, 0 \N[1] found 25 Coins!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -682,7 +682,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 1 \N[1] trouve 25 jetons !
+        - 16, 1 \N[1] found 25 Coins!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -747,7 +747,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 2 \N[1] trouve 25 jetons !
+        - 16, 2 \N[1] found 25 Coins!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -812,7 +812,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 3 \N[1] trouve 25 jetons !
+        - 16, 3 \N[1] found 25 Coins!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -877,8 +877,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDQgXE5bMV0gdHJvdXZlIDEwMCBqZXRvbnMgISBDJ2VzdCBqb3VyIGRlIGbDqnRlICE=
+        - 16, 4 \N[1] found 100 Coins! It's a day of celebration!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -943,27 +942,27 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 5 Activation du jeu de Minage !
+        - '16, 5 Mining Game: Activated!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 6 Que voulez-vous faire ?
+        - 16, 6 What do you want to do?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 7 Jouer
-          - 16, 8 Réglage de la borne
-          - 16, 9 Consulter mes stats
-          - 16, 10 Quitter
+        - - 16, 7 Play
+          - 16, 8 Machine's settings
+          - 16, 9 Check my stats
+          - 16, 10 Exit
         - 4
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Jouer
+        - 16, 7 Play
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -1008,26 +1007,22 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          UsOpZ2xhZ2UgZGUgbGEgYm9ybmU=
+        - 16, 8 Machine's settings
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDExIENldHRlIGJvcm5lIGVzdCByw6lnbMOpZSBhdmVjIGxlcyBwYXJhbcOodHJlcyBzdWl2YW50cyA6
+        - '16, 11 This machine was set with the following parameters:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBFbnRyZSAyIGV0IDUgb2JqZXRzIGF1IGhhc2FyZCAocGFyYW3DqHRyZSBkZSBiYXNlKQ==
+        - "- Bewteen 2 and 5 items at random (basic settings)"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBSw6lww6l0YWJsZQ==
+        - "- Repeatable"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1037,7 +1032,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Consulter mes stats
+        - 16, 9 Check my stats
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -1092,8 +1087,8 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEyIFZvdXMgYXZleiBqb3XDqSBbTkJfTEFVTkNIXSBmb2lzLCBnYWduw6kgW05CX1dJTl0gZm9pcywgcGVyZHUgW05CX0xPU0VdLg==
+        - 16, 12 You have played [NB_LAUNCH] time(s), won [NB_WIN] time(s), and lost
+          [NB_LOSE] time(s).
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1104,8 +1099,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEzIFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcywgYXZlYyBsYSBtYXNzZSBbTkJfTUFDRV0gZm9pcywgZXQgYXZlYyBsYSBkeW5hbWl0ZSBbTkJfRFlOQU1JVEVdIGZvaXMu
+        - 16, 13 You have hit with the pickaxe [NB_PICKAXE] time(s), with the mace
+          [NB_MACE] time(s), and with the dynamite [NB_DYNAMITE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1118,8 +1113,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE0IFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcyBldCBhdmVjIGxhIG1hc3NlIFtOQl9NQUNFXSBmb2lzLg==
+        - 16, 14 You have hit with the pickaxe [NB_PICKAXE] time(s) and with the mace
+          [NB_MACE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1132,8 +1127,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE1IFBvdXIgZmluaXIsIHZvdXMgYXZleiBkw6l0ZXJyw6kgZGVzIG9iamV0cyBbTkJfSVRFTVNdIGZvaXMgIQ==
+        - 16, 15 Finally, you have dug up items [NB_ITEMS] time(s)!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1163,13 +1157,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - Quitter
+        - 16, 10 Exit
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE2IE1lcmNpIGQnYXZvaXIgam91w6kgIQ==
+        - 16, 16 Thank you for playing!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1229,14 +1222,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE3IFZvdWxlei12b3VzIGpvdWVyIGF1IFZvbHRvcmJhdGFpbGxlID8gTGEgcGFydGllIGNvw7t0ZSA1IGpldG9ucy4=
+        - 16, 17 Do you want to play Voltorb Flip? A game costs 5 Coins.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 18 Oui
-          - 16, 19 Non
+        - - 16, 18 Yes
+          - 16, 19 No
         - 2
         indent: 0
         code: 102
@@ -1290,7 +1282,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 20 Vous n'avez pas assez de jetons.
+        - 16, 20 You don't have enough Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1311,8 +1303,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIxIElsIHZvdXMgZmF1dCB1bmUgQm/DrnRlIEpldG9ucyBwb3VyIHBvdXZvaXIgam91ZXIgIQ==
+        - 16, 21 You need a Coin Case to play!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1669,27 +1660,27 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 22 Activation du jeu de Minage !
+        - '16, 22 Mining Game: activated!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 23 Que voulez-vous faire ?
+        - 16, 23 What do you want to do?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 24 Jouer
-          - 16, 25 Réglage de la borne
-          - 16, 26 Consulter mes stats
-          - 16, 27 Quitter
+        - - 16, 24 Play
+          - 16, 25 Machine's settings
+          - 16, 26 Check my stats
+          - 16, 27 Exit
         - 4
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Jouer
+        - 16, 24 Play
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -1734,25 +1725,22 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          UsOpZ2xhZ2UgZGUgbGEgYm9ybmU=
+        - 16, 25 Machine's settings
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI4IENldHRlIGJvcm5lIGVzdCByw6lnbMOpZSBhdmVjIGxlcyBwYXJhbcOodHJlcyBzdWl2YW50cyA6
+        - '16, 28 This machine was set with the following parameters:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - "- 3 objets au hasard"
+        - "- 3 items at random"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBSw6lww6l0YWJsZQ==
+        - "- Repeatable"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1762,7 +1750,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Consulter mes stats
+        - 16, 26 Check my stats
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -1817,8 +1805,8 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI5IFZvdXMgYXZleiBqb3XDqSBbTkJfTEFVTkNIXSBmb2lzLCBnYWduw6kgW05CX1dJTl0gZm9pcywgcGVyZHUgW05CX0xPU0VdLg==
+        - 16, 29 You have played [NB_LAUNCH] time(s), won [NB_WIN] time(s), and lost
+          [NB_LOSE] time(s).
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1829,8 +1817,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDMwIFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcywgYXZlYyBsYSBtYXNzZSBbTkJfTUFDRV0gZm9pcywgZXQgYXZlYyBsYSBkeW5hbWl0ZSBbTkJfRFlOQU1JVEVdIGZvaXMu
+        - 16, 30 You have hit with the pickaxe [NB_PICKAXE] time(s), with the mace
+          [NB_MACE] time(s), and with the dynamite [NB_DYNAMITE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1843,8 +1831,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDMxIFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcyBldCBhdmVjIGxhIG1hc3NlIFtOQl9NQUNFXSBmb2lzLg==
+        - 16, 31 You have hit with the pickaxe [NB_PICKAXE] time(s) and with the mace
+          [NB_MACE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1857,8 +1845,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDMyIFBvdXIgZmluaXIsIHZvdXMgYXZleiBkw6l0ZXJyw6kgZGVzIG9iamV0cyBbTkJfSVRFTVNdIGZvaXMgIQ==
+        - 16, 32 Finally, you have dug up items [NB_ITEMS] time(s)!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1888,13 +1875,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - Quitter
+        - 16, 27 Exit
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDMzIE1lcmNpIGQnYXZvaXIgam91w6kgIQ==
+        - 16, 33 Thank you for playing!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1954,27 +1940,27 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 34 Activation du jeu de Minage !
+        - '16, 34 Mining Game: activated!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 35 Que voulez-vous faire ?
+        - 16, 35 What do you want to do?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 36 Jouer
-          - 16, 37 Réglage de la borne
-          - 16, 38 Consulter mes stats
-          - 16, 39 Quitter
+        - - 16, 36 Play
+          - 16, 37 Machine's settings
+          - 16, 38 Check my stats
+          - 16, 39 Exit
         - 4
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Jouer
+        - 16, 36 Play
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2059,31 +2045,27 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          UsOpZ2xhZ2UgZGUgbGEgYm9ybmU=
+        - 16, 37 Machine's settings
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDQwIENldHRlIGJvcm5lIGVzdCByw6lnbMOpZSBhdmVjIGxlcyBwYXJhbcOodHJlcyBzdWl2YW50cyA6
+        - '16, 40 This machine was set with the following parameters:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - "- 4 objets au hasard"
+        - "- 4 items at random"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBIYXJkIG1vZGUgYWN0aXbDqSBhdmFudCwgZMOpc2FjdGl2w6kgYXByw6hz
+        - Hard mode at first, then disabled
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBSw6lww6l0YWJsZQ==
+        - "- Repeatable"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2093,7 +2075,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Consulter mes stats
+        - 16, 38 Check my stats
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2148,8 +2130,8 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDQxIFZvdXMgYXZleiBqb3XDqSBbTkJfTEFVTkNIXSBmb2lzLCBnYWduw6kgW05CX1dJTl0gZm9pcywgcGVyZHUgW05CX0xPU0VdLg==
+        - 16, 41 You have played [NB_LAUNCH] time(s), won [NB_WIN] time(s), and lost
+          [NB_LOSE] time(s).
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2160,8 +2142,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDQyIFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcywgYXZlYyBsYSBtYXNzZSBbTkJfTUFDRV0gZm9pcywgZXQgYXZlYyBsYSBkeW5hbWl0ZSBbTkJfRFlOQU1JVEVdIGZvaXMu
+        - 16, 42 You have hit with the pickaxe [NB_PICKAXE] time(s), with the mace
+          [NB_MACE] time(s), and with the dynamite [NB_DYNAMITE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2174,8 +2156,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDQzIFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcyBldCBhdmVjIGxhIG1hc3NlIFtOQl9NQUNFXSBmb2lzLg==
+        - 16, 43 You have hit with the pickaxe [NB_PICKAXE] time(s) and with the mace
+          [NB_MACE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2188,8 +2170,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDQ0IFBvdXIgZmluaXIsIHZvdXMgYXZleiBkw6l0ZXJyw6kgZGVzIG9iamV0cyBbTkJfSVRFTVNdIGZvaXMgIQ==
+        - 16, 44 Finally, you have dug up items [NB_ITEMS] time(s)!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2219,13 +2200,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - Quitter
+        - 16, 39 Exit
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDQ1IE1lcmNpIGQnYXZvaXIgam91w6kgIQ==
+        - 16, 45 Thank you for playing!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2285,27 +2265,27 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 46 Activation du jeu de Minage !
+        - '16, 46 Mining Game: activated!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 47 Que voulez-vous faire ?
+        - 16, 47 What do you want to do?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 48 Jouer
-          - 16, 49 Réglage de la borne
-          - 16, 50 Consulter mes stats
-          - 16, 51 Quitter
+        - - 16, 48 Play
+          - 16, 49 Machine's settings
+          - 16, 50 Check my stats
+          - 16, 51 Exit
         - 4
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Jouer
+        - 16, 48 Play
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2366,31 +2346,27 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          UsOpZ2xhZ2UgZGUgbGEgYm9ybmU=
+        - 16, 49 Machine's settings
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDUyIENldHRlIGJvcm5lIGVzdCByw6lnbMOpZSBhdmVjIGxlcyBwYXJhbcOodHJlcyBzdWl2YW50cyA6
+        - '16, 52 This machine was set with the following parameters:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - "- 5 objets au hasard"
+        - "- 5 items at random"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBTZSBkw6lzYWN0aXZlIHRlbXBvcmFpcmVtZW50ICgxIGhldXJlKQ==
+        - Turns off for a limited time (1hr)
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBSw6lww6l0YWJsZQ==
+        - "- Repeatable"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2400,7 +2376,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Consulter mes stats
+        - 16, 50 Check my stats
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2455,8 +2431,8 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDUzIFZvdXMgYXZleiBqb3XDqSBbTkJfTEFVTkNIXSBmb2lzLCBnYWduw6kgW05CX1dJTl0gZm9pcywgcGVyZHUgW05CX0xPU0VdLg==
+        - 16, 53 You have played [NB_LAUNCH] time(s), won [NB_WIN] time(s), and lost
+          [NB_LOSE] time(s).
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2467,8 +2443,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDU0IFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcywgYXZlYyBsYSBtYXNzZSBbTkJfTUFDRV0gZm9pcywgZXQgYXZlYyBsYSBkeW5hbWl0ZSBbTkJfRFlOQU1JVEVdIGZvaXMu
+        - 16, 54 You have hit with the pickaxe [NB_PICKAXE] time(s), with the mace
+          [NB_MACE] time(s), and with the dynamite [NB_DYNAMITE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2481,8 +2457,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDU1IFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcyBldCBhdmVjIGxhIG1hc3NlIFtOQl9NQUNFXSBmb2lzLg==
+        - 16, 55 You have hit with the pickaxe [NB_PICKAXE] time(s) and with the mace
+          [NB_MACE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2495,8 +2471,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDU2IFBvdXIgZmluaXIsIHZvdXMgYXZleiBkw6l0ZXJyw6kgZGVzIG9iamV0cyBbTkJfSVRFTVNdIGZvaXMgIQ==
+        - 16, 56 Finally, you have dug up items [NB_ITEMS] time(s)!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2526,13 +2501,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - Quitter
+        - 16, 51 Exit
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDU3IE1lcmNpIGQnYXZvaXIgam91w6kgIQ==
+        - 16, 57 Thank you for playing!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2762,27 +2736,27 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 58 Activation du jeu de Minage !
+        - '16, 58 Mining Game: activated!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 59 Que voulez-vous faire ?
+        - 16, 59 What do you want to do?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 60 Jouer
-          - 16, 61 Réglage de la borne
-          - 16, 62 Consulter mes stats
-          - 16, 63 Quitter
+        - - 16, 60 Play
+          - 16, 61 Machine's settings
+          - 16, 62 Check my stats
+          - 16, 63 Exit
         - 4
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Jouer
+        - 16, 60 Play
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2838,25 +2812,22 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          UsOpZ2xhZ2UgZGUgbGEgYm9ybmU=
+        - 16, 61 Machine's settings
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDY0IENldHRlIGJvcm5lIGVzdCByw6lnbMOpZSBhdmVjIGxlcyBwYXJhbcOodHJlcyBzdWl2YW50cyA6
+        - '16, 64 This machine was set with the following parameters:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - "- 1 Tesson Jaune, 1 Pierre Foudre, 1 Plaque Volt"
+        - "- 1 Yellow Shard, 1 Thunder Stone, 1 Zap Plate"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBDZXR0ZSBtYWNoaW5lIG5lIHNlcmEgcGx1cyBhY2Nlc3NpYmxlIGFwcsOocyB1dGlsaXNhdGlvbi4=
+        - This machine won't be usable after one use.
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2866,7 +2837,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Consulter mes stats
+        - 16, 62 Check my stats
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -2921,8 +2892,8 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDY1IFZvdXMgYXZleiBqb3XDqSBbTkJfTEFVTkNIXSBmb2lzLCBnYWduw6kgW05CX1dJTl0gZm9pcywgcGVyZHUgW05CX0xPU0VdLg==
+        - 16, 65 You have played [NB_LAUNCH] time(s), won [NB_WIN] time(s), and lost
+          [NB_LOSE] time(s).
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2933,8 +2904,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDY2IFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcywgYXZlYyBsYSBtYXNzZSBbTkJfTUFDRV0gZm9pcywgZXQgYXZlYyBsYSBkeW5hbWl0ZSBbTkJfRFlOQU1JVEVdIGZvaXMu
+        - 16, 66 You have hit with the pickaxe [NB_PICKAXE] time(s), with the mace
+          [NB_MACE] time(s), and with the dynamite [NB_DYNAMITE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2947,8 +2918,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDY3IFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcyBldCBhdmVjIGxhIG1hc3NlIFtOQl9NQUNFXSBmb2lzLg==
+        - 16, 67 You have hit with the pickaxe [NB_PICKAXE] time(s) and with the mace
+          [NB_MACE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2961,8 +2932,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDY4IFBvdXIgZmluaXIsIHZvdXMgYXZleiBkw6l0ZXJyw6kgZGVzIG9iamV0cyBbTkJfSVRFTVNdIGZvaXMgIQ==
+        - 16, 68 Finally, you have dug up items [NB_ITEMS] time(s)!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2992,13 +2962,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - Quitter
+        - 16, 63 Exit
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDY5IE1lcmNpIGQnYXZvaXIgam91w6kgIQ==
+        - 16, 69 Thank you for playing!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3057,27 +3026,27 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 70 Activation du jeu de Minage !
+        - '16, 70 Mining Game: activated!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 71 Que voulez-vous faire ?
+        - 16, 71 What do you want to do?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 72 Jouer
-          - 16, 73 Réglage de la borne
-          - 16, 74 Consulter mes stats
-          - 16, 75 Quitter
+        - - 16, 72 Play
+          - 16, 73 Machine's settings
+          - 16, 74 Check my stats
+          - 16, 75 Exit
         - 4
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Jouer
+        - 16, 72 Play
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -3132,25 +3101,22 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          UsOpZ2xhZ2UgZGUgbGEgYm9ybmU=
+        - 16, 73 Machine's settings
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDc2IENldHRlIGJvcm5lIGVzdCByw6lnbMOpZSBhdmVjIGxlcyBwYXJhbcOodHJlcyBzdWl2YW50cyA6
+        - '16, 76 This machine was set with the following parameters:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - "- 1 Tesson rouge, 1 Pierre Feu, 1 Plaque Flamme"
+        - "- 1 Red Shard, 1 Fire Stone, 1 Flame Plate"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBDZXR0ZSBtYWNoaW5lIG5lIHNlcmEgcGx1cyBhY2Nlc3NpYmxlIGFwcsOocyB1dGlsaXNhdGlvbi4=
+        - This machine won't be usable after one use.
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3160,7 +3126,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Consulter mes stats
+        - 16, 74 Check my stats
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -3215,8 +3181,8 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDc3IFZvdXMgYXZleiBqb3XDqSBbTkJfTEFVTkNIXSBmb2lzLCBnYWduw6kgW05CX1dJTl0gZm9pcywgcGVyZHUgW05CX0xPU0VdLg==
+        - 16, 77 You have played [NB_LAUNCH] time(s), won [NB_WIN] time(s), and lost
+          [NB_LOSE] time(s).
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3227,8 +3193,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDc4IFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcywgYXZlYyBsYSBtYXNzZSBbTkJfTUFDRV0gZm9pcywgZXQgYXZlYyBsYSBkeW5hbWl0ZSBbTkJfRFlOQU1JVEVdIGZvaXMu
+        - 16, 78 You have hit with the pickaxe [NB_PICKAXE] time(s), with the mace
+          [NB_MACE] time(s), and with the dynamite [NB_DYNAMITE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3241,8 +3207,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDc5IFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcyBldCBhdmVjIGxhIG1hc3NlIFtOQl9NQUNFXSBmb2lzLg==
+        - 16, 79 You have hit with the pickaxe [NB_PICKAXE] time(s) and with the mace
+          [NB_MACE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3255,8 +3221,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDgwIFBvdXIgZmluaXIsIHZvdXMgYXZleiBkw6l0ZXJyw6kgZGVzIG9iamV0cyBbTkJfSVRFTVNdIGZvaXMgIQ==
+        - 16, 80 Finally, you have dug up items [NB_ITEMS] time(s)!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3286,13 +3251,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - Quitter
+        - 16, 75 Exit
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDgxIE1lcmNpIGQnYXZvaXIgam91w6kgIQ==
+        - 16, 81 Thank you for playing!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3351,27 +3315,27 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 82 Activation du jeu de Minage !
+        - '16, 82 Mining Game: activated!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 83 Que voulez-vous faire ?
+        - 16, 83 What do you want to do?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 84 Jouer
-          - 16, 85 Réglage de la borne
-          - 16, 86 Consulter mes stats
-          - 16, 87 Quitter
+        - - 16, 84 Play
+          - 16, 85 Machine's settings
+          - 16, 86 Check my stats
+          - 16, 87 Exit
         - 4
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Jouer
+        - 16, 84 Play
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -3426,25 +3390,22 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          UsOpZ2xhZ2UgZGUgbGEgYm9ybmU=
+        - 16, 85 Machine's settings
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDg4IENldHRlIGJvcm5lIGVzdCByw6lnbMOpZSBhdmVjIGxlcyBwYXJhbcOodHJlcyBzdWl2YW50cyA6
+        - '16, 88 This machine was set with the following parameters:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - "- 1 Tesson vert, 1 Pierre Plante, 1 Plaque Herbe"
+        - "- 1 Green Shard, 1 Leaf Stone, 1 Meadow Plate"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBDZXR0ZSBtYWNoaW5lIG5lIHNlcmEgcGx1cyBhY2Nlc3NpYmxlIGFwcsOocyB1dGlsaXNhdGlvbi4=
+        - This machine won't be usable after one use.
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3454,7 +3415,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Consulter mes stats
+        - 16, 86 Check my stats
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -3509,8 +3470,8 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDg5IFZvdXMgYXZleiBqb3XDqSBbTkJfTEFVTkNIXSBmb2lzLCBnYWduw6kgW05CX1dJTl0gZm9pcywgcGVyZHUgW05CX0xPU0VdLg==
+        - 16, 89 You have played [NB_LAUNCH] time(s), won [NB_WIN] time(s), and lost
+          [NB_LOSE] time(s).
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3521,8 +3482,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDkwIFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcywgYXZlYyBsYSBtYXNzZSBbTkJfTUFDRV0gZm9pcywgZXQgYXZlYyBsYSBkeW5hbWl0ZSBbTkJfRFlOQU1JVEVdIGZvaXMu
+        - 16, 90 You have hit with the pickaxe [NB_PICKAXE] time(s), with the mace
+          [NB_MACE] time(s), and with the dynamite [NB_DYNAMITE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3535,8 +3496,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDkxIFZvdXMgYXZleiB0YXDDqSBhdmVjIGxhIHBpb2NoZSBbTkJfUElDS0FYRV0gZm9pcyBldCBhdmVjIGxhIG1hc3NlIFtOQl9NQUNFXSBmb2lzLg==
+        - 16, 91 You have hit with the pickaxe [NB_PICKAXE] time(s) and with the mace
+          [NB_MACE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3549,8 +3510,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDkyIFBvdXIgZmluaXIsIHZvdXMgYXZleiBkw6l0ZXJyw6kgZGVzIG9iamV0cyBbTkJfSVRFTVNdIGZvaXMgIQ==
+        - 16, 92 Finally, you have dug up items [NB_ITEMS] time(s)!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3580,13 +3540,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - Quitter
+        - 16, 87 Exit
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDkzIE1lcmNpIGQnYXZvaXIgam91w6kgIQ==
+        - 16, 93 Thank you for playing!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3645,27 +3604,27 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 94 Activation du jeu de Minage !
+        - '16, 94 Mining Game: activated!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 95 Que voulez-vous faire ?
+        - 16, 95 What do you want to do?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 96 Jouer
-          - 16, 97 Réglage de la borne
-          - 16, 98 Consulter mes stats
-          - 16, 99 Quitter
+        - - 16, 96 Play
+          - 16, 97 Machine's settings
+          - 16, 98 Check my stats
+          - 16, 99 Exit
         - 4
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Jouer
+        - 16, 96 Play
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -3720,25 +3679,22 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          UsOpZ2xhZ2UgZGUgbGEgYm9ybmU=
+        - 16, 97 Machine's settings
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEwMCBDZXR0ZSBib3JuZSBlc3QgcsOpZ2zDqWUgYXZlYyBsZXMgcGFyYW3DqHRyZXMgc3VpdmFudHMgOg==
+        - '16, 100 This machine was set with the following parameters:'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - "- 1 Tesson bleu, 1 Pierre Eau, 1 Plaque Hydro"
+        - "- 1 Blue Shard, 1 Water Stone, 1 Splash Plate"
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          LSBDZXR0ZSBtYWNoaW5lIG5lIHNlcmEgcGx1cyBhY2Nlc3NpYmxlIGFwcsOocyB1dGlsaXNhdGlvbi4=
+        - This machine won't be usable after one use.
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3748,7 +3704,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Consulter mes stats
+        - 16, 98 Check my stats
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -3803,8 +3759,8 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEwMSBWb3VzIGF2ZXogam91w6kgW05CX0xBVU5DSF0gZm9pcywgZ2FnbsOpIFtOQl9XSU5dIGZvaXMsIHBlcmR1IFtOQl9MT1NFXS4=
+        - 16, 101 You have played [NB_LAUNCH] time(s), won [NB_WIN] time(s), and lost
+          [NB_LOSE] time(s).
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3815,8 +3771,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEwMiBWb3VzIGF2ZXogdGFww6kgYXZlYyBsYSBwaW9jaGUgW05CX1BJQ0tBWEVdIGZvaXMsIGF2ZWMgbGEgbWFzc2UgW05CX01BQ0VdIGZvaXMsIGV0IGF2ZWMgbGEgZHluYW1pdGUgW05CX0RZTkFNSVRFXSBmb2lzLg==
+        - 16, 102 You have hit with the pickaxe [NB_PICKAXE] time(s), with the mace
+          [NB_MACE] time(s), and with the dynamite [NB_DYNAMITE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3829,8 +3785,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEwMyBWb3VzIGF2ZXogdGFww6kgYXZlYyBsYSBwaW9jaGUgW05CX1BJQ0tBWEVdIGZvaXMgZXQgYXZlYyBsYSBtYXNzZSBbTkJfTUFDRV0gZm9pcy4=
+        - 16, 103 You have hit with the pickaxe [NB_PICKAXE] time(s) and with the
+          mace [NB_MACE] time(s).
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3843,8 +3799,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEwNCBQb3VyIGZpbmlyLCB2b3VzIGF2ZXogZMOpdGVycsOpIGRlcyBvYmpldHMgW05CX0lURU1TXSBmb2lzICE=
+        - 16, 104 Finally, you have dug up items [NB_ITEMS] time(s)!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3874,13 +3829,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 3
-        - Quitter
+        - 16, 99 Exit
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEwNSBNZXJjaSBkJ2F2b2lyIGpvdcOpICE=
+        - 16, 105 Thank you for playing!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3939,14 +3893,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEwNiBWb3VsZXotdm91cyBqb3VlciBhdSBWb2x0b3JiYXRhaWxsZSA/IExhIHBhcnRpZSBjb8O7dGUgNSBqZXRvbnMu
+        - 16, 106 Do you want to play Voltorb Flip? A game costs 5 Coins.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 107 Oui
-          - 16, 108 Non
+        - - 16, 107 Yes
+          - 16, 108 No
         - 2
         indent: 0
         code: 102
@@ -4000,7 +3953,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 109 Vous n'avez pas assez de jetons.
+        - 16, 109 You don't have enough Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4021,8 +3974,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDExMCBJbCB2b3VzIGZhdXQgdW5lIEJvw650ZSBKZXRvbnMgcG91ciBwb3V2b2lyIGpvdWVyICE=
+        - 16, 110 You need a Coin Case to play!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4099,14 +4051,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDExMSBWb3VsZXotdm91cyBqb3VlciBhdSBWb2x0b3JiYXRhaWxsZSA/IExhIHBhcnRpZSBjb8O7dGUgNSBqZXRvbnMu
+        - 16, 111 Do you want to play Voltorb Flip? A game costs 5 Coins.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 112 Oui
-          - 16, 113 Non
+        - - 16, 112 Yes
+          - 16, 113 No
         - 2
         indent: 0
         code: 102
@@ -4160,7 +4111,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 114 Vous n'avez pas assez de jetons.
+        - 16, 114 You don't have enough Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4181,8 +4132,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDExNSBJbCB2b3VzIGZhdXQgdW5lIEJvw650ZSBKZXRvbnMgcG91ciBwb3V2b2lyIGpvdWVyICE=
+        - 16, 115 You need a Coin Case to play!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4259,14 +4209,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDExNiBWb3VsZXotdm91cyBqb3VlciBhdSBWb2x0b3JiYXRhaWxsZSA/IExhIHBhcnRpZSBjb8O7dGUgNSBqZXRvbnMu
+        - 16, 116 Do you want to play Voltorb Flip? A game costs 5 Coins.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 117 Oui
-          - 16, 118 Non
+        - - 16, 117 Yes
+          - 16, 118 No
         - 2
         indent: 0
         code: 102
@@ -4320,7 +4269,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 119 Vous n'avez pas assez de jetons.
+        - 16, 119 You don't have enough Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4341,8 +4290,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEyMCBJbCB2b3VzIGZhdXQgdW5lIEJvw650ZSBKZXRvbnMgcG91ciBwb3V2b2lyIGpvdWVyICE=
+        - 16, 120 You need a Coin Case to play!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4419,14 +4367,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEyMSBWb3VsZXotdm91cyBqb3VlciBhdSBWb2x0b3JiYXRhaWxsZSA/IExhIHBhcnRpZSBjb8O7dGUgNSBqZXRvbnMu
+        - 16, 121 Do you want to play Voltorb Flip? A game costs 5 Coins.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 122 Oui
-          - 16, 123 Non
+        - - 16, 122 Yes
+          - 16, 123 No
         - 2
         indent: 0
         code: 102
@@ -4480,7 +4427,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 124 Vous n'avez pas assez de jetons.
+        - 16, 124 You don't have enough Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4501,8 +4448,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEyNSBJbCB2b3VzIGZhdXQgdW5lIEJvw650ZSBKZXRvbnMgcG91ciBwb3V2b2lyIGpvdWVyICE=
+        - 16, 125 You need a Coin Case to play!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4579,14 +4525,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEyNiBWb3VsZXotdm91cyBqb3VlciBhdSBWb2x0b3JiYXRhaWxsZSA/IExhIHBhcnRpZSBjb8O7dGUgNSBqZXRvbnMu
+        - 16, 126 Do you want to play Voltorb Flip? A game costs 5 Coins.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 127 Oui
-          - 16, 128 Non
+        - - 16, 127 Yes
+          - 16, 128 No
         - 2
         indent: 0
         code: 102
@@ -4640,7 +4585,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 129 Vous n'avez pas assez de jetons.
+        - 16, 129 You don't have enough Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4661,8 +4606,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEzMCBJbCB2b3VzIGZhdXQgdW5lIEJvw650ZSBKZXRvbnMgcG91ciBwb3V2b2lyIGpvdWVyICE=
+        - 16, 130 You need a Coin Case to play!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4739,20 +4683,20 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 131 Voulez-vous jouer aux Ruines Alpha ?
+        - 16, 131 Do you want to play Ruins of Alph?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 132 Oui
-          - 16, 133 Non
+        - - 16, 132 Yes
+          - 16, 133 No
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 16, 132 Yes
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -4774,8 +4718,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEzNCBWb3VzIGF2ZXogY29tcGzDqXTDqSBsZSBQdXp6bGUgbnVtw6lybyAxICE=
+        - 16, 134 You have completed Puzzle number 1!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4787,8 +4730,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEzNSBQb3VyIHZvdHJlIHByZW1pw6hyZSB2aWN0b2lyZSwgbm91cyB2b3VzIG9mZnJvbnMgNTAwIGpldG9ucyAh
+        - 16, 135 For your first win, we offer you 500 Coins!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4829,7 +4771,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 16, 133 No
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5118,20 +5060,20 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 136 Voulez-vous jouer aux Ruines Alpha ?
+        - 16, 136 Do you want to play Ruins of Alph?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 137 Oui
-          - 16, 138 Non
+        - - 16, 137 Yes
+          - 16, 138 No
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 16, 137 Yes
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5153,8 +5095,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDEzOSBWb3VzIGF2ZXogY29tcGzDqXTDqSBsZSBQdXp6bGUgbnVtw6lybyAyICE=
+        - 16, 139 You have completed Puzzle number 2!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5166,8 +5107,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE0MCBQb3VyIHZvdHJlIHByZW1pw6hyZSB2aWN0b2lyZSwgbm91cyB2b3VzIG9mZnJvbnMgNTAwIGpldG9ucyAh
+        - 16, 140 For your first win, we offer you 500 Coins!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5208,7 +5148,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 16, 138 No
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5275,20 +5215,20 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 141 Voulez-vous jouer aux Ruines Alpha ?
+        - 16, 141 Do you want to play Ruins of Alph?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 142 Oui
-          - 16, 143 Non
+        - - 16, 142 Yes
+          - 16, 143 No
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 16, 142 Yes
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5310,8 +5250,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE0NCBWb3VzIGF2ZXogY29tcGzDqXTDqSBsZSBQdXp6bGUgbnVtw6lybyAzICE=
+        - 16, 144 You have completed Puzzle number 3!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5323,8 +5262,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE0NSBQb3VyIHZvdHJlIHByZW1pw6hyZSB2aWN0b2lyZSwgbm91cyB2b3VzIG9mZnJvbnMgNTAwIGpldG9ucyAh
+        - 16, 145 For your first win, we offer you 500 Coins!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5365,7 +5303,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 16, 143 No
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5432,20 +5370,20 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 146 Voulez-vous jouer aux Ruines Alpha ?
+        - 16, 146 Do you want to play Ruins of Alph?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 147 Oui
-          - 16, 148 Non
+        - - 16, 147 Yes
+          - 16, 148 No
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 16, 147 Yes
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5467,8 +5405,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE0OSBWb3VzIGF2ZXogY29tcGzDqXTDqSBsZSBQdXp6bGUgbnVtw6lybyA0ICE=
+        - 16, 149 You have completed Puzzle number 4!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5480,8 +5417,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE1MCBQb3VyIHZvdHJlIHByZW1pw6hyZSB2aWN0b2lyZSwgbm91cyB2b3VzIG9mZnJvbnMgNTAwIGpldG9ucyAh
+        - 16, 150 For your first win, we offer you 500 Coins!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5522,7 +5458,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 16, 148 No
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5589,21 +5525,20 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE1MSBWb3VsZXotdm91cyBqb3VlciDDoCBsYSBtYWNoaW5lIMOgIHNvdXMgPw==
+        - 16, 151 Do you want to play the Slot machine?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 152 Oui
-          - 16, 153 Non
+        - - 16, 152 Yes
+          - 16, 153 No
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 16, 152 Yes
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5646,7 +5581,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 154 Vous n'avez pas assez de jetons.
+        - 16, 154 You don't have enough Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5667,8 +5602,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE1NSBJbCB2b3VzIGZhdXQgdW5lIEJvw650ZSBKZXRvbnMgcG91ciBwb3V2b2lyIGpvdWVyICE=
+        - 16, 155 You need a Coin Case to play!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5686,7 +5620,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 16, 153 No
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5745,21 +5679,20 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE1NiBWb3VsZXotdm91cyBqb3VlciDDoCBsYSBtYWNoaW5lIMOgIHNvdXMgPw==
+        - 16, 156 Do you want to play the Slot machine?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 157 Oui
-          - 16, 158 Non
+        - - 16, 157 Yes
+          - 16, 158 No
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 16, 157 Yes
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5802,7 +5735,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 159 Vous n'avez pas assez de jetons.
+        - 16, 159 You don't have enough Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5823,8 +5756,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE2MCBJbCB2b3VzIGZhdXQgdW5lIEJvw650ZSBKZXRvbnMgcG91ciBwb3V2b2lyIGpvdWVyICE=
+        - 16, 160 You need a Coin Case to play!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5842,7 +5774,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 16, 158 No
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5901,21 +5833,20 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE2MSBWb3VsZXotdm91cyBqb3VlciDDoCBsYSBtYWNoaW5lIMOgIHNvdXMgPw==
+        - 16, 161 Do you want to play the Slot machine?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 162 Oui
-          - 16, 163 Non
+        - - 16, 162 Yes
+          - 16, 163 No
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 16, 162 Yes
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -5958,7 +5889,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 164 Vous n'avez pas assez de jetons.
+        - 16, 164 You don't have enough Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5979,8 +5910,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE2NSBJbCB2b3VzIGZhdXQgdW5lIEJvw650ZSBKZXRvbnMgcG91ciBwb3V2b2lyIGpvdWVyICE=
+        - 16, 165 You need a Coin Case to play!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5998,7 +5928,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 16, 163 No
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -6057,21 +5987,20 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE2NiBWb3VsZXotdm91cyBqb3VlciDDoCBsYSBtYWNoaW5lIMOgIHNvdXMgPw==
+        - 16, 166 Do you want to play the Slot machine?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 167 Oui
-          - 16, 168 Non
+        - - 16, 167 Yes
+          - 16, 168 No
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 16, 167 Yes
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -6114,7 +6043,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 169 Vous n'avez pas assez de jetons.
+        - 16, 169 You don't have enough Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6135,8 +6064,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE3MCBJbCB2b3VzIGZhdXQgdW5lIEJvw650ZSBKZXRvbnMgcG91ciBwb3V2b2lyIGpvdWVyICE=
+        - 16, 170 You need a Coin Case to play!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6154,7 +6082,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 16, 168 No
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -6213,8 +6141,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE3MSA6W25hbWU9V2FsdmVuXTpRdWUgcXVvaSA/IExlcyBtYWNoaW5lcyBzJ2VmZmFjZW50IGFwcsOocyB1bmUgc2ltcGxlIHV0aWxpc2F0aW9uID8gQ2EgZG9ubmUgcGFzIGVudmllIGRlIHNlIGZvaXJlci4uLg==
+        - 16, 171 :[name=Walven]:Wh-what? The machines turn off after one use? You
+          don't want to mess it up...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6247,46 +6175,41 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE3MiA6W25hbWU9V2FsdmVuXTpPaCBwYXJkb24sIGplIGfDqm5lIHBldXQtw6p0cmUgPyBEw6lzb2zDqSwgaidhcnJpdmUgcGFzIMOgIGTDqWNpZGVyIHNpIGplIHRlbnRlIG1hIGNoYW5jZSBvdSBub24uLi4=
+        - 16, 172 :[name=Walven]:Oh excuse-me, was I blocking you?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE3MyA6W25hbWU9V2FsdmVuXTpUJ2FzIGwnYWlyIGQnYXZvaXIgdW4gRXhwbG9yYWtpdCwgdCdhcyBwcm9iYWJsZW1lbnQgcGx1cyBkJ2V4cMOpcmllbmNlIHF1ZSBtb2ksIGplIHRlIGxhaXNzZSBsYSBwbGFjZSB2b2xvbnRpZXJzICE=
+        - 16, 173 :[name=Walven]:It looks like you have an Explorer Kit.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE3NCA6W25hbWU9V2FsdmVuXTpIdW0gPyBPaCwgdCdhcyBlbnRlbmR1IHBhcmxlciBkZSBtb2kgPyBBaCBtYWlzIG91aSwgdCdlcyBcZltsYSBub3V2ZWxsZcKnbGUgbm91dmVhdV0gTWFrZXIgcsOpY2VtbWVudCBhcnJpdsOpXEUgc3VyIGwnw45sZSAh
+        - 16, 174 :[name=Walven]:Hm? Oh, you've heard about me?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE3NSA6W25hbWU9V2FsdmVuXTpDb21tZW50IHNlIHBhc3NlIHRvbiBzw6lqb3VyIGp1c3F1J2ljaSA/
+        - 16, 175 :[name=Walven]:How is your stay going so far?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 176 Bien !
-          - 16, 177 Pas trop mal !
-          - 16, 178 La bouffe laisse à désirer...
+        - - 16, 176 Good!
+          - 16, 177 Not bad!
+          - 16, 178 The food isn't up to par...
         - 0
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Bien !
+        - 16, 176 Good!
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE3OSA6W25hbWU9V2FsdmVuXTpUYW50IG1pZXV4LCBvbiBzJ2VzdCBkb25uw6kgw6AgZm9uZCBwb3VyIHF1ZSB2b3VzIHBhc3NpZXogdW4gYm9uIG1vbWVudC4=
+        - 16, 179 :[name=Walven]:Great! We gave our all so you can enjoy it!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6296,13 +6219,12 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Pas trop mal !
+        - 16, 177 Not bad!
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE4MCA6W25hbWU9V2FsdmVuXTogTWlldXggcXVlIHJpZW4gamUgZGlyYWksIGjDqXNpdGUgcGFzIMOgIG5vdXMgZmFpcmUgZGVzIHJldG91cnMgc2kgdHUgcGVuc2VzIHF1ZSBjZXJ0YWluZXMgY2hvc2VzIHBvdXJyYWllbnQgw6p0cmUgYW3DqWxpb3LDqWVzICE=
+        - 16, 180 :[name=Walven]:That's better than nothing...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6312,14 +6234,13 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - !binary |-
-          TGEgYm91ZmZlIGxhaXNzZSDDoCBkw6lzaXJlci4uLg==
+        - 16, 178 The food isn't up to par...
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE4MSA6W25hbWU9V2FsdmVuXTpPdWFpcyBiYWggaGVpbiwgbGVzIE1ha2VycyDDp2Egc2FpdCBmYWlyZSBhdSBtaWV1eCBkZXMgcMOidGVzIGF1IHBhcm1lc2FuLCBkZXMgZ8OidGVhdXggY3JhbcOpcyBldCBkZXMgYnJvd25pZXMgcXVpIHRvdXJuZW50IGF1IGZvbmRhbnQgYXUgY2hvY29sYXQsIG9uIGZhaXQgY2UgcXUnb24gcGV1dC4uLg==
+        - 16, 181 :[name=Walven]:Well huh - at best, makers know how to cook pastas
+          with parmesan, burnt cakes and brownies that look more like chocolate fondants...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6332,38 +6253,34 @@ events:
         code: 404
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE4MiA6W25hbWU9V2FsdmVuXTpNYWlzIHRyw6p2ZSBkZSBiYXZhcmRhZ2UsIHNpIHR1IGVzIHZlbnUgbWUgcGFybGVyIGMnZXN0IHF1ZSB0dSB2ZXV4IHLDqWN1cMOpcmVyIG1hIFBpZXJyZSBJbnNvbGl0ZSwgamUgbWUgdHJvbXBlID8=
+        - 16, 182 :[name=Walven]:Enough chit-chat, I guess you came to talk to me
+          to get my Intriguing Stone, right?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE4MyA6W25hbWU9V2FsdmVuXTpFdCBwb3VyIMOnYSwgaidhdXJhaSB1biBwZXRpdCBjaGFsbGVuZ2UgcG91ciB0b2ku
+        - 16, 183 :[name=Walven]:If that so, I have a little challenge for you.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 184 :[name=Walven]:J'suis une bille aux jeux d'argents, et y'a un prix
-          dans la boutique de jetons que je veux absolument...
+        - 16, 184 :[name=Walven]:I really suck at gambling, but there's a prize at
+          the Prize corner that I absolutely want...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE4NSA6W25hbWU9V2FsdmVuXTpJbCBzJ2FnaXQgZGUgbGEgQ2zDqSBTZWNyw6h0ZS4gTmUgbWUgZGVtYW5kZSBwYXMgY2UgcXVlIGplIHZhaXMgZW4gZmFpcmUgZXQgcG91cnF1b2kgbGEgVG91ciBsYSBtZXQgZW4gdmVudGUgY29udHJlIGRlcyBqZXRvbnMsIGplIG4nYWkgcGFzIGxhIHLDqXBvbnNlIMOgIGNlcyBxdWVzdGlvbnMu
+        - 16, 185 :[name=Walven]:It's the Secret Key.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE4NiA6W25hbWU9V2FsdmVuXTpBbcOobmUgbW9pIGxhLCBldCBqZSB0ZSBkb25uZXJhaSBtYSBQaWVycmUgSW5zb2xpdGUu
+        - 16, 186 :[name=Walven]:Bring it to me and I'll give you my Intriguing Stone.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE4NyA6W25hbWU9V2FsdmVuXTpKZSB0J2F0dGVuZHJhaSBlbiBiYXMgZGUgY2V0IMOpdGFnZSwgZW4gdHJhaW4gZGUgc2lyb3RlciB1biBwdGl0IGNvY2t0YWlsLg==
+        - 16, 187 :[name=Walven]:I'll be waiting for you over there, enjoying a cocktail.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6456,26 +6373,25 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE4OCA6W25hbWU9V2FsdmVuXTouLi4gQydlc3QgYmllbiBjZSBxdWUgamUgcGVuc2UgPyBDJ2VzdCBsYSBDbMOpIFNlY3LDqHRlID8gQ2hhcGVhdSBsJ2FtaVxFLCB0J2VzIHVuXEUgdnJhaVxFIGFjY3JvIGF1eCBqZXV4ICE=
+        - 16, 188 :[name=Walven]:... Is that it? The Secret Key?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 189 :[name=Walven]:Tu veux bien me la donner du coup ?
+        - 16, 189 :[name=Walven]:Would you mind giving it to me?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 190 Oui
-          - 16, 191 Non
+        - - 16, 190 Yes
+          - 16, 191 No
         - 2
         indent: 1
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Oui
+        - 16, 190 Yes
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -6485,8 +6401,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 192 :[name=Walven]:Merci infiniment ! Laisse moi m'assurer que la marchandise
-          est bonne...
+        - 16, 192 :[name=Walven]:Thanks a lot!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6496,8 +6411,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 193 :[name=Walven]:Y'a pas de doute, c'est pas une fausse ! Je cours
-          l'utiliser de suite ! Tchao !
+        - '16, 193 :[name=Walven]:No doubt: it''s not fake!'
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6563,8 +6477,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE5NCBPbiBkaXJhaXQgcXUnaWwgdm91cyBhIG91Ymxpw6kuLi4=
+        - 16, 194 It looks like he forgot you...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6624,8 +6537,7 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE5NSA6W25hbWU9V2FsdmVuXTpQQVJET04sIEonQUkgT1VCTEnDiSBERSBURSBET05ORVIgw4dBICE=
+        - 16, 195 :[name=Walven]:SORRY I FORGOT TO GIVE YOU THAT!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6635,7 +6547,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 196 :[name=Walven]:VOILA, LA BISE !
+        - 16, 196 :[name=Walven]:THERE YOU GO, KISS!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6691,18 +6603,17 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Non
+        - 16, 191 No
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 197 :[name=Walven]:Je comprends, c'est un objet d'une valeur inestimable...
-          Du moins pour moi.
+        - 16, 197 :[name=Walven]:I get it, it's a priceless item...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 198 :[name=Walven]:Je serai ici si tu changes d'avis.
+        - 16, 198 :[name=Walven]:I'll be there if you change your mind.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6723,8 +6634,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDE5OSA6W25hbWU9V2FsdmVuXTpBbG9ycywgdHUgdCdhbXVzZXMgPyBIw6lzaXRlIHBhcyDDoCBmYWlyZSBkZXMgcGF1c2VzLCBsJ2FkZGljdGlvbiBhdXggamV1eCBkJ2FyZ2VudHMgZXN0IHVuIHbDqXJpdGFibGUgZmzDqWF1IGRhbnMgbm90cmUgc29jacOpdMOpLg==
+        - 16, 199 :[name=Walven]:Having fun?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6827,8 +6737,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIwMCBKZSBzdWlzIGVuIHJlbmRlei12b3VzIGF2ZWMgbWEgbW9pdGnDqSwgbWFpcyBqJ2FpIGwnaW1wcmVzc2lvbiBxdSdlbGxlIG5lIHNlIHBsYcOudCBwYXMgdHJvcCBpY2kuLi4=
+        - 16, 200 I'm on a date with my fiancée, but it looks like she's not liking
+          this place that much...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6879,8 +6789,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIwMSBKZSBzdWlzIGVuIHJlbmRlei12b3VzIGF2ZWMgbWEgbW9pdGnDqSwgbWFpcyBwb3VyIMOqdHJlIGZyYW5jaGUsIGonYXVyYWlzIHByw6lmw6lyw6kgdW4gcGlxdWUtbmlxdWUgw6AgbCfDqXRhZ2UgZGUgbGEgUHJhaXJpZSBydWlzc2VsYW50ZS4uLg==
+        - 16, 201 I'm on a date with my fiancé, but to be honest, I'd had prefer a
+          picnic on the Prairie Stream...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6931,54 +6841,50 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIwMiBCaWVudmVudWUgXGZbY2jDqHJlIGpvdWV1c2XCp2NoZXIgam91ZXVyXSBkYW5zIG5vdHJlIGh1bWJsZSDDqXRhYmxpc3NlbWVudCAh
+        - 16, 202 Welcome, dear Player, to our humble institution.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIwMyBRdWUgZMOpc2lyZXotdm91cyA/
+        - 16, 203 How can I help you?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 204 Acheter des jetons
-          - 16, 205 Explication des machines
-          - 16, 206 J'ai changé d'avis
+        - - 16, 204 Buy Coins
+          - 16, 205 Explanations on the machines
+          - 16, 206 I changed my mind
         - 3
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Acheter des jetons
+        - 16, 204 Buy Coins
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 207 Bien entendu. Nous vendons un pack de 50 jetons pour 1000$, et un
-          pack de 500 jetons pour 10000$.
+        - 16, 207 All right.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIwOCBMZXF1ZWwgZMOpc2lyZXotdm91cyBhY2hldGVyID9cRw==
+        - 16, 208 Which one would you like?\G
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - '16, 209 50 jetons : 1000$'
-          - '16, 210 500 jetons : 10000$'
-          - 16, 211 J'ai changé d'avis
+        - - '16, 209 50 Coins: 1000$'
+          - '16, 210 500 Coins: 10000$'
+          - 16, 211 I changed my mind
         - 3
         indent: 1
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - '50 jetons : 1000$'
+        - '16, 209 50 Coins: 1000$'
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -6998,7 +6904,7 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 212 Voici vos jetons, merci de votre achat.
+        - 16, 212 Your Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7027,8 +6933,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIxMyBKZSBzdWlzIG5hdnLDqSwgaWwgc2VtYmxlcmFpdCBxdWUgdm91cyBuJ2F2ZXogcGFzIGxlcyBmb25kcyBzdWZmaXNhbnRzIHBvdXIgY2V0dGUgdHJhbnNhY3Rpb24uLi4gUmV2ZW5leiBsb3JzcXVlIHZvdXMgYXVyZXogYXNzZXogPw==
+        - 16, 213 I'm sorry, it looks like you don't have enough money for this purchase...
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7046,7 +6951,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - '500 jetons : 10000$'
+        - '16, 210 500 Coins: 10000$'
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -7066,7 +6971,7 @@ events:
         code: 250
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 214 Voici vos jetons, merci de votre achat.
+        - 16, 214 Your Coins.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7095,8 +7000,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIxNSBKZSBzdWlzIG5hdnLDqSwgaWwgc2VtYmxlcmFpdCBxdWUgdm91cyBuJ2F2ZXogcGFzIGxlcyBmb25kcyBzdWZmaXNhbnRzIHBvdXIgY2V0dGUgdHJhbnNhY3Rpb24uLi4gUmV2ZW5leiBsb3JzcXVlIHZvdXMgYXVyZXogYXNzZXogPw==
+        - 16, 215 I'm sorry, it looks like you don't have enough money for this purchase...
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7114,8 +7018,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - !binary |-
-          SidhaSBjaGFuZ8OpIGQnYXZpcw==
+        - 16, 211 I changed my mind
         indent: 1
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -7138,49 +7041,48 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Explication des machines
+        - 16, 205 Explanations on the machines
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIxNiBCaWVuIHPDu3IgISBOb3VzIHBvc3PDqWRvbnMgYWN0dWVsbGVtZW50IDMgbWFuacOocmVzIGRlIHZvdXMgZGl2ZXJ0aXIu
+        - 16, 216 Of course! We can entertain you in four ways.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIxNyBMYSBwcmVtacOocmUgZXN0IGxlIFZvbHRvcmJhdGFpbGxlLCB1bmUgc29ydGUgZGUgZMOpbWluZXVyIHF1aSBtZXR0cmEgdm9zIG5lcmZzIMOgIHJ1ZGUgw6lwcmV1dmUu
+        - 16, 217 The first one is Voltorb Flip, a kind of minesweeper that will test
+          your nerves to their limit.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIxOCBMYSBkZXV4acOobWUgZXN0IGxhIG1hY2hpbmUgw6Agc291cy4gSW5zw6lyZXogZGVzIGpldG9ucywgbGFuY2V6IGxhIG1hY2hpbmUsIGV0IGFjdGlvbm5leiBsZXMgbGV2aWVycyBwb3VyIHN0b3BwZXIgbGEgbWFjaGluZS4gVm91cyB5IHJlc3NlbnRpcmV6IGxlcyBmcmlzc29ucyBkZSBsJ2F0dGVudGUgZCd1biBjb21ibyBnYWduYW50ICE=
+        - 16, 218 The third one is the Slot machine.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIxOSBQb3VyIGZpbmlyLCBub3VzIGF2b25zIHVuIGpldSB1biBwZXUgcGFydGljdWxpZXIsIGluc3BpcsOpIGRlcyBzb3V0ZXJyYWlucyBkZSBsYSByw6lnaW9uIGRlIFNpbm5vaCA6IGxlIGpldSBkZSBtaW5hZ2UuIENlIGpldSBuZSByZXF1acOocmUgcGFzIGRlIGpldG9uIGV0IG5lIHZvdXMgZW4gZG9ubmVyYSBwYXMgbm9uIHBsdXMgZW4gcsOpY29tcGVuc2UsIG1haXMgaWwgdm91cyBwZXJtZXR0cmEgZCdvYnRlbmlyIGRlIGZhYnVsZXV4IG9iamV0cywgY2FkZWF1eCBkZSBsYSBtYWlzb24gIQ==
+        - '16, 219 Finally, we have quite a special game, based on Sinnoh''s Undergrounds:
+          the Mining Game.'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIyMCBOZSB2b3VzIMOpdG9ubmV6IHBhcyBzaSBsZXMgbWFjaGluZXMgdm91cyBwYXJsZW50IGRlICJtdXJzIiBvdSBkZSAicm9jaGVycyIsIG5vdXMgYXZvbnMganVzdGUgdm91bHUgw6p0cmUgYXUgcGx1cyBwcm9jaGUgZGVzIGNvbmRpdGlvbnMgcsOpZWxsZXMgc2kgdm91cyBsJ3V0aWxpc2lleiBzdXIgdm90cmUgcHJvamV0Lg==
+        - 16, 220 Don't be surprised if the machines talk about "walls" and "rocks",
+          we just wanted to be as close as the real conditions if you were to use
+          them on your project.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIyMSBEZSBtw6ptZSwgY2hhcXVlIG1hY2hpbmUgYSBzYSBwcm9wcmUgY29uZmlndXJhdGlvbiA6IGxlcyBtYWNoaW5lcyBkZSBnYXVjaGUgc29udCBkZXMgbWFjaGluZXMgcGVybWFuZW50ZXMgYXZlYyBkZXMgcGFyYW3DqHRyZXMgc2ltcGxlcywgbGVzIG1hY2hpbmVzIGRlIGRyb2l0ZSBzb250IGRlcyBtYWNoaW5lcyBxdWkgbmUgZm9uY3Rpb25uZXJvbnQgcXUndW5lIGZvaXMgYXZlYyBkZXMgcGFyYW3DqHRyZXMgdHLDqHMgc3DDqWNpZmlxdWVzICE=
+        - '16, 221 Besides, each machine has its own configuration: on the left, the
+          machines are permanent with simple settings, while those on the right will
+          only work once and have very specific settings! '
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIyMiBKZSB2b3VzIHNvdWhhaXRlIGRlIHBhc3NlciB1biBhZ3LDqWFibGUgbW9tZW50IGRhbnMgbm90cmUgZXNwYWNlIGRlIGpldXgu
+        - 16, 222 I wish you a very pleasant moment in our Game Corner.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7190,8 +7092,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - !binary |-
-          SidhaSBjaGFuZ8OpIGQnYXZpcw==
+        - 16, 206 I changed my mind
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -7201,8 +7102,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIyMyBUcsOocyBiaWVuLCBqZSB2b3VzIHNvdWhhaXRlIHVuZSBhZ3LDqWFibGUgam91cm7DqWUgZGFucyBub3RyZSDDqXRhYmxpc3NlbWVudCAh
+        - 16, 223 Very well, have a nice day in our establishment.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7315,14 +7215,12 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIyNCBCaWVudmVudWUgZGFucyBub3RyZSBodW1ibGUgw6l0YWJsaXNzZW1lbnQgISBKZSBjb25zdGF0ZSBxdWUgYydlc3Qgdm90cmUgcHJlbWnDqHJlIHZpc2l0ZSBpY2ksIGplIHZhaXMgZG9uYyBtZSBwZXJtZXR0cmUgZGUgdm91cyBwcsOpc2VudGVyIGxlcyBsaWV1eC4g
+        - 16, 224 Welcome in our humble institution!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 225 Mais tout d'abord, je me dois de vous remettre ceci, en gage de
-          bienvenue.
+        - 16, 225 First of all, I must give you that, as a welcome gift.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7337,44 +7235,41 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIyNiBDZXR0ZSBCb8OudGUgSmV0b24gdm91cyBwZXJtZXR0cmEgZGUgc3RvY2tlciB2b3MgamV0b25zIGR1cmVtZW50IGdhZ27DqXMgbG9ycyBkZSB2b3MgcGFydGllcyBlbiBjZSBsaWV1Lg==
+        - 16, 226 This Coin Case can stock your hard-earned Coins.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIyNyBFbiBjZSBxdWkgY29uY2VybmUgbGVzIGpldXggw6AgZGlzcG9zaXRpb24sIG5vdXMgcG9zc8OpZG9ucyBhY3R1ZWxsZW1lbnQgMyBtYW5pw6hyZXMgZGUgdm91cyBkaXZlcnRpci4=
+        - 16, 227 As for the games you can find, we actually offer four ways of entertainment.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIyOCBMYSBwcmVtacOocmUgZXN0IGxlIFZvbHRvcmJhdGFpbGxlLCB1bmUgc29ydGUgZGUgZMOpbWluZXVyIHF1aSBtZXR0cmEgdm9zIG5lcmZzIMOgIHJ1ZGUgw6lwcmV1dmUu
+        - 16, 228 The first one is Voltorb Flip, a kind of minesweeper that will test
+          your nerves to their limit.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIyOSBMYSBkZXV4acOobWUgZXN0IGxhIG1hY2hpbmUgw6Agc291cy4gSW5zw6lyZXogZGVzIGpldG9ucywgbGFuY2V6IGxhIG1hY2hpbmUsIGV0IGFjdGlvbm5leiBsZXMgbGV2aWVycyBwb3VyIHN0b3BwZXIgbGEgbWFjaGluZS4gVm91cyB5IHJlc3NlbnRpcmV6IGxlcyBmcmlzc29ucyBkZSBsJ2F0dGVudGUgZCd1biBjb21ibyBnYWduYW50ICE=
+        - 16, 229 The second one is the "Ruins of Alph" machine, based on the puzzles
+          you can find in Johto.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIzMCBMYSB0cm9pc2nDqG1lIGVzdCBsYSBtYWNoaW5lIMOgICJSdWluZXMgQWxwaGEiLiBFbGxlIHMnaW5zcGlyZSBkZXMgZmFtZXV4IHB1enpsZXMgZGVzIFJ1aW5lcyBBbHBoYSBkZSBsYSByw6lnaW9uIGRlIEpvaHRvLiBFbGxlIHZvdXMgZGVtYW5kZXJhIGQndXNlciBkZSB2b3RyZSBsb2dpcXVlIHBvdXIgcsOpYXNzZW1ibGVyIGxlIHB1enpsZS4=
+        - 16, 230 The third one is the Slot machine.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIzMSBQb3VyIGZpbmlyLCBub3VzIGF2b25zIHVuIGpldSB1biBwZXUgcGFydGljdWxpZXIsIGluc3BpcsOpIGRlcyBzb3V0ZXJyYWlucyBkZSBsYSByw6lnaW9uIGRlIFNpbm5vaCA6IGxlIGpldSBkZSBtaW5hZ2UuIENlIGpldSBuZSByZXF1aWVydCBwYXMgZGUgamV0b24gZXQgbmUgdm91cyBlbiBkb25uZXJhIHBhcyBub24gcGx1cyBlbiByw6ljb21wZW5zZSwgbWFpcyBpbCB2b3VzIHBlcm1ldHRyYSBkJ29idGVuaXIgZGUgZmFidWxldXggb2JqZXRzLCBjYWRlYXV4IGRlIGxhIG1haXNvbiAh
+        - '16, 231 Finally, we have quite a special game, based on Sinnoh''s Undergrounds:
+          the Mining Game.'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 232 Il vous faut cependant un Explorakit pour l'actionner, je vais donc
-          vous en fournir un.
+        - 16, 232 However, you need an Explorer Kit to play it, so I will give you
+          one.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7389,20 +7284,21 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIzMyBOZSB2b3VzIMOpdG9ubmV6IHBhcyBzaSBsZXMgbWFjaGluZXMgdm91cyBwYXJsZW50IGRlICJtdXJzIiBvdSBkZSAicm9jaGVycyIsIG5vdXMgYXZvbnMganVzdGUgdm91bHUgw6p0cmUgYXUgcGx1cyBwcm9jaGUgZGVzIGNvbmRpdGlvbnMgcsOpZWxsZXMgc2kgdm91cyBsJ3V0aWxpc2lleiBzdXIgdm90cmUgcHJvamV0Lg==
+        - 16, 233 Don't be surprised if the machines talk about "walls" and "rocks",
+          we just wanted to be as close as the real conditions if you were to use
+          them on your project.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIzNCBEZSBtw6ptZSwgY2hhcXVlIG1hY2hpbmUgYSBzYSBwcm9wcmUgY29uZmlndXJhdGlvbiA6IGxlcyBtYWNoaW5lcyBkZSBnYXVjaGUgc29udCBkZXMgbWFjaGluZXMgcGVybWFuZW50ZXMgYXZlYyBkZXMgcGFyYW3DqHRyZXMgc2ltcGxlcywgbGVzIG1hY2hpbmVzIGRlIGRyb2l0ZSBzb250IGRlcyBtYWNoaW5lcyBxdWkgbmUgZm9uY3Rpb25uZXJvbnQgcXUndW5lIGZvaXMgYXZlYyBkZXMgcGFyYW3DqHRyZXMgdHLDqHMgc3DDqWNpZmlxdWVzICE=
+        - '16, 234 Besides, each machine has its own configuration: on the left, the
+          machines are permanent with simple settings, while those on the right will
+          only work once and have very specific settings! '
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIzNSBQb3VyIMOpY2hhbmdlciB2b3MgamV0b25zIGNvbnRyZSBkZXMgcsOpY29tcGVuc2VzLCBhZHJlc3Nlei12b3VzIGF1eCBndWljaGV0cyBqdXN0ZSBsw6Au
+        - 16, 235 To exchange Coins for prize, head towards the counters over there.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7413,8 +7309,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIzNiBQb3VyIGZpbmlyLCBzaSB2b3VzIGF2ZXogdW4gQ2hlcmNoJ09iamV0LCBqZSBuZSBwZXV4IHF1ZSB2b3VzIGNvbnNlaWxsZXogZGUgbCd1dGlsaXNlci4gUGFyZm9pcywgY2VydGFpbnMgY2xpZW50cyB1biBwZXUgcHJlc3PDqSBmb250IHRvbWJlciBxdWVscXVlcyBqZXRvbnMgYXUgc29sLi4u
+        - 16, 236 To finish off, if you appear to have a Dowsing Machine, I can only
+          adivse you to use it.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7427,8 +7323,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIzNyBFbmZpbiwgcG91ciBmaW5pciwgc2FjaGV6IHF1ZSBjZXJ0YWlucyBjbGllbnRzIGZvbnQgcGFyZm9pcyB0b21iZXIgcXVlbHF1ZXMgdW5zIGRlIGxldXJzIGpldG9ucyBhdSBzb2wuIFRlbmV6LCBqZSB2b3VzIG9mZnJlIHVuIENoZXJjaCdPYmpldCBwb3VyIGxlcyByw6ljdXDDqXJlci4=
+        - 16, 237 To finish off, you should know that our customers sometimes drop
+          a few Coins on the floor.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7446,14 +7342,12 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIzOCBDZWxhIHBvdXJyYWl0IHZvdXMgYWlkZXIgw6AgY29uc3RpdHVlciB1bmUgbWlzZSBkZSBkw6lwYXJ0IHNhbnMgYXZvaXIgw6AgZMOpcGVuc2VyIGQnYXJnZW50LiBCaWVuIGVudGVuZHUsIGNlbGEgcmVzdGUgZW50cmUgbm91cywgbidhbGxleiBwYXMgbGUgcsOpcMOpdGVyIMOgIG1lcyByZXNwb25zYWJsZXMuIEplIHZvdXMgbGUgZGlzIGNhciB2b3VzIG1lIHNlbWJsZXogYmllbiBhaW1hYmxlLg==
+        - 16, 238 It can help you gather some Coins without spending money on it.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDIzOSBKZSB2b3VzIHNvdWhhaXRlIGRlIHBhc3NlciB1biBhZ3LDqWFibGUgbW9tZW50IGRhbnMgbm90cmUgZXNwYWNlIGRlIGpldXgu
+        - 16, 239 I wish you a very pleasant moment in our Game Corner.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7530,34 +7424,32 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI0MCBCb25qb3VyIFxuWzFdLCBzb3lleiBcZltsYcKnbGVdIGJpZW52ZW51XEUgw6AgbCdlc3BhY2UgZCfDqWNoYW5nZSBkdSBDYXNpbm8gIQ==
+        - 16, 240 Hello, and welcome to our Prize Corner!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI0MSBOb3VzIMOpY2hhbmdlb25zIHZvcyBqZXRvbnMgY29udHJlIGRlIGZhYnVsZXV4IFBva8OpbW9uLCDDqWxldsOpcyBhdmVjIGFtb3VyIGV0IGRhbnMgbGUgcmVzcGVjdCBkZXMgbG9pcyBpbnRlcm5hdGlvbmFsZXMgYmllbiBlbnRlbmR1Li4u
+        - 16, 241 We exchange Coins for remarkable Pokémon, trained with love and
+          in compliance with international law...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI0MiBRdWVsIFBva8OpbW9uIGTDqXNpcmV6LXZvdXMgPw==
+        - 16, 242 Which Pokémon would you like?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 243 Draby
-          - 16, 244 Griknot
-          - 16, 245 Coupenotte
+        - - 16, 243 Bagon
+          - 16, 244 Gible
+          - 16, 245 Axew
         - 5
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Draby
+        - 16, 243 Bagon
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -7571,13 +7463,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 246 Un Draby pour 1000 jetons. Cela vous convient ?
+        - 16, 246 A Bagon for 1000 Coins.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 247 Oui
-          - 16, 248 Non
+        - - 16, 247 Yes
+          - 16, 248 No
         - 2
         indent: 2
         code: 102
@@ -7589,7 +7481,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 249 Merci de votre achat ! Voici votre Draby !
+        - 16, 249 Thank you for your purchase!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7639,14 +7531,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI1MCBEw6lzb2zDqSwgbWFpcyBpbCBzZW1ibGVyYWl0IHF1ZSB2b3VzIG4nYXlleiBwYXMgYXNzZXogZGUgamV0b25zLi4u
+        - 16, 250 Sorry, but it looks like you don't have enough Coins...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI1MSBOJ2jDqXNpdGV6IHBhcyDDoCByZXZlbmlyIHF1YW5kIHZvdXMgZW4gYXVyZXogYXNzZXogIQ==
+        - 16, 251 Please come back when you'll have enough.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7664,7 +7554,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - Griknot
+        - 16, 244 Gible
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -7678,13 +7568,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 252 Un Griknot pour 1000 jetons. Cela vous convient ?
+        - 16, 252 A Gible for 1000 Coins.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 253 Oui
-          - 16, 254 Non
+        - - 16, 253 Yes
+          - 16, 254 No
         - 2
         indent: 2
         code: 102
@@ -7696,7 +7586,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 255 Merci de votre achat ! Voici votre Griknot !
+        - 16, 255 Thank you for your purchase!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7746,14 +7636,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI1NiBEw6lzb2zDqSwgbWFpcyBpbCBzZW1ibGVyYWl0IHF1ZSB2b3VzIG4nYXlleiBwYXMgYXNzZXogZGUgamV0b25zLi4u
+        - 16, 256 Sorry, but it looks like you don't have enough Coins...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI1NyBOJ2jDqXNpdGV6IHBhcyDDoCByZXZlbmlyIHF1YW5kIHZvdXMgZW4gYXVyZXogYXNzZXogIQ==
+        - 16, 257 Please come back when you'll have enough.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7771,7 +7659,7 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 2
-        - Coupenotte
+        - 16, 245 Axew
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
@@ -7785,13 +7673,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 258 Un Coupenotte pour 1000 jetons. Cela vous convient ?
+        - 16, 258 An Axew for 1000 Coins.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 259 Oui
-          - 16, 260 Non
+        - - 16, 259 Yes
+          - 16, 260 No
         - 2
         indent: 2
         code: 102
@@ -7803,7 +7691,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 261 Merci de votre achat ! Voici votre Coupenotte !
+        - 16, 261 Thank you for your purchase!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7853,14 +7741,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI2MiBEw6lzb2zDqSwgbWFpcyBpbCBzZW1ibGVyYWl0IHF1ZSB2b3VzIG4nYXlleiBwYXMgYXNzZXogZGUgamV0b25zLi4u
+        - 16, 262 Sorry, but it looks like you don't have enough Coins...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI2MyBOJ2jDqXNpdGV6IHBhcyDDoCByZXZlbmlyIHF1YW5kIHZvdXMgZW4gYXVyZXogYXNzZXogIQ==
+        - 16, 263 Please come back when you'll have enough.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7886,8 +7772,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI2NCBBIHVuZSBwcm9jaGFpbmUgZm9pcyBwZXV0LcOqdHJlICE=
+        - 16, 264 See you soon!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7946,14 +7831,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI2NSBCb25qb3VyIFxuWzFdLCBzb3lleiBcZltsYcKnbGVdIGJpZW52ZW51XEUgw6AgbCdlc3BhY2UgZCfDqWNoYW5nZSBkdSBDYXNpbm8gIQ==
+        - 16, 265 Hello, and welcome to our Prize Corner!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI2NiBPbiDDqWNoYW5nZSBsZXMgamV0b25zIGNvbnRyZSBkZSBmYWJ1bGV1eCBwcml4ICE=
+        - 16, 266 We exchange Coins for fantastic prize!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7963,18 +7846,17 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"16, 305 Super Bonbon : 500", '
+        - '"16, 305 Rare Candy: 500", '
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          IjE2LCAzMDYgUMOpcGl0ZSA6IDEwMDAiLCA=
+        - '"16, 306 Nugget: 1000", '
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"16, 307 Master Ball : 3000"'
+        - '"16, 307 Master Ball: 3000"'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
@@ -7984,8 +7866,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          Y2hvaWNlcyA8PCAiMTYsIDMwOCBDbMOpIFNlY3LDqHRlIDogMTAwMCIgdW5sZXNzIGdldF9zZWxmX3N3aXRjaCgiQSIp
+        - 'choices << "16, 308 Secret Key: 1000" unless get_self_switch("A")'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
@@ -7995,8 +7876,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI2NyBRdWVsIHByaXggZMOpc2lyZXotdm91cyA/
+        - 16, 267 Which prize would you like?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8019,13 +7899,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 268 Un Super Bonbon pour 500 jetons. Cela vous convient ?
+        - 16, 268 A Rare Candy for 500 Coins.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 269 Oui
-          - 16, 270 Non
+        - - 16, 269 Yes
+          - 16, 270 No
         - 2
         indent: 2
         code: 102
@@ -8037,7 +7917,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 271 Merci de votre achat ! Voici votre Super Bonbon !
+        - 16, 271 Thank you for your purchase!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8087,14 +7967,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI3MiBEw6lzb2zDqSwgbWFpcyBpbCBzZW1ibGVyYWl0IHF1ZSB2b3VzIG4nYXlleiBwYXMgYXNzZXogZGUgamV0b25zLi4u
+        - 16, 272 Sorry, but it looks like you don't have enough Coins...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI3MyBOJ2jDqXNpdGV6IHBhcyDDoCByZXZlbmlyIHF1YW5kIHZvdXMgZW4gYXVyZXogYXNzZXogIQ==
+        - 16, 273 Please come back when you'll have enough.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8133,14 +8011,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI3NCBVbmUgUMOpcGl0ZSBwb3VyIDEwMDAgamV0b25zLiBDZWxhIHZvdXMgY29udmllbnQgPw==
+        - 16, 274 A Nugget for 1000 Coins.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 275 Oui
-          - 16, 276 Non
+        - - 16, 275 Yes
+          - 16, 276 No
         - 2
         indent: 2
         code: 102
@@ -8152,8 +8029,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI3NyBNZXJjaSBkZSB2b3RyZSBhY2hhdCAhIFZvaWNpIHZvdHJlIFDDqXBpdGUgIQ==
+        - 16, 277 Thank you for your purchase!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8203,14 +8079,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI3OCBEw6lzb2zDqSwgbWFpcyBpbCBzZW1ibGVyYWl0IHF1ZSB2b3VzIG4nYXlleiBwYXMgYXNzZXogZGUgamV0b25zLi4u
+        - 16, 278 Sorry, but it looks like you don't have enough Coins...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI3OSBOJ2jDqXNpdGV6IHBhcyDDoCByZXZlbmlyIHF1YW5kIHZvdXMgZW4gYXVyZXogYXNzZXogIQ==
+        - 16, 279 Please come back when you'll have enough.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8249,13 +8123,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 280 Une Master Ball pour 3000 jetons. Cela vous convient ?
+        - 16, 280 A Master Ball for 3000 Coins.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 281 Oui
-          - 16, 282 Non
+        - - 16, 281 Yes
+          - 16, 282 No
         - 2
         indent: 2
         code: 102
@@ -8267,7 +8141,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 283 Merci de votre achat ! Voici votre Master Ball !
+        - 16, 283 Thank you for your purchase!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8317,14 +8191,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI4NCBEw6lzb2zDqSwgbWFpcyBpbCBzZW1ibGVyYWl0IHF1ZSB2b3VzIG4nYXlleiBwYXMgYXNzZXogZGUgamV0b25zLi4u
+        - 16, 284 Sorry, but it looks like you don't have enough Coins...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI4NSBOJ2jDqXNpdGV6IHBhcyDDoCByZXZlbmlyIHF1YW5kIHZvdXMgZW4gYXVyZXogYXNzZXogIQ==
+        - 16, 285 Please come back when you'll have enough.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8363,14 +8235,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI4NiBVbmUgQ2zDqSBTZWNyw6h0ZSBwb3VyIDEwMDAgamV0b25zLiBDZWxhIHZvdXMgY29udmllbnQgPyBDJ2VzdCBsZSBzZXVsIGV4ZW1wbGFpcmUgcXVlIG5vdXMgYXZvbnMgIQ==
+        - 16, 286 A Secret Key for 1000 Coins. Is that fine?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 16, 287 Oui
-          - 16, 288 Non
+        - - 16, 287 Yes
+          - 16, 288 No
         - 2
         indent: 2
         code: 102
@@ -8382,8 +8253,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI4OSBNZXJjaSBkZSB2b3RyZSBhY2hhdCAhIFZvaWNpIHZvdHJlIENsw6kgU2VjcsOodGUgIQ==
+        - 16, 289 Thank you for your purchase!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8444,14 +8314,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI5MCBEw6lzb2zDqSwgbWFpcyBpbCBzZW1ibGVyYWl0IHF1ZSB2b3VzIG4nYXlleiBwYXMgYXNzZXogZGUgamV0b25zLi4u
+        - 16, 290 Sorry, but it looks like you don't have enough Coins...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI5MSBOJ2jDqXNpdGV6IHBhcyDDoCByZXZlbmlyIHF1YW5kIHZvdXMgZW4gYXVyZXogYXNzZXogIQ==
+        - 16, 291 Please come back when you'll have enough.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8486,8 +8354,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI5MiBBIHVuZSBwcm9jaGFpbmUgZm9pcyBwZXV0LcOqdHJlICE=
+        - 16, 292 See you soon!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8546,8 +8413,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI5MyBTaSBqZSB0b3VjaGUgbGUgamFja3BvdCwgamUgcG91cnJhaXMgZW5maW4gcXVpdHRlciBsYSBUZWFtIFJvY2tldCBldCBwYXJ0aXIgbSdpbnN0YWxsZXIgYXV4IMOubGVzIE1hc2Nhw69tYW4gIQ==
+        - 16, 293 If I hit the jackpot, I'll finally be able to leave Team Rocket
+          and go settle in the Totodile Islands!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8557,8 +8424,7 @@ events:
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTYsIDI5NSBadXQsIGVuY29yZSByYXTDqSAh
+        - 16, 295 Darn, I missed again!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8706,7 +8572,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 301 \N[1] trouve 25 jetons !
+        - 16, 301 \N[1] found 25 Coins!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8771,7 +8637,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 302 \N[1] trouve 25 jetons !
+        - 16, 302 \N[1] found 25 Coins!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8836,7 +8702,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 303 \N[1] trouve 25 jetons !
+        - 16, 303 \N[1] found 25 Coins!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8901,7 +8767,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 16, 304 \N[1] trouve 25 jetons !
+        - 16, 304 \N[1] found 25 Coins!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map017.rxdata.yml
+++ b/Data/Map017.rxdata.yml
@@ -586,14 +586,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDAgXGNbMThdQm9uam91ciBldCBiaWVudmVudWUgw6AgbGEgYm9ybmUgZGUgcsOpc2VydmF0aW9uIGRlIGNvbWJhdCAh
+        - 17, 0 \c[18]Hello and welcome to the battle reservation terminal!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEgXGNbMThdU291aGFpdGV6LXZvdXMgcsOpc2VydmVyIHVuIGNvbWJhdCBzcMOpY2lmaXF1ZSA/
+        - 17, 1 \c[18]Do you want to reserve a specific battle?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -771,8 +769,7 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIgXGNbMThdUXVlbCBjb21iYXQgdm91bGV6LXZvdXMgcsOpc2VydmVyID8=
+        - 17, 2 \c[18]Which battle do you want to reserve?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -806,14 +803,13 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDMgXGNbMThdRXhjZWxsZW50IGNob2l4LCBub3VzIHByb2dyYW1tb25zIHZvdHJlIGNvbWJhdCBkYW5zIGxlcyBtZWlsbGV1cnMgZMOpbGFpcy4=
+        - 17, 3 \c[18]Excellent choice, we're programming your battle in the shortest
+          possible time.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQgXGNbMThdVmV1aWxsZXogdm91cyByZW5kcmUgw6AgbCdhcsOobmUu
+        - 17, 4 \c[18]Please head to the stage.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -844,8 +840,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDUgXGNbMThdTWFpcyBhdmFudCwgbWVyY2kgZGUgc8OpbGVjdGlvbm5lciBsZXMgMiBQb2vDqW1vbiBxdWkgdm91cyBhY2NvbXBhZ25lcm9udCBwb3VyIGNlIGNvbWJhdC4=
+        - 17, 5 \c[18]But before, please select the two Pokémon you will be fighting
+          with.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -895,8 +891,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDYgXGNbMThdVW5lIMOpcXVpcGUgbidhIHBhcyDDqXTDqSBzw6lsZWN0aW9ubsOpZSwgbGUgY29tYmF0IGEgw6l0w6kgZMOpY29tbWFuZMOpLg==
+        - '17, 6 \c[18]No team was selected, the battle was cancelled. '
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -914,8 +909,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDcgXGNbMThdVm90cmUgY2hvaXggYSBiaWVuIMOpdMOpIGVucmVnaXN0csOpLiBNZXJjaSBkZSB2b3RyZSBwYXRpZW5jZSwgbGUgY29tYmF0IHZhIGJpZW50w7R0IGTDqW1hcnJlci4=
+        - 17, 7 \c[18]Your choice was successfully registered.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1012,8 +1006,7 @@ events:
         code: 118
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDggXGNbMThdTWVyY2kgZCdhdm9pciB1dGlsaXPDqSBsYSBib3JuZSBkZSByw6lzZXJ2YXRpb24gZGUgY29tYmF0LCBub3VzIHZvdXMgc291aGFpdG9ucyB1bmUgYWdyw6lhYmxlIGpvdXJuw6llICE=
+        - 17, 8 \c[18]Thank you for using the battle reservation terminal.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1248,44 +1241,40 @@ events:
         code: 241
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDkgOltuYW1lPVBhbGJvbHNreV06QmllbnZlbnVlIMOgIHRvdXMgY2hlcnMgc3BlY3RhdGV1cnMgIQ==
+        - 17, 9 :[name=Palbolsky]:Welcome to you all, dear spectators!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwIDpbbmFtZT1QYWxib2xza3ldOkNlIGNvbWJhdCBzZXJhIHVuIGNvbWJhdCBzb2xvLCBhdmVjIGF1Y3VuZSBsaW1pdGUgZW4gbm9tYnJlIGRlIFBva8OpbW9uICE=
+        - 17, 10 :[name=Palbolsky]:This battle will be a solo battle, with no limit
+          in the number of usable Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDExIDpbbmFtZT1QYWxib2xza3ldOsOAIG1hIGdhdWNoZSwgdm91cyBwb3VycmV6IHkgcmV0cm91dmVyIFtDTEFTU10gW05BTUVdLCBsZSBmaW5hbGlzdGUgZHUgcHLDqWPDqWRlbnQgdG91cm5vaSAh
+        - 17, 11 :[name=Palbolsky]:On my left, you'll find [CLASS] [NAME], the finalist
+          of the last tournament!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEyIDpbbmFtZT1QYWxib2xza3ldOsOAIG1hIGRyb2l0ZSwgbGUgbm91dmVhdSBjaGFsbGVuZ2VyIGZyYcOuY2hlbWVudCBhcnJpdsOpXEUgc3VyIGwnw45sZSwgcXVlIHZvdXMgY29ubmFpc3NleiBwZXV0LcOqdHJlLi4u
+        - 17, 12 :[name=Palbolsky]:On my right, the freshly arrived new challenger
+          on the Island, as you may know...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEzIDpbbmFtZT1QYWxib2xza3ldOkonYWkgbm9tbcOpLi4uIFxOWzFdICE=
+        - 17, 13 :[name=Palbolsky]:I named... \N[1]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE0IDpbbmFtZT1QYWxib2xza3ldOkNoYWxsZW5nZXJzLCDDqnRlcy12b3VzIHByw6p0cyA/
+        - 17, 14 :[name=Palbolsky]:Challengers, are you ready?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE1IDpbbmFtZT1QYWxib2xza3ldOkTDqW1hcnJleiAh
+        - 17, 15 :[name=Palbolsky]:Start!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1295,8 +1284,8 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 16 :[name=[NAME]]:Mon Rattatac est encore plus fort que lors du tournoi,
-          tu vas morfler !
+        - 17, 16 :[name=[NAME]]:My Raticate is even stronger than during the tournament,
+          you're gonna suffer!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1392,7 +1381,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 17 :[name=Palbolsky]:Et c'est une victoire pour \N[1] !
+        - 17, 17 :[name=Palbolsky]:Victory goes to \N[1]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1403,8 +1392,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE4IDpbbmFtZT1QYWxib2xza3ldOkonaW5zY3JpcyBjZXR0ZSB2aWN0b2lyZSDDoCBsJ29yZGluYXRldXIuLi4=
+        - 17, 18 :[name=Palbolsky]:I'll add this victory to the computer...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1453,20 +1441,18 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 19 :[name=Palbolsky]:Que vois-je ? \N[1] a vaincu tous mes apprentis
-          ?
+        - 17, 19 :[name=Palbolsky]:Oh, what do I see? \N[1] won against all my apprentices?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIwIDpbbmFtZT1QYWxib2xza3ldOk1lc2RhbWVzIGV0IG1lc3NpZXVycywgbGUgbW9tZW50IHF1ZSB2b3VzIGF0dGVuZGlleiB0b3VzIGVzdCBhcnJpdsOpICE=
+        - 17, 20 :[name=Palbolsky]:Ladies and gentlemen, the moment you've all been
+          waiting for is here!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIxIDpbbmFtZT1QYWxib2xza3ldOlVuIGNoYWxsZW5nZXIgYSBkw6libG9xdcOpIGxlIGRyb2l0IGRlIG1lIGNvbWJhdHRyZSAhIFJlc3RleiBkYW5zIGxlcyBlbnZpcm9ucyBwb3VyIGFzc2lzdGVyIMOgIHVuIG1hdGNoIGQnYW50aG9sb2dpZSAh
+        - 17, 21 :[name=Palbolsky]:A new challenger unlocked the right to fight me!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1488,8 +1474,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIyIDpbbmFtZT1QYWxib2xza3ldOk9oICEgSWwgbmUgcmVzdGUgcGx1cyBxdSd1biBzZXVsIGNvbWJhdCDDoCBnYWduZXIgcG91ciBcTlsxXSBhdmFudCBkZSBwb3V2b2lyIG0nYWZmcm9udGVyICEgVGllbnMgbGUgY291cCwgZ3JhaW5lIGRlIFxmW2NoYW1waW9ubmXCp2NoYW1waW9uXSAh
+        - 17, 22 :[name=Palbolsky]:Oh! There's only one battle left for \N[1] before
+          they can battle me!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1502,8 +1488,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIzIDpbbmFtZT1QYWxib2xza3ldOk9oICEgSWwgbmUgcmVzdGUgcXVlIFxWWzI2XSBjb21iYXRzIMOgIGdhZ25lciBwb3VyIFxOWzFdIGF2YW50IGRlIHBvdXZvaXIgbSdhZmZyb250ZXIgIQ==
+        - 17, 23 :[name=Palbolsky]:Oh! There's still \V[26] battles left to win for
+          \N[1] before they can challenge me!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1532,8 +1518,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDI0IDpbbmFtZT1QYWxib2xza3ldOkxhIHZpY3RvaXJlIHJldmllbnQgw6AgW05BTUVdICE=
+        - 17, 24 :[name=Palbolsky]:Victory goes to [NAME]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1546,14 +1531,14 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDI1IDpbbmFtZT1QYWxib2xza3ldOkVuIHRvdXQgY2FzLCBjZSBmdXQgdW4gbWF0Y2ggZCd1bmUgZ3JhbmRlIGludGVuc2l0w6ksIGonZXNww6hyZSBxdWUgdm91cyBsJ2F2ZXogcmVzc2VudGkgYXVzc2kgZGFucyBsZXMgZ3JhZGlucyAh
+        - 17, 25 :[name=Palbolsky]:Anyway, it was a match of great intensity, I hope
+          you felt it all the way to the stands!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDI2IDpbbmFtZT1QYWxib2xza3ldOkNoYWxsZW5nZXJzLCBqZSB2YWlzIHNvaWduZXIgdm9zIFBva8OpbW9uIHBvdXIgcXVlIHZvdXMgbidheWV6IHBhcyDDoCBhbGxlciBhdSBDZW50cmUgUG9rw6ltb24u
+        - 17, 26 :[name=Palbolsky]:Challengers, I'll heal your Pokémon so you don't
+          have to go to the Pokémon Center.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1586,14 +1571,14 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDI3IDpbbmFtZT1QYWxib2xza3ldOk4naMOpc2l0ZXogcGFzIMOgIHJldmVuaXIgdm91cyBiYXR0cmUgc2kgdm91cyBsZSB2b3VsZXosIGMnZXN0IHRvdWpvdXJzIHVuIHBsYWlzaXIgZCdhc3Npc3RlciDDoCBkZXMgbWF0Y2hzIGF1c3NpIHBhc3Npb25uYW50cyAh
+        - 17, 27 :[name=Palbolsky]:Don't hesitate to come battle again if you feel
+          like it, it's always a pleasure to attend to such passionating battles!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDI4IDpbbmFtZT1QYWxib2xza3ldOkNoZXJzIHNwZWN0YXRldXJzLCBtZXJjaSBkJ8OqdHJlIHZlbnVzLCBldCDDoCBsYSBwcm9jaGFpbmUgIQ==
+        - 17, 28 :[name=Palbolsky]:Dear spectators, thank you for coming, and see
+          you all next time!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1850,36 +1835,34 @@ events:
         code: 241
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDI5IDpbbmFtZT1QYWxib2xza3ldOkJpZW52ZW51ZSDDoCB0b3VzIGNoZXJzIHNwZWN0YXRldXJzICE=
+        - 17, 29 :[name=Palbolsky]:Welcome to you all, dear spectators!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDMwIDpbbmFtZT1QYWxib2xza3ldOkNlIGNvbWJhdCBzZXJhIHVuIGNvbWJhdCBzb2xvLCBhdmVjIHVuZSBsaW1pdGUgZGUgZGV1eCBQb2vDqW1vbiAh
+        - 17, 30 :[name=Palbolsky]:This battle will be a solo battle, with a limit
+          of two usable Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDMxIDpbbmFtZT1QYWxib2xza3ldOsOAIG1hIGdhdWNoZSwgbGEgZ3JhbmRlIGdhZ25hbnRlIGR1IHByw6ljw6lkZW50IHRvdXJub2kgOiBbQ0xBU1NdIFtOQU1FXSAh
+        - '17, 31 :[name=Palbolsky]:On my left, the winner of the last tournament:
+          [CLASS] [NAME]!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDMyIDpbbmFtZT1QYWxib2xza3ldOsOAIG1hIGRyb2l0ZSwgbGEgc3RhciBtb250YW50ZSBkZSBjZXR0ZSBhcsOobmUuLi4=
+        - 17, 32 :[name=Palbolsky]:On my right, the rising star of this arena...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 33 :[name=Palbolsky]:Applaudissez bien fort... \N[1] !
+        - 17, 33 :[name=Palbolsky]:Please make an ovation for... \N[1]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 34 :[name=Palbolsky]:Le combat peut commencer !
+        - 17, 34 :[name=Palbolsky]:The battle may begin!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1889,8 +1872,8 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDM1IDpbbmFtZT1bTkFNRV1dOkNlIHRvdXJub2kgbifDqXRhaXQgcXUndW4gw6ljaGF1ZmZlbWVudC4uLiBUJ2VzIGxlIHBsYXQgZGUgcsOpc2lzdGFuY2UgIQ==
+        - 17, 35 :[name=[NAME]]:This tournament was only the warm-up, you're the real
+          deal and I'll beat you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1997,7 +1980,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 36 :[name=Palbolsky]:Et c'est une victoire pour \N[1] !
+        - 17, 36 :[name=Palbolsky]:Victory goes to \N[1]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2008,8 +1991,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDM3IDpbbmFtZT1QYWxib2xza3ldOkonaW5zY3JpcyBjZXR0ZSB2aWN0b2lyZSDDoCBsJ29yZGluYXRldXIuLi4=
+        - 17, 37 :[name=Palbolsky]:I'll add this victory to the computer...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2058,20 +2040,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 38 :[name=Palbolsky]:Que vois-je ? \N[1] a vaincu tous mes apprentis
-          ?
+        - 17, 38 :[name=Palbolsky]:Oh, what do I see? \N[1] won against all my apprentices?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDM5IDpbbmFtZT1QYWxib2xza3ldOk1lc2RhbWVzIGV0IG1lc3NpZXVycywgbGUgbW9tZW50IHF1ZSB2b3VzIGF0dGVuZGlleiB0b3VzIGVzdCBhcnJpdsOpICE=
+        - 17, 39 :[name=Palbolsky]:Ladies and gentlemen, the moment you've all been
+          waiting for is here!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQwIDpbbmFtZT1QYWxib2xza3ldOlVuIGNoYWxsZW5nZXIgYSBkw6libG9xdcOpIGxlIGRyb2l0IGRlIG1lIGNvbWJhdHRyZSAhIFJlc3RleiBkYW5zIGxlcyBlbnZpcm9ucyBwb3VyIGFzc2lzdGVyIMOgIHVuIG1hdGNoIGQnYW50aG9sb2dpZSAh
+        - 17, 40 :[name=Palbolsky]:A new challenger unlocked the right to fight me!
+          Stick around to assist to a match made in history!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2093,8 +2074,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQxIDpbbmFtZT1QYWxib2xza3ldOk9oICEgSWwgbmUgcmVzdGUgcGx1cyBxdSd1biBzZXVsIGNvbWJhdCDDoCBnYWduZXIgcG91ciBcTlsxXSBhdmFudCBkZSBwb3V2b2lyIG0nYWZmcm9udGVyICEgVGllbnMgbGUgY291cCwgZ3JhaW5lIGRlIFxmW2NoYW1waW9ubmXCp2NoYW1waW9uXSAh
+        - 17, 41 :[name=Palbolsky]:Oh! There's only one battle left for \N[1] before
+          they can battle me! Keep it up, champion in the making!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2107,8 +2088,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQyIDpbbmFtZT1QYWxib2xza3ldOk9oICEgSWwgbmUgcmVzdGUgcXVlIFxWWzI2XSBjb21iYXRzIMOgIGdhZ25lciBwb3VyIFxOWzFdIGF2YW50IGRlIHBvdXZvaXIgbSdhZmZyb250ZXIgIQ==
+        - 17, 42 :[name=Palbolsky]:Oh! There's still \V[26] battles left to win for
+          \N[1] before they can challenge me!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2137,8 +2118,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQzIDpbbmFtZT1QYWxib2xza3ldOkxhIHZpY3RvaXJlIHJldmllbnQgw6AgW05BTUVdICE=
+        - 17, 43 :[name=Palbolsky]:Victory goes to [NAME]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2151,14 +2131,14 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQ0IDpbbmFtZT1QYWxib2xza3ldOkVuIHRvdXQgY2FzLCBjZSBmdXQgdW4gbWF0Y2ggZCd1bmUgZ3JhbmRlIGludGVuc2l0w6ksIGonZXNww6hyZSBxdWUgdm91cyBsJ2F2ZXogcmVzc2VudGkgYXVzc2kgZGFucyBsZXMgZ3JhZGlucyAh
+        - 17, 44 :[name=Palbolsky]:In any case, it was a match of great intensity,
+          I hope you felt it all the way to the stands!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQ1IDpbbmFtZT1QYWxib2xza3ldOkNoYWxsZW5nZXJzLCBqZSB2YWlzIHNvaWduZXIgdm9zIFBva8OpbW9uIHBvdXIgcXVlIHZvdXMgbidheWV6IHBhcyDDoCBhbGxlciBhdSBDZW50cmUgUG9rw6ltb24u
+        - 17, 45 :[name=Palbolsky]:Challengers, I'll heal your Pokémon so you don't
+          have to go to the Pokémon Center.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2191,14 +2171,14 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQ2IDpbbmFtZT1QYWxib2xza3ldOk4naMOpc2l0ZXogcGFzIMOgIHJldmVuaXIgdm91cyBiYXR0cmUgc2kgdm91cyBsZSB2b3VsZXosIGMnZXN0IHRvdWpvdXJzIHVuIHBsYWlzaXIgZCdhc3Npc3RlciDDoCBkZXMgbWF0Y2hzIGF1c3NpIHBhc3Npb25uYW50cyAh
+        - 17, 46 :[name=Palbolsky]:Don't hesitate to come battle again if you want,
+          it's always a pleasure to assist to such passionating battles!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQ3IDpbbmFtZT1QYWxib2xza3ldOkNoZXJzIHNwZWN0YXRldXJzLCBtZXJjaSBkJ8OqdHJlIHZlbnVzLCBldCDDoCBsYSBwcm9jaGFpbmUgIQ==
+        - 17, 47 :[name=Palbolsky]:Dear spectators, thanks for coming, and see you
+          all next time!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2461,38 +2441,34 @@ events:
         code: 241
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQ4IDpbbmFtZT1QYWxib2xza3ldOkJpZW52ZW51ZSDDoCB0b3VzIGNoZXJzIHNwZWN0YXRldXJzICE=
+        - 17, 48 :[name=Palbolsky]:Welcome to you all, dear spectators!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDQ5IDpbbmFtZT1QYWxib2xza3ldOkNlIGNvbWJhdCBzZXJhIHVuIGNvbWJhdCBkdW8sIGF2ZWMgYXVjdW5lIGxpbWl0ZSBlbiBub21icmUgZGUgUG9rw6ltb24gIQ==
+        - 17, 49 :[name=Palbolsky]:This battle will be a duo battle, with no limit
+          in the number of usable Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDUwIDpbbmFtZT1QYWxib2xza3ldOsOAIG1hIGdhdWNoZSwgbGEgdGVycmV1ciBkZXMgdmFndWVzLCBsJ2ludmluY2libGUgYXJwZW50ZXVyIGRlcyA3IG1lcnMgOiBbQ0xBU1NdIFtOQU1FXSAh
+        - '17, 50 :[name=Palbolsky]:On my left, the terror of the waves, the invincible
+          surveyor of the 7 seas: [CLASS] [NAME]!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDUxIDpbbmFtZT1QYWxib2xza3ldOsOAIG1hIGRyb2l0ZSwgXGZbY2VsbGXCp2NlbHVpXSBxdWkgbWV0dHJhIHBldXQtw6p0cmUgZmluIMOgIHNvbiBvZHlzc8OpZS4uLg==
+        - 17, 51 :[name=Palbolsky]:On my right, the one who might end their odyssey...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDUyIDpbbmFtZT1QYWxib2xza3ldOlxOWzFdIFxmW2xhwqdsZV0gTWFrZXIgIQ==
+        - 17, 52 :[name=Palbolsky]:\N[1] the Maker!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 53 :[name=Palbolsky]:Sans plus attendre, c'est l'heure du coooooombat
-          !
+        - 17, 53 :[name=Palbolsky]:Without further ado, it's time for the baaaaattleeeeeeeeee!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2502,8 +2478,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDU0IDpbbmFtZT1bTkFNRV1dOlByw6lwYXJlIHRvaSwgdGVzIGxhcm1lcyB2b250IGNvdWxlci4=
+        - 17, 54 :[name=[NAME]]:Prepare yourself, your tears are going to flow.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2585,7 +2560,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 55 :[name=Palbolsky]:Et c'est une victoire pour \N[1] !
+        - 17, 55 :[name=Palbolsky]:Victory goes to \N[1]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2596,8 +2571,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDU2IDpbbmFtZT1QYWxib2xza3ldOkonaW5zY3JpcyBjZXR0ZSB2aWN0b2lyZSDDoCBsJ29yZGluYXRldXIuLi4=
+        - 17, 56 :[name=Palbolsky]:I'll add this victory to the computer...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2651,20 +2625,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 57 :[name=Palbolsky]:Que vois-je ? \N[1] a vaincu tous mes apprentis
-          ?
+        - 17, 57 :[name=Palbolsky]:Oh, what do I see? \N[1] won against all my apprentices?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDU4IDpbbmFtZT1QYWxib2xza3ldOk1lc2RhbWVzIGV0IG1lc3NpZXVycywgbGUgbW9tZW50IHF1ZSB2b3VzIGF0dGVuZGlleiB0b3VzIGVzdCBhcnJpdsOpICE=
+        - 17, 58 :[name=Palbolsky]:Ladies and gentlemen, the moment you've all been
+          waiting for is here!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDU5IDpbbmFtZT1QYWxib2xza3ldOlVuIGNoYWxsZW5nZXIgYSBkw6libG9xdcOpIGxlIGRyb2l0IGRlIG1lIGNvbWJhdHRyZSAhIFJlc3RleiBkYW5zIGxlcyBlbnZpcm9ucyBwb3VyIGFzc2lzdGVyIMOgIHVuIG1hdGNoIGQnYW50aG9sb2dpZSAh
+        - 17, 59 :[name=Palbolsky]:A new challenger unlocked the right to fight me!
+          Stick around to assist to a match made in history!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2686,8 +2659,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDYwIDpbbmFtZT1QYWxib2xza3ldOk9oICEgSWwgbmUgcmVzdGUgcGx1cyBxdSd1biBzZXVsIGNvbWJhdCDDoCBnYWduZXIgcG91ciBcTlsxXSBhdmFudCBkZSBwb3V2b2lyIG0nYWZmcm9udGVyICEgVGllbnMgbGUgY291cCwgZ3JhaW5lIGRlIFxmW2NoYW1waW9ubmXCp2NoYW1waW9uXSAh
+        - 17, 60 :[name=Palbolsky]:Oh! There's only one battle left for \N[1] before
+          they can battle me! Keep it up, champion in the making!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2700,8 +2673,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDYxIDpbbmFtZT1QYWxib2xza3ldOk9oICEgSWwgbmUgcmVzdGUgcXVlIFxWWzI2XSBjb21iYXRzIMOgIGdhZ25lciBwb3VyIFxOWzFdIGF2YW50IGRlIHBvdXZvaXIgbSdhZmZyb250ZXIgIQ==
+        - 17, 61 :[name=Palbolsky]:Oh! There's still \V[26] battles left to win for
+          \N[1] before they can challenge me!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2730,8 +2703,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDYyIDpbbmFtZT1QYWxib2xza3ldOkxhIHZpY3RvaXJlIHJldmllbnQgw6AgW05BTUVdICE=
+        - 17, 62 :[name=Palbolsky]:Victory goes to [NAME]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2744,14 +2716,14 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDYzIDpbbmFtZT1QYWxib2xza3ldOkVuIHRvdXQgY2FzLCBjZSBmdXQgdW4gbWF0Y2ggZCd1bmUgZ3JhbmRlIGludGVuc2l0w6ksIGonZXNww6hyZSBxdWUgdm91cyBsJ2F2ZXogcmVzc2VudGkgYXVzc2kgZGFucyBsZXMgZ3JhZGlucyAh
+        - 17, 63 :[name=Palbolsky]:In any case, it was a match of great intensity,
+          I hope you felt it all the way to the stands!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDY0IDpbbmFtZT1QYWxib2xza3ldOkNoYWxsZW5nZXJzLCBqZSB2YWlzIHNvaWduZXIgdm9zIFBva8OpbW9uIHBvdXIgcXVlIHZvdXMgbidheWV6IHBhcyDDoCBhbGxlciBhdSBDZW50cmUgUG9rw6ltb24u
+        - 17, 64 :[name=Palbolsky]:Challengers, I'll heal your Pokémon so you don't
+          have to go to the Pokémon Center.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2784,14 +2756,14 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDY1IDpbbmFtZT1QYWxib2xza3ldOk4naMOpc2l0ZXogcGFzIMOgIHJldmVuaXIgdm91cyBiYXR0cmUgc2kgdm91cyBsZSB2b3VsZXosIGMnZXN0IHRvdWpvdXJzIHVuIHBsYWlzaXIgZCdhc3Npc3RlciDDoCBkZXMgbWF0Y2hzIGF1c3NpIHBhc3Npb25uYW50cyAh
+        - 17, 65 :[name=Palbolsky]:Don't hesitate to come battle again if you want,
+          it's always a pleasure to assist to such passionating battles!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDY2IDpbbmFtZT1QYWxib2xza3ldOkNoZXJzIHNwZWN0YXRldXJzLCBtZXJjaSBkJ8OqdHJlIHZlbnVzLCBldCDDoCBsYSBwcm9jaGFpbmUgIQ==
+        - 17, 66 :[name=Palbolsky]:Dear spectators, thanks for coming, and see you
+          all next time!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3091,41 +3063,40 @@ events:
         code: 241
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDY3IDpbbmFtZT1QYWxib2xza3ldOkJpZW52ZW51ZSDDoCB0b3VzIGNoZXJzIHNwZWN0YXRldXJzICE=
+        - 17, 67 :[name=Palbolsky]:Welcome to you all, dear spectators!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDY4IDpbbmFtZT1QYWxib2xza3ldOkNlIGNvbWJhdCBzZXJhIHVuIGNvbWJhdCBzZXVsIGNvbnRyZSBkZXV4LCBhdmVjIGF1Y3VuZSBsaW1pdGF0aW9uIGRlIFBva8OpbW9uICE=
+        - 17, 68 :[name=Palbolsky]:This battle will be a one versus two, with no limit
+          in the number of usable Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDY5IDpbbmFtZT1QYWxib2xza3ldOsOAIG1hIGdhdWNoZSwgMiBjb21iYXR0YW50cyBwcsOqdHMgw6AgZW4gZMOpY291ZHJlIGF2ZWMgbGV1cnMgc3RyYXTDqWdpZXMgY29vcMOpcmF0aXZlcyAh
+        - 17, 69 :[name=Palbolsky]:On my left, 2 fighters ready for action with their
+          cooperative strategies!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 70 :[name=Palbolsky]:[CLASS1] [NAME1] et [CLASS2] [NAME2] !
+        - 17, 70 :[name=Palbolsky]:[CLASS1] [NAME1] and [CLASS2] [NAME2]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDcxIDpbbmFtZT1QYWxib2xza3ldOsOAIG1hIGRyb2l0ZSwgdW5cRSBcZlt2YWxldXJldXNlIGRyZXNzZXVzZcKndmFsZXVyZXV4IGRyZXNzZXVyXSwgcXVpIHZhIHRvdXQgZG9ubmVyIHBvdXIgc29ydGlyIFxmW3ZpY3RvcmlldXNlwqd2aWN0b3JpZXV4XSBkZSBjZXR0ZSBhZmZyb250ZW1lbnQuLi4=
+        - 17, 71 :[name=Palbolsky]:On my right, a courageous trainer who will give
+          their all to leave this battle victorious!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 72 :[name=Palbolsky]:Accueillons... \N[1] !
+        - 17, 72 :[name=Palbolsky]:Let's welcome... \N[1]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 73 :[name=Palbolsky]:Que le match commence !
+        - 17, 73 :[name=Palbolsky]:Let the battle begin!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3135,14 +3106,13 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDc0IDpbbmFtZT1bTkFNRTFdXTpFc3NhaWUgZGUgbmUgcGFzIGFiw65tZXIgbWEgdGVudWUgamUgdGUgcHJpZS4=
+        - 17, 74 :[name=[NAME1]]:Please try to not damage my dress please.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDc1IDpbbmFtZT1bTkFNRTJdXTpNb24gcsOqdmUgZXN0IHF1ZSB0b3VzIGFkbWV0dGVudCBsYSBzcGxlbmRldXIgZGVzIFBva8OpbW9uIEbDqWUgIQ==
+        - 17, 75 :[name=[NAME2]]:My dream is that everyone admit the splendor of the
+          Fairy Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3234,7 +3204,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 76 :[name=Palbolsky]:Et c'est une victoire pour \N[1] !
+        - 17, 76 :[name=Palbolsky]:Victory goes to \N[1]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3245,8 +3215,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDc3IDpbbmFtZT1QYWxib2xza3ldOkonaW5zY3JpcyBjZXR0ZSB2aWN0b2lyZSDDoCBsJ29yZGluYXRldXIuLi4=
+        - 17, 77 :[name=Palbolsky]:I'll add this victory to the computer...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3300,20 +3269,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 78 :[name=Palbolsky]:Que vois-je ? \N[1] a vaincu tous mes apprentis
-          ?
+        - 17, 78 :[name=Palbolsky]:Oh, what do I see? \N[1] won against all my apprentices?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDc5IDpbbmFtZT1QYWxib2xza3ldOk1lc2RhbWVzIGV0IG1lc3NpZXVycywgbGUgbW9tZW50IHF1ZSB2b3VzIGF0dGVuZGlleiB0b3VzIGVzdCBhcnJpdsOpICE=
+        - 17, 79 :[name=Palbolsky]:Ladies and gentlemen, the moment you've all been
+          waiting for is here!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDgwIDpbbmFtZT1QYWxib2xza3ldOlVuIGNoYWxsZW5nZXIgYSBkw6libG9xdcOpIGxlIGRyb2l0IGRlIG1lIGNvbWJhdHRyZSAhIFJlc3RleiBkYW5zIGxlcyBlbnZpcm9ucyBwb3VyIGFzc2lzdGVyIMOgIHVuIG1hdGNoIGQnYW50aG9sb2dpZSAh
+        - 17, 80 :[name=Palbolsky]:A new challenger unlocked the right to fight me!
+          Stick around to assist to a match made in history!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3335,8 +3303,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDgxIDpbbmFtZT1QYWxib2xza3ldOk9oICEgSWwgbmUgcmVzdGUgcGx1cyBxdSd1biBzZXVsIGNvbWJhdCDDoCBnYWduZXIgcG91ciBcTlsxXSBhdmFudCBkZSBwb3V2b2lyIG0nYWZmcm9udGVyICEgVGllbnMgbGUgY291cCwgZ3JhaW5lIGRlIFxmW2NoYW1waW9ubmXCp2NoYW1waW9uXSAh
+        - 17, 81 :[name=Palbolsky]:Oh! There's only one battle left for \N[1] before
+          they can battle me! Keep it up, champion in the making!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3349,8 +3317,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDgyIDpbbmFtZT1QYWxib2xza3ldOk9oICEgSWwgbmUgcmVzdGUgcXVlIFxWWzI2XSBjb21iYXRzIMOgIGdhZ25lciBwb3VyIFxOWzFdIGF2YW50IGRlIHBvdXZvaXIgbSdhZmZyb250ZXIgIQ==
+        - 17, 82 :[name=Palbolsky]:Oh! There's still \V[26] battles left to win for
+          \N[1] before they can challenge me!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3379,8 +3347,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDgzIDpbbmFtZT1QYWxib2xza3ldOkxhIHZpY3RvaXJlIHJldmllbnQgw6AgW05BTUUxXSBldCBbTkFNRTJdICEgQyfDqXRhaXQgdW4gbWF0Y2ggY29tcGxleGUgZXQgXE5bMV0gbidhIHBhcyBkw6ltw6lyaXTDqSBwb3VyIGF1dGFudCAh
+        - 17, 83 :[name=Palbolsky]:Victory goes to [NAME1] and [NAME2]! This was a
+          really difficult match and \N[1] didn't disappoint us at any point!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3393,14 +3361,14 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDg0IDpbbmFtZT1QYWxib2xza3ldOkVuIHRvdXQgY2FzLCBjZSBmdXQgdW4gbWF0Y2ggZCd1bmUgZ3JhbmRlIGludGVuc2l0w6ksIGonZXNww6hyZSBxdWUgdm91cyBsJ2F2ZXogcmVzc2VudGkgYXVzc2kgZGFucyBsZXMgZ3JhZGlucyAh
+        - 17, 84 :[name=Palbolsky]:In any case, it was a match of great intensity,
+          I hope you felt it all the way to the stands!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDg1IDpbbmFtZT1QYWxib2xza3ldOkNoYWxsZW5nZXJzLCBqZSB2YWlzIHNvaWduZXIgdm9zIFBva8OpbW9uIHBvdXIgcXVlIHZvdXMgbidheWV6IHBhcyDDoCBhbGxlciBhdSBDZW50cmUgUG9rw6ltb24u
+        - 17, 85 :[name=Palbolsky]:Challengers, I'll heal your Pokémon so you don't
+          have to go to the Pokémon Center.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3433,14 +3401,14 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDg2IDpbbmFtZT1QYWxib2xza3ldOk4naMOpc2l0ZXogcGFzIMOgIHJldmVuaXIgdm91cyBiYXR0cmUgc2kgdm91cyBsZSB2b3VsZXosIGMnZXN0IHRvdWpvdXJzIHVuIHBsYWlzaXIgZCdhc3Npc3RlciDDoCBkZXMgbWF0Y2hzIGF1c3NpIHBhc3Npb25uYW50cyAh
+        - 17, 86 :[name=Palbolsky]:Don't hesitate to come battle again if you want,
+          it's always a pleasure to assist to such passionating battles!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDg3IDpbbmFtZT1QYWxib2xza3ldOkNoZXJzIHNwZWN0YXRldXJzLCBtZXJjaSBkJ8OqdHJlIHZlbnVzLCBldCDDoCBsYSBwcm9jaGFpbmUgIQ==
+        - 17, 87 :[name=Palbolsky]:Dear spectators, thanks for coming, and see you
+          all next time!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3740,48 +3708,46 @@ events:
         code: 241
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDg4IDpbbmFtZT1QYWxib2xza3ldOkJpZW52ZW51ZSDDoCB0b3VzIGNoZXJzIHNwZWN0YXRldXJzICE=
+        - 17, 88 :[name=Palbolsky]:Welcome to you all, dear spectators!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDg5IDpbbmFtZT1QYWxib2xza3ldOkNlIGNvbWJhdCBzZXJhIHVuIGNvbWJhdCBlbiBkZXV4IGNvbnRyZSB1biwgYXZlYyBhdWN1bmUgbGltaXRlIGVuIG5vbWJyZSBkZSBQb2vDqW1vbiAh
+        - 17, 89 :[name=Palbolsky]:This battle will be a two versus one, with no limit
+          in the number of usable Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDkwIDpbbmFtZT1QYWxib2xza3ldOsOAIG1hIGdhdWNoZSwgdm91cyBwb3VycmV6IHkgcmV0cm91dmVyIFtDTEFTUzFdIFtOQU1FMV0sIHF1aSBkZXZyYSBzZSBiYXR0cmUgc2V1bCBjb250cmUgbCdhZHZlcnNpdMOpICE=
+        - 17, 90 :[name=Palbolsky]:On my left, you'll find [CLASS1] [NAME1], who's
+          going to battle alone against adversity!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDkxIDpbbmFtZT1QYWxib2xza3ldOsOAIG1hIGRyb2l0ZSwgXE5bMV0sIG1haXMgcGFzIHNldWxcRSBjZXR0ZSBmb2lzICE=
+        - 17, 91 :[name=Palbolsky]:On my right, \N[1], but not alone this time!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 92 :[name=Palbolsky]:Je vous prie de bien accueillir... [NAME2] !
+        - 17, 92 :[name=Palbolsky]:I ask you to welcome... [NAME2]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDkzIDpbbmFtZT1QYWxib2xza3ldOlBldGl0ZSByw6hnbGUgc3VwcGzDqW1lbnRhaXJlIHBvdXIgcmVzdGVyIMOpcXVpdGFibGUgOiBcTlsxXSBwZXJkcmEgc2kgc29uIMOpcXVpcGUgZXN0IG1pc2UgS08sIGV0IGNlIG3Dqm1lIHNpIGNlbGxlIGRlIFtOQU1FMl0gZXN0IGVuY29yZSBhcHRlIMOgIGNvbWJhdHRyZSAh
+        - '17, 93 :[name=Palbolsky]:For this battle to remain fair, here''s a little
+          rule: \N[1] will lose if their team is unable to battle, even if [NAME2]''s
+          is still able to!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDk0IDpbbmFtZT1QYWxib2xza3ldOkRyZXNzZXVycywgw6p0ZXMtdm91cyBwcsOqdHMgPw==
+        - 17, 94 :[name=Palbolsky]:Trainers, are you ready?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 95 :[name=Palbolsky]:C'est parti !
+        - 17, 95 :[name=Palbolsky]:Begin!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3791,8 +3757,8 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDk2IDpbbmFtZT1bTkFNRTFdXTpTJ2lsIHZvdXMgcGxhw650LCBuZSB2b3VzIHJldGVuZXogcGFzLi4uIEplIHZldXggdm91cyB2YWluY3JlIMOgIHZvdHJlIG1heGltdW0u
+        - 17, 96 :[name=[NAME1]]:Please, don't hold back... I want to best you at
+          your maximum.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3884,7 +3850,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 97 :[name=Palbolsky]:Et c'est une victoire pour \N[1] et [NAME2] !
+        - 17, 97 :[name=Palbolsky]:Victory goes to \N[1] and [NAME2]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3895,8 +3861,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDk4IDpbbmFtZT1QYWxib2xza3ldOkonaW5zY3JpcyBjZXR0ZSB2aWN0b2lyZSDDoCBsJ29yZGluYXRldXIuLi4=
+        - 17, 98 :[name=Palbolsky]:I'll add this victory to the computer...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3950,20 +3915,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 99 :[name=Palbolsky]:Que vois-je ? \N[1] a vaincu tous mes apprentis
-          ?
+        - 17, 99 :[name=Palbolsky]:Oh, what do I see? \N[1] won against all my apprentices?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwMCA6W25hbWU9UGFsYm9sc2t5XTpNZXNkYW1lcyBldCBtZXNzaWV1cnMsIGxlIG1vbWVudCBxdWUgdm91cyBhdHRlbmRpZXogdG91cyBlc3QgYXJyaXbDqSAh
+        - 17, 100 :[name=Palbolsky]:Ladies and gentlemen, the moment you've all been
+          waiting for is here!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwMSA6W25hbWU9UGFsYm9sc2t5XTpVbiBjaGFsbGVuZ2VyIGEgZMOpYmxvcXXDqSBsZSBkcm9pdCBkZSBtZSBjb21iYXR0cmUgISBSZXN0ZXogZGFucyBsZXMgZW52aXJvbnMgcG91ciBhc3Npc3RlciDDoCB1biBtYXRjaCBkJ2FudGhvbG9naWUgIQ==
+        - 17, 101 :[name=Palbolsky]:A new challenger unlocked the right to fight me!
+          Stick around to assist to a match made in history!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3985,8 +3949,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwMiA6W25hbWU9UGFsYm9sc2t5XTpPaCAhIElsIG5lIHJlc3RlIHBsdXMgcXUndW4gc2V1bCBjb21iYXQgw6AgZ2FnbmVyIHBvdXIgXE5bMV0gYXZhbnQgZGUgcG91dm9pciBtJ2FmZnJvbnRlciAhIFRpZW5zIGxlIGNvdXAsIGdyYWluZSBkZSBcZltjaGFtcGlvbm5lwqdjaGFtcGlvbl0gIQ==
+        - 17, 102 :[name=Palbolsky]:Oh! There's only one battle left for \N[1] before
+          they can battle me! Keep it up, champion in the making!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3999,8 +3963,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwMyA6W25hbWU9UGFsYm9sc2t5XTpPaCAhIElsIG5lIHJlc3RlIHF1ZSBcVlsyNl0gY29tYmF0cyDDoCBnYWduZXIgcG91ciBcTlsxXSBhdmFudCBkZSBwb3V2b2lyIG0nYWZmcm9udGVyICE=
+        - 17, 103 :[name=Palbolsky]:Oh! There's still \V[26] battles left to win for
+          \N[1] before they can challenge me!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4029,8 +3993,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwNCA6W25hbWU9UGFsYm9sc2t5XTpMYSB2aWN0b2lyZSByZXZpZW50IMOgIFtOQU1FMV0gcXVpIGEgcsOpdXNzaSDDoCBzJ2VuIHNvcnRpciwgY29udHJlIHRvdXRlIGF0dGVudGUgIQ==
+        - 17, 104 :[name=Palbolsky]:Victory goes to [NAME1] who managed to come out
+          on top against all the odds!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4043,14 +4007,14 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwNSA6W25hbWU9UGFsYm9sc2t5XTpFbiB0b3V0IGNhcywgY2UgZnV0IHVuIG1hdGNoIGQndW5lIGdyYW5kZSBpbnRlbnNpdMOpLCBqJ2VzcMOocmUgcXVlIHZvdXMgbCdhdmV6IHJlc3NlbnRpIGF1c3NpIGRhbnMgbGVzIGdyYWRpbnMgIQ==
+        - 17, 105 :[name=Palbolsky]:In any case, it was a match of great intensity,
+          I hope you felt it all the way to the stands!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwNiA6W25hbWU9UGFsYm9sc2t5XTpDaGFsbGVuZ2VycywgamUgdmFpcyBzb2lnbmVyIHZvcyBQb2vDqW1vbiBwb3VyIHF1ZSB2b3VzIG4nYXlleiBwYXMgw6AgYWxsZXIgYXUgQ2VudHJlIFBva8OpbW9uLg==
+        - 17, 106 :[name=Palbolsky]:Challengers, I'll heal your Pokémon so you don't
+          have to go to the Pokémon Center.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4083,14 +4047,14 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwNyA6W25hbWU9UGFsYm9sc2t5XTpOJ2jDqXNpdGV6IHBhcyDDoCByZXZlbmlyIHZvdXMgYmF0dHJlIHNpIHZvdXMgbGUgdm91bGV6LCBjJ2VzdCB0b3Vqb3VycyB1biBwbGFpc2lyIGQnYXNzaXN0ZXIgw6AgZGVzIG1hdGNocyBhdXNzaSBwYXNzaW9ubmFudHMgIQ==
+        - 17, 107 :[name=Palbolsky]:Don't hesitate to come battle again if you want,
+          it's always a pleasure to assist to such passionating battles!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwOCA6W25hbWU9UGFsYm9sc2t5XTpDaGVycyBzcGVjdGF0ZXVycywgbWVyY2kgZCfDqnRyZSB2ZW51cywgZXQgw6AgbGEgcHJvY2hhaW5lICE=
+        - 17, 108 :[name=Palbolsky]:Dear spectators, thanks for coming, and see you
+          all next time!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4457,49 +4421,47 @@ events:
         code: 241
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEwOSA6W25hbWU9UGFsYm9sc2t5XTpCaWVudmVudWUgw6AgdG91cyBjaGVycyBzcGVjdGF0ZXVycyAh
+        - 17, 109 :[name=Palbolsky]:Welcome to you all, dear spectators!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDExMCA6W25hbWU9UGFsYm9sc2t5XTpDZSBjb21iYXQgc2VyYSB1biBjb21iYXQgZGV1eCBjb250cmUgZGV1eCwgYXZlYyBhdWN1bmUgbGltaXRlIGVuIG5vbWJyZSBkZSBQb2vDqW1vbiAh
+        - 17, 110 :[name=Palbolsky]:This battle will be a two versus two, with no
+          limit in the number of usable Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDExMSA6W25hbWU9UGFsYm9sc2t5XTrDgCBtYSBnYXVjaGUsIHZvdXMgcG91cnJleiB5IHJldHJvdXZlciBbQ0xBU1MxXSBbTkFNRTFdIGV0IFtDTEFTUzJdIFtOQU1FMl0sIGxlIGR1byBkZSBjaG9jIHRvdWpvdXJzIMOgIGwnaGV1cmUgcG91ciBsJ2FjdHVhbGl0w6kgIQ==
+        - 17, 111 :[name=Palbolsky]:On my left, you'll find [CLASS1] [NAME1] and [CLASS2]
+          [NAME2], the power duo always on track for the newest news!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDExMiA6W25hbWU9UGFsYm9sc2t5XTrDgCBtYSBkcm9pdGUsIHVuIGF1dHJlIGR1byBwcsOqdCDDoCBmYWlyZSBkZXMgw6l0aW5jZWxsZXMuLi4gXE5bMV0gZXQgW05BTUUzXSAh
+        - 17, 112 :[name=Palbolsky]:On my right, another duo ready to make some sparks...
+          \N[1] and [NAME3]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDExMyA6W25hbWU9UGFsYm9sc2t5XTpQb3VyIGNlIGNvbWJhdCwgbGEgdmljdG9pcmUgcmV2aWVuZHJhIMOgIGwnw6lxdWlwZSBxdWkgYXVyYSBhdSBtb2lucyB1biBQb2vDqW1vbiBlbmNvcmUgZW4gw6l0YXQgZGUgY29tYmF0dHJlICE=
+        - 17, 113 :[name=Palbolsky]:For this battle, the victory will belong to the
+          team with at least one Pokémon still able to fight!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDExNCA6W25hbWU9UGFsYm9sc2t5XTpDZSBxdWkgdmV1dCBkb25jIGRpcmUsIFxOWzFdLCBxdWUgc2kgdG9uIMOpcXVpcGUgZXN0IG1pc2UgS08sIFtOQU1FM10gcG91cnJhIHRlbnRlciBkZSBnYWduZXIgbWFsZ3LDqSB0b3V0ICE=
+        - 17, 114 :[name=Palbolsky]:This means that, if \N[1]'s team is wiped out
+          but [NAME3]'s is still able to fight, they will win nonetheless!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDExNSA6W25hbWU9UGFsYm9sc2t5XTpBaS1qZSDDqXTDqSBzdWZmaXNhbW1lbnQgY2xhaXIgPw==
+        - 17, 115 :[name=Palbolsky]:Was I clear enough?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 116 :[name=Palbolsky]:Si oui, commencez !
+        - 17, 116 :[name=Palbolsky]:If yes, then begin!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4509,14 +4471,13 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDExNyA6W25hbWU9W05BTUUxXV06RmFpc29ucyB2aXRlLCBqJ2FpIHVuIHRyYWluIMOgIHByZW5kcmUu
+        - 17, 117 :[name=[NAME1]]:Let's make this quick, I have a train to take.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDExOCA6W25hbWU9W05BTUUyXV06TGVzIHRyYWlucyBlbiByZXRhcmQgw6dhIHZhIGJpZW4gZGV1eCBtaW51dGVzLi4uIFZvdXMgYXVyaWV6IHBhcyB1biBzY29vcCBwb3VyIG1vaSA/
+        - 17, 118 :[name=[NAME2]]:Delayed trains don't sell well, don't you have a
+          scoop for me?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4625,7 +4586,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 119 :[name=Palbolsky]:Et c'est une victoire pour \N[1] et [NAME3] !
+        - 17, 119 :[name=Palbolsky]:Victory goes to \N[1] and [NAME3]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4636,8 +4597,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEyMCA6W25hbWU9UGFsYm9sc2t5XTpKJ2luc2NyaXMgY2V0dGUgdmljdG9pcmUgw6AgbCdvcmRpbmF0ZXVyLi4u
+        - 17, 120 :[name=Palbolsky]:I'll add this victory to the computer...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4691,20 +4651,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 121 :[name=Palbolsky]:Que vois-je ? \N[1] a vaincu tous mes apprentis
-          ?
+        - 17, 121 :[name=Palbolsky]:Oh, what do I see? \N[1] won against all my apprentices?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEyMiA6W25hbWU9UGFsYm9sc2t5XTpNZXNkYW1lcyBldCBtZXNzaWV1cnMsIGxlIG1vbWVudCBxdWUgdm91cyBhdHRlbmRpZXogdG91cyBlc3QgYXJyaXbDqSAh
+        - 17, 122 :[name=Palbolsky]:Ladies and gentlemen, the moment you've all been
+          waiting for is here!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEyMyA6W25hbWU9UGFsYm9sc2t5XTpVbiBjaGFsbGVuZ2VyIGEgZMOpYmxvcXXDqSBsZSBkcm9pdCBkZSBtZSBjb21iYXR0cmUgISBSZXN0ZXogZGFucyBsZXMgZW52aXJvbnMgcG91ciBhc3Npc3RlciDDoCB1biBtYXRjaCBkJ2FudGhvbG9naWUgIQ==
+        - 17, 123 :[name=Palbolsky]:A new challenger unlocked the right to fight me!
+          Stick around to assist to a match made in history!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4726,8 +4685,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEyNCA6W25hbWU9UGFsYm9sc2t5XTpPaCAhIElsIG5lIHJlc3RlIHBsdXMgcXUndW4gc2V1bCBjb21iYXQgw6AgZ2FnbmVyIHBvdXIgXE5bMV0gYXZhbnQgZGUgcG91dm9pciBtJ2FmZnJvbnRlciAhIFRpZW5zIGxlIGNvdXAsIGdyYWluZSBkZSBcZltjaGFtcGlvbm5lwqdjaGFtcGlvbl0gIQ==
+        - 17, 124 :[name=Palbolsky]:Oh! There's only one battle left for \N[1] before
+          they can battle me! Keep it up, champion in the making!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4740,8 +4699,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEyNSA6W25hbWU9UGFsYm9sc2t5XTpPaCAhIElsIG5lIHJlc3RlIHF1ZSBcVlsyNl0gY29tYmF0cyDDoCBnYWduZXIgcG91ciBcTlsxXSBhdmFudCBkZSBwb3V2b2lyIG0nYWZmcm9udGVyICE=
+        - 17, 125 :[name=Palbolsky]:Oh! There's still \V[26] battles left to win for
+          \N[1] before they can challenge me!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4770,8 +4729,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEyNiA6W25hbWU9UGFsYm9sc2t5XTpMYSB2aWN0b2lyZSByZXZpZW50IMOgIFtOQU1FMV0gZXQgW05BTUUyXSAh
+        - 17, 126 :[name=Palbolsky]:The victory goes to [NAME1] and [NAME2]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4784,14 +4742,14 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEyNyA6W25hbWU9UGFsYm9sc2t5XTpFbiB0b3V0IGNhcywgY2UgZnV0IHVuIG1hdGNoIGQndW5lIGdyYW5kZSBpbnRlbnNpdMOpLCBqJ2VzcMOocmUgcXVlIHZvdXMgbCdhdmV6IHJlc3NlbnRpIGF1c3NpIGRhbnMgbGVzIGdyYWRpbnMgIQ==
+        - 17, 127 :[name=Palbolsky]:In any case, it was a match of great intensity,
+          I hope you felt it all the way to the stands!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEyOCA6W25hbWU9UGFsYm9sc2t5XTpDaGFsbGVuZ2VycywgamUgdmFpcyBzb2lnbmVyIHZvcyBQb2vDqW1vbiBwb3VyIHF1ZSB2b3VzIG4nYXlleiBwYXMgw6AgYWxsZXIgYXUgQ2VudHJlIFBva8OpbW9uLg==
+        - 17, 128 :[name=Palbolsky]:Challengers, I'll heal your Pokémon so you don't
+          have to go to the Pokémon Center.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4824,14 +4782,14 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEyOSA6W25hbWU9UGFsYm9sc2t5XTpOJ2jDqXNpdGV6IHBhcyDDoCByZXZlbmlyIHZvdXMgYmF0dHJlIHNpIHZvdXMgbGUgdm91bGV6LCBjJ2VzdCB0b3Vqb3VycyB1biBwbGFpc2lyIGQnYXNzaXN0ZXIgw6AgZGVzIG1hdGNocyBhdXNzaSBwYXNzaW9ubmFudHMgIQ==
+        - 17, 129 :[name=Palbolsky]:Don't hesitate to come battle again if you want,
+          it's always a pleasure to assist to such passionating battles!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEzMCA6W25hbWU9UGFsYm9sc2t5XTpDaGVycyBzcGVjdGF0ZXVycywgbWVyY2kgZCfDqnRyZSB2ZW51cywgZXQgw6AgbGEgcHJvY2hhaW5lICE=
+        - 17, 130 :[name=Palbolsky]:Dear spectators, thanks for coming, and see you
+          all next time!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5088,38 +5046,36 @@ events:
         code: 241
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEzMSA6W25hbWU9UGFsYm9sc2t5XTpCaWVudmVudWUgw6AgdG91cyBjaGVycyBzcGVjdGF0ZXVycyAh
+        - 17, 131 :[name=Palbolsky]:Welcome to you all, dear spectators!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEzMiA6W25hbWU9UGFsYm9sc2t5XTpDZSBjb21iYXQgc2VyYSB1biBjb21iYXQgc29sbyB1biBwZXUgcGFydGljdWxpZXIsIGNhciBjZWx1aS1jaSBhIMOpdMOpIGNyw6nDqSDDoCBsYSB2b2zDqWUgw6AgbCdhaWRlIGRlIHNjcmlwdHMgIQ==
+        - 17, 132 :[name=Palbolsky]:This battle is a bit particular solo battle, as
+          it was entirely created using scripts!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEzMyA6W25hbWU9UGFsYm9sc2t5XTpWb3VzIG5lIHZlcnJleiBwYXMgZGUgZGlmZsOpcmVuY2UgYXZlYyB1biBjb21iYXQgIm5vcm1hbCIsIG1haXMgc2FjaGV6IHF1ZSBjJ2VzdCB0b3V0IMOgIGZhaXQgcG9zc2libGUgZXQgcXUnaWxzIHBlcm1ldHRlbnQgZGUgZmFpcmUgYmllbiBwbHVzIGRlIGNob3NlcyAh
+        - 17, 133 :[name=Palbolsky]:You won't see any difference between with a "normal"
+          battle, but be aware that it's a thing and it allows you to make more things
+          than a regular battle!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEzNCA6W25hbWU9UGFsYm9sc2t5XTrDgCBtYSBnYXVjaGUsIHZvdXMgcG91cnJleiB5IHJldHJvdXZlciBbQ0xBU1NdIFtOQU1FXSwgdW5lIGRvY3RldXJlIGVuIHJlY2hlcmNoZSBpbmZvcm1hdGlxdWUgIQ==
+        - 17, 134 :[name=Palbolsky]:On my left, you'll find [CLASS] [NAME], a doctorate
+          in computer science!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEzNSA6W25hbWU9UGFsYm9sc2t5XTrDgCBtYSBkcm9pdGUsIFxOWzFdLCBwcsOqdFxFIMOgIGNvbWJhdHRyZSBsZXMgYnVncyBldCBsZXMgY3Jhc2hzICE=
+        - 17, 135 :[name=Palbolsky]:On my right, \N[1], ready to fight bugs and crashes!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEzNiA6W25hbWU9UGFsYm9sc2t5XTpDaGFsbGVuZ2VycywgYydlc3Qgw6Agdm91cyAh
+        - 17, 136 :[name=Palbolsky]:Challengers, it's up to you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5129,8 +5085,8 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 137 :[name=[NAME]]:L'analyse de tes patterns de combat me permettront
-          de te vaincre.
+        - 17, 137 :[name=[NAME]]:The analysis of your battle patterns will offer me
+          the way to beat you.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5221,8 +5177,9 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          YmkuYWRkX3BhcnR5KDEsIHBhcnR5LCAnTWFyaWUnLCAnU2NpZW50aWZpcXVlJywgJ2RwX3NjaWVudGlzdF9GJywgYmFnLCAyNTUsIDQsICIxNywgMjI1IEplIHQnYWkgcHLDqWRpdCBhdXNzaSBiaWVuIHF1ZSBsYSBsaXN0ZSBkZXMgbm9tYnJlcyBwcmVtaWVycy4iLCAiMTcsIDIyNiBUZXMgcGF0dGVybnMgc3VpdmVudCBsYSB0aMOpb3JpZSBkdSBjaGFvcywgamUgbmUgcG91dmFpcyByaWVuIGZhaXJlLi4uIik=
+        - bi.add_party(1, party, 'Marie', 'Scientifique', 'dp_scientist_F', bag, 255,
+          4, "17, 225 I predicted you as easily as I can predict the prime numbers.",
+          "17, 226 Your patterns follows the chaos theory, I couldn't do anything...")
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
@@ -5274,7 +5231,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 138 :[name=Palbolsky]:Et c'est une victoire pour \N[1] !
+        - 17, 138 :[name=Palbolsky]:Victory goes to \N[1]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5285,8 +5242,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDEzOSA6W25hbWU9UGFsYm9sc2t5XTpKJ2luc2NyaXMgY2V0dGUgdmljdG9pcmUgw6AgbCdvcmRpbmF0ZXVyLi4u
+        - 17, 139 :[name=Palbolsky]:I'll add this victory to the computer...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5340,20 +5296,19 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 140 :[name=Palbolsky]:Que vois-je ? \N[1] a vaincu tous mes apprentis
-          ?
+        - 17, 140 :[name=Palbolsky]:Oh, what do I see? \N[1] won against all my apprentices?
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE0MSA6W25hbWU9UGFsYm9sc2t5XTpNZXNkYW1lcyBldCBtZXNzaWV1cnMsIGxlIG1vbWVudCBxdWUgdm91cyBhdHRlbmRpZXogdG91cyBlc3QgYXJyaXbDqSAh
+        - 17, 141 :[name=Palbolsky]:Ladies and gentlemen, the moment you've all been
+          waiting for is here!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE0MiA6W25hbWU9UGFsYm9sc2t5XTpVbiBjaGFsbGVuZ2VyIGEgZMOpYmxvcXXDqSBsZSBkcm9pdCBkZSBtZSBjb21iYXR0cmUgISBSZXN0ZXogZGFucyBsZXMgZW52aXJvbnMgcG91ciBhc3Npc3RlciDDoCB1biBtYXRjaCBkJ2FudGhvbG9naWUgIQ==
+        - 17, 142 :[name=Palbolsky]:A new challenger unlocked the right to fight me!
+          Stick around to assist to a match made in history!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5375,8 +5330,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE0MyA6W25hbWU9UGFsYm9sc2t5XTpPaCAhIElsIG5lIHJlc3RlIHBsdXMgcXUndW4gc2V1bCBjb21iYXQgw6AgZ2FnbmVyIHBvdXIgXE5bMV0gYXZhbnQgZGUgcG91dm9pciBtJ2FmZnJvbnRlciAhIFRpZW5zIGxlIGNvdXAsIGdyYWluZSBkZSBcZltjaGFtcGlvbm5lwqdjaGFtcGlvbl0gIQ==
+        - 17, 143 :[name=Palbolsky]:Oh! There's only one battle left for \N[1] before
+          they can battle me! Keep it up, champion in the making!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5389,8 +5344,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE0NCA6W25hbWU9UGFsYm9sc2t5XTpPaCAhIElsIG5lIHJlc3RlIHF1ZSBcVlsyNl0gY29tYmF0cyDDoCBnYWduZXIgcG91ciBcTlsxXSBhdmFudCBkZSBwb3V2b2lyIG0nYWZmcm9udGVyICE=
+        - 17, 144 :[name=Palbolsky]:Oh! There's still \V[26] battles left to win for
+          \N[1] before they can challenge me!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5419,8 +5374,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE0NSA6W25hbWU9UGFsYm9sc2t5XTpMYSB2aWN0b2lyZSByZXZpZW50IMOgIFtOQU1FXSAh
+        - 17, 145 :[name=Palbolsky]:The victory goes to [NAME]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5433,14 +5387,14 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE0NiA6W25hbWU9UGFsYm9sc2t5XTpFbiB0b3V0IGNhcywgY2UgZnV0IHVuIG1hdGNoIGQndW5lIGdyYW5kZSBpbnRlbnNpdMOpLCBqJ2VzcMOocmUgcXVlIHZvdXMgbCdhdmV6IHJlc3NlbnRpIGF1c3NpIGRhbnMgbGVzIGdyYWRpbnMgIQ==
+        - 17, 146 :[name=Palbolsky]:In any case, it was a match of great intensity,
+          I hope you felt it all the way to the stands!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE0NyA6W25hbWU9UGFsYm9sc2t5XTpDaGFsbGVuZ2VycywgamUgdmFpcyBzb2lnbmVyIHZvcyBQb2vDqW1vbiBwb3VyIHF1ZSB2b3VzIG4nYXlleiBwYXMgw6AgYWxsZXIgYXUgQ2VudHJlIFBva8OpbW9uLg==
+        - 17, 147 :[name=Palbolsky]:Challengers, I'll heal your Pokémon so you don't
+          have to go to the Pokémon Center.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5473,14 +5427,14 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE0OCA6W25hbWU9UGFsYm9sc2t5XTpOJ2jDqXNpdGV6IHBhcyDDoCByZXZlbmlyIHZvdXMgYmF0dHJlIHNpIHZvdXMgbGUgdm91bGV6LCBjJ2VzdCB0b3Vqb3VycyB1biBwbGFpc2lyIGQnYXNzaXN0ZXIgw6AgZGVzIG1hdGNocyBhdXNzaSBwYXNzaW9ubmFudHMgIQ==
+        - 17, 148 :[name=Palbolsky]:Don't hesitate to come battle again if you want,
+          it's always a pleasure to assist to such passionating battles!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE0OSA6W25hbWU9UGFsYm9sc2t5XTpDaGVycyBzcGVjdGF0ZXVycywgbWVyY2kgZCfDqnRyZSB2ZW51cywgZXQgw6AgbGEgcHJvY2hhaW5lICE=
+        - 17, 149 :[name=Palbolsky]:Dear spectators, thanks for coming, and see you
+          all next time!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5929,14 +5883,13 @@ events:
         code: 241
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE1MCA6W25hbWU9UGFsYm9sc2t5XTpCaWVudmVudWUgw6AgdG91cyBjaGVycyBzcGVjdGF0ZXVycyAh
+        - 17, 150 :[name=Palbolsky]:Welcome to you all, dear spectators!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 151 :[name=Palbolsky]:Ce combat sera un combat d'anthologie... Pourquoi,
-          me demandez-vous ?
+        - 17, 151 :[name=Palbolsky]:This battle will be battle made in history...
+          Why, you'll ask me?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6055,13 +6008,13 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 152 :[name=Palbolsky]:Car aujourd'hui, je serai l'adversaire !
+        - 17, 152 :[name=Palbolsky]:Because today, I will be the opponent!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE1MyA6W25hbWU9UGFsYm9sc2t5XTpKZSBsYWlzc2UgZG9uYyBtYSBwbGFjZSBkJ2FyYml0cmUgw6AgW05BTUVdLCBjZWxsZSBxdWkgYSBnYWduw6kgbGUgcHLDqWPDqWRlbnQgdG91cm5vaSAhIFtOQU1FXSwgamUgdGUgbGFpc3NlIGxhIHBhcm9sZS4=
+        - 17, 153 :[name=Palbolsky]:I leave my referee title to [NAME], the victor
+          of the last tournament! [NAME], the mic is yours!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6086,37 +6039,35 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 154 :[name=[NAME]]:Merci Palbolsky, je ferai de mon mieux !
+        - 17, 154 :[name=[NAME]]:Thanks Palbolsky, I'll do my best!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE1NSA6W25hbWU9W05BTUVdXTpDaGVycyBzcGVjdGF0ZXVycywgbWVyY2kgZCfDqnRyZSB2ZW51cyBwb3VyIGFzc2lzdGVyIMOgIGNlIG1hdGNoICE=
+        - 17, 155 :[name=[NAME]]:Dear spectators, thanks for assisting this match!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE1NiA6W25hbWU9W05BTUVdXTrDgCBtYSBnYXVjaGUsIGxlIHNldWwsIGwndW5pcXVlLCBsZSBNYcOudHJlIGRlcyBEcmFnb25zIGRlIGwnw45sZSwgaidhaSBub21tw6kuLi4gUGFsYm9sc2t5ICE=
+        - '17, 156 :[name=[NAME]]:On my left, the one and only Master of the Island''s
+          Dragons: Palbolsky!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE1NyA6W25hbWU9W05BTUVdXTrDgCBtYSBkcm9pdGUsIFxmW2xhIGNoYWxsZW5nZXVzZcKnbGUgY2hhbGxlbmdlcl0gcXVpIGEgdmFpbGxhbW1lbnQgZ2FnbsOpIHNvbiB0aWNrZXQgcG91ciBjZSBtYXRjaC4uLg==
+        - 17, 157 :[name=[NAME]]:On my right, the challenger who valiantly gained
+          their ticket for this match...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE1OCA6W25hbWU9W05BTUVdXTpWYS10LVxmW2VsbGXCp2lsXSBkw6lmYWlyZSBQYWxib2xza3kgPyBOb3VzIGxlIHNhdXJvbnMgw6AgbCdpc3N1ZSBkZSBjZSBtYXRjaCwgbWFpcyBlbiBhdHRlbmRhbnQsIG1lcmNpIGQnYWNjbGFtZXIgXE5bMV0gIQ==
+        - 17, 158 :[name=[NAME]]:Will they defeat Palbolsky? We'll know that at the
+          end of this battle, but for now, please cheer \N[1]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE1OSA6W25hbWU9UGFsYm9sc2t5XTpEcmVzc2V1cnMsIGZhaXRlcyBjaGF1ZmZlciBjZXR0ZSBhcsOobmUgIQ==
+        - 17, 159 :[name=[NAME]]:Trainers, get this arena fired up!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6126,19 +6077,19 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE2MCA6W25hbWU9UGFsYm9sc2t5XTpFaCBiaWVuLCBhcHLDqHMgdW5lIHRlbGxlIHByw6lzZW50YXRpb24gb24gbmUgcGV1dCBxdWUgc2UgZG9ubmVyIMOgIGZvbmQu
+        - 17, 160 :[name=Palbolsky]:Well, after such a presentation we can give it
+          our all!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE2MSA6W25hbWU9UGFsYm9sc2t5XTpcTlsxXSwgdGVzIHLDqWNlbnRzIG1hdGNocyBvbnQgw6l0w6kgZXhjZXB0aW9ubmVscy4gSidhdHRlbmRzIGRlIHRvaSBxdWUgdHUgbWUgY29tYmF0dGVzIGF2ZWMgbGEgbcOqbWUgYXJkZXVyLCB2b2lyZSBwbHVzIGVuY29yZSAh
+        - 17, 161 :[name=Palbolsky]:\N[1], your recent battles were exceptional. I
+          expect you to fight me with the same ardor, or even more!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 162 :[name=Palbolsky]:Mais sache que je ne me laisserai pas faire !
+        - 17, 162 :[name=Palbolsky]:But know that I won't let you get me down!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6313,8 +6264,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE2MyA6W25hbWU9W05BTUVdXTpNZXNkYW1lcyBldCBtZXNzaWV1cnMsIGFwcsOocyBjZSBtYXRjaCBleGNlcHRpb25uZWwsIGplIHN1aXMgZmnDqHJlIGRlIHZvdXMgYW5ub25jZXIgbGEgdmljdG9pcmUgZGUuLi4gXE5bMV0gIQ==
+        - 17, 163 :[name=[NAME]]:Ladies and gentlemen, now that this fantastic match
+          is over, I am proud to announce the victory of... \N[1]!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6325,8 +6276,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE2NCA6W25hbWU9W05BTUVdXTpKJ2F1cmFpcyBiaWVuIGluc2NyaXQgbW9pLW3Dqm1lIGxhIHZpY3RvaXJlIGRhbnMgbCdvcmRpbmF0ZXVyLi4uIE1haXMgamUgbmUgc2FpcyBwYXMgY29tbWVudCBmYWlyZSwgamUgbGFpc3NlIGRvbmMgUGFsYm9sc2t5IHMnZW4gY2hhcmdlciAh
+        - 17, 164 :[name=[NAME]]:I would have entered the victory into the computer
+          myself, but I don't know how it works, so I'll let Palbolsky handle it!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6361,8 +6312,7 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE2NSA6W25hbWU9UGFsYm9sc2t5XTpOZSB0J2lucXVpw6h0ZSBwYXMsIFtOQU1FXSwgamUgbSdlbiBvY2N1cGUu
+        - 17, 165 :[name=Palbolsky]:Don't worry, [NAME], I got it.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6425,14 +6375,14 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE2NiA6W25hbWU9UGFsYm9sc2t5XTpBdmVjIGNldHRlIHZpY3RvaXJlLCBcTlsxXSwgdHUgYXMgb2ZmaWNpZWxsZW1lbnQgdHJpb21waMOpIGRlIGwnQXLDqG5lIGRlIENvbWJhdC4=
+        - 17, 166 :[name=Palbolsky]:After this victory, \N[1], you have officially
+          triumphed over the Battle Arena.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 167 :[name=Palbolsky]:C'est donc avec grand plaisir que je te donne
-          ma Pierre Insolite.
+        - 17, 167 :[name=Palbolsky]:It's with great pleasure I give you my Intriguing
+          Stone.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6442,7 +6392,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 168 :[name=Palbolsky]:Je voudrais aussi que tu acceptes ceci...
+        - 17, 168 :[name=Palbolsky]:I also would like you to accept this...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6472,14 +6422,15 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE2OSA6W25hbWU9UGFsYm9sc2t5XTpDJ2VzdCBsJ3VuIGRlcyBQb2vDqW1vbiDDiW9uLiBUdSBsJ2FzIGFmZnJvbnTDqSBwZW5kYW50IGNlIGNvbWJhdCwgZXQgamUgc2VucyBxdSdpbCBzZXJhIGJpZW4gYXZlYyB0b2kuIEwnYXV0cmUgUG9rw6ltb24gRW9uIGEgYXBwYXJlbW1lbnQgw6l0w6kgYXBlcsOndSBzdXIgbCfDjmxlLCBwZXV0LcOqdHJlIGwnYXMtdHUgZMOpasOgIHJlbmNvbnRyw6kgPw==
+        - 17, 169 :[name=Palbolsky]:It's one of the Eon Pokémon. You fought it during
+          the battle, and I feel it'll be fine with you. The other Eon Pokémon was
+          sighted on the Island, apparently, maybe you already encountered it?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE3MCA6W25hbWU9UGFsYm9sc2t5XToqc291cGlyKi4uLiBNZXJjaSBwb3VyIGNlIG1hdGNoLCBqZSBuZSBtJ8OpdGFpcyBwYXMgYXV0YW50IGFtdXPDqSBkZXB1aXMgbG9uZ3RlbXBzICEgTidow6lzaXRlIHBhcyDDoCByZXZlbmlyIG0nYWZmcm9udGVyIMOgIGwnb2NjYXNpb24gIQ==
+        - 17, 170 :[name=Palbolsky]:*sigh*... Thanks for this match, it was a minute
+          since I had this much fun! Don't hesitate to come fight me again some time!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6492,8 +6443,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE3MSA6W25hbWU9UGFsYm9sc2t5XTpCaWVuIGpvdcOpLCBcTlsxXSwgZW5jb3JlIHVuZSBiZWxsZSB2aWN0b2lyZSDDoCB0b24gYWN0aWYgIQ==
+        - 17, 171 :[name=Palbolsky]:Well done, \N[1], another fine victory to your
+          credit!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6514,8 +6465,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE3MiA6W25hbWU9W05BTUVdXTpMYSB2aWN0b2lyZSByZXZpZW50IMOgIFBhbGJvbHNreSAh
+        - 17, 172 :[name=[NAME]]:Victory goes to Palbolsky!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6528,8 +6478,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE3MyA6W25hbWU9W05BTUVdXTpKZSB2YWlzIHNvaWduZXIgdm9zIMOpcXVpcGVzIHBvdXIgcXVlIHZvdXMgbidheWV6IHBhcyDDoCBsZSBmYWlyZS4=
+        - 17, 173 :[name=[NAME]]:I will heal your Pokémon so you won't have to.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6562,8 +6511,8 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE3NCA6W25hbWU9W05BTUVdXTpNZXJjaSDDoCB0b3VzIGQnw6p0cmUgdmVudXMgcG91ciBhc3Npc3RlciDDoCBjZSBtYXRjaCwgb24gZXNww6hyZSB2b3VzIHZvaXIgcG91ciBsZXMgcHJvY2hhaW5zICE=
+        - 17, 174 :[name=[NAME]]:Thanks for coming to this match, we hope to see you
+          for the next ones!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7248,14 +7197,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE3NSBVbmUgdm9peCByw6lzb25uZSBkYW5zIHZvdHJlIHTDqnRlLi4u
+        - 17, 175 A voice resonates in your mind...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE3NiAiQ2V0dGUgcG9ydGUgbmUgc2VydCDDoCByaWVuIGV0IGVzdCBqdXN0ZSBsw6AgcG91ciBmYWlyZSBqb2xpLiI=
+        - 17, 176 "This door serves no purpose and is there just to look pretty."
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7638,14 +7585,13 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE3NyA6W25hbWU9Pz8/LDNdOk9vb29vb29vaCAhIExlIFBva8OpbW9uIGR1IGNoYWxsZW5nZXIgZXN0IHRvbWLDqSBLTyAhIElsIG5lIGx1aSByZXN0ZSBwbHVzIHF1J3VuIFBva8OpbW9uIGVuIMOpdGF0IGRlIGNvbWJhdHRyZSwgZXQgc29uIGFkdmVyc2FpcmUgZXN0IGTDqWrDoCBzdXIgbGUgZGVybmllciBtZW1icmUgZGUgc29uIMOpcXVpcGUgIQ==
+        - '17, 177 :[name=???,3]:Ooooooooh! The challenger''s Pokémon is KO! He only
+          has one Pokémon left, and his opponent is already on her last Pokémon! '
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE3OCA6W25hbWU9Pz8/LDNdOlF1aSB2YSBkb25jIGdhZ25lciBjZSBtYXRjaCBhdSBkw6lub3VlbWVudCBpbmNlcnRhaW4gPyE=
+        - 17, 178 :[name=???,3]:Who's going to win this match with an uncertain outcome?!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7754,7 +7700,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 179 :[name=???,5]:Gallame, utilise Coupe Psycho !
+        - 17, 179 :[name=???,5]:Gallade, use Psycho Cut!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7983,8 +7929,7 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE4MCA6W25hbWU9Pz8/LDFdOlJhdHRhdGFjLCB1dGlsaXNlIFZpdGVzc2UgRXh0csOqbWUgIQ==
+        - 17, 180 :[name=???,1]:Raticate, use Extreme Speed!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8731,25 +8676,24 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE4MSA6W25hbWU9Pz8/LDVdOlZpdGVzc2UgRXh0csOqbWUgPyEgQ29tbWVudCBlc3QtY2UgcG9zc2libGUgPyE=
+        - 17, 181 :[name=???,5]:Extreme Speed?! How is it possible?!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 182 :[name=???,1]:Tu ne t'y attendais pas, mais mon Rattatac est le
-          plus rapide des Rattatac ! Un Rattatac de top niveau !
+        - 17, 182 :[name=???,1]:You weren't expecting that, but my Raticate is the
+          fastest Raticate! A top-level Raticate!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 183 :[name=???,5]:Je vois, dans ce cas, je me vois dans l'obligation
-          de finir ce combat au plus vite !
+        - 17, 183 :[name=???,5]:I see, in this case, I feel obliged to end this battle
+          as quickly as possible!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 184 :[name=???,5]:Gallame, utilise Psyko et aplatit ce rongeur !
+        - 17, 184 :[name=???,5]:Gallade, use Psychic and flatten this rodent!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9134,13 +9078,13 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 185 :[name=???,1]:Rattatac, non !
+        - 17, 185 :[name=???,1]:Raticate, no!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE4NiA6W25hbWU9Pz8/LDVdOkTDqXNvbMOpLCBtYWlzIGMnZXN0IHRyb3AgdGFyZCAhIEdhbGxhbWUsIGZhaXMgbGUgcyfDqWNyYXNlciBzdXIgbGUgc29sICE=
+        - 17, 186 :[name=???,5]:Sorry, but it's already too late! Gallade, make it
+          crash to the ground!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9198,7 +9142,7 @@ events:
         code: 223
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 187 :[name=???,1]:Nooooooooooooon !
+        - 17, 187 :[name=???,1]:Noooooooooooooo!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9276,8 +9220,8 @@ events:
         code: 241
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE4OCA6W25hbWU9Pz8/LDNdOkNlIG1hdGNoIGVzdCBtYWludGVuYW50IHRlcm1pbsOpICEgSWwgbm91cyBhdXJhIHRvdXMgdGVudSBlbiBoYWxlaW5lLCBtYWlzIGplIHN1aXMgZmllciBkZSBwb3V2b2lyIHZvdXMgcHLDqXNlbnRlciBsZSB2YWlucXVldXIgZGUgY2UgbWF0Y2guLi4=
+        - 17, 188 :[name=???,3]:This match is now over! It kept us all on our toes,
+          but I'm proud to announce you the victor of this match...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9302,8 +9246,7 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 189 :[name=???,3]:Veuillez applaudir notre grande gagnante de ce match
-          !
+        - 17, 189 :[name=???,3]:Please applaud the grand winner!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9321,8 +9264,8 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE5MCA6W25hbWU9Pz8/LDNdOlF1YW50IMOgIG1vaSwgamUgdm91cyByZXRyb3V2ZSBwcm9jaGFpbmVtZW50IHBvdXIgYWZmcm9udGVyIG5vdHJlIHByb2NoYWluIGNoYWxsZW5nZXIgISBEJ2ljaSBsw6AsIGVudHJhaW5lei12b3VzLCBkZXZlbmV6IG1laWxsZXVyLCBldCBnYWduZXogdm90cmUgcGxhY2UgcG91ciB0ZW50ZXIgZGUgbWUgdmFpbmNyZSAh
+        - 17, 190 :[name=???,3]:As for me, I will see you soon to face the next challenger!
+          Until then, train, become better, and win your place to try to best me!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9448,8 +9391,8 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE5MSA6W25hbWU9Pz8/XTpFbmNvcmUgdW4gY29tYmF0IHJvbmRlbWVudCBtZW7DqSAhIE1haW50ZW5hbnQsIGonZXNww6hyZSBxdWUgbm90cmUgcHJvY2hhaW5cRSBjaGFsbGVuZ2VyIG5lIHMnZXN0IHBhcyBwZXJkdVxFLi4u
+        - 17, 191 :[name=???]:Another battle well fought! Now, I hope our next challenger
+          aren't lost...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9484,7 +9427,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 193 :[name=???]:Quand on parle du loup !
+        - 17, 193 :[name=???]:Speak of the devil!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9576,8 +9519,8 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE5NCA6W25hbWU9Pz8/XTpFeGN1c2UtbW9pIGRlIHRlIGTDqXJhbmdlciwgbWFpcyB0dSBuZSBzZXJhaXMgcGFzIGxhIHBlcnNvbm5lIHLDqWNlbW1lbnQgYXJyaXbDqWUgc3VyIGwnw45sZSwgcGFyIGhhc2FyZCA/
+        - 17, 194 :[name=???]:Sorry to bother you, but are you the recently arrived
+          newcomer of the Island, by any chance?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9607,49 +9550,49 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE5NSA6W25hbWU9Pz8/XTrDh2EgbSdhIHRvdXQgbCdhaXIgZCfDqnRyZSBsZSBjYXMgIQ==
+        - 17, 195 :[name=???]:To me, it's seems like it's the case!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE5NiA6W25hbWU9UGFsYm9sc2t5XTpKZSBtZSBwcsOpc2VudGUsIGplIHN1aXMgUGFsYm9sc2t5LCBtYWlzIFNpck1hbG8gYSBkw7sgdGUgcGFybGVyIHVuIHBldSBkZSBtb2kgZMOpasOgLg==
+        - '17, 196 :[name=Palbolsky]:Let me introduce myself: I am Palbolsky, I believe
+          SirMalo talked to you about me already.'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE5NyA6W25hbWU9UGFsYm9sc2t5XTpKZSBzdWlzIGxlIHJlc3BvbnNhYmxlIGRlIGwnQXLDqG5lIGRlIENvbWJhdCwgdW5lIHNhbGxlIGTDqWRpw6llIMOgIGwnYXBwcmVudGlzc2FnZSBkdSBjb21iYXQgUG9rw6ltb24gZXQgZGVzIGRpdmVyc2VzIG1hbmnDqHJlcyBkJ2VuIG1ldHRyZSBlbiBwbGFjZS4=
+        - 17, 197 :[name=Palbolsky]:I'm the manager of the Battle Arena, a room dedicated
+          to learning Pokémon battles and the diverse ways to setup one.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE5OCA6W25hbWU9UGFsYm9sc2t5XTpFdCwgw6AgbW9pbnMgcXVlIGplIG5lIG1lIHRyb21wZSBldCBxdWUgdHUgbidlbiBhaWVzIHJpZW4gw6AgZmFpcmUsIGplIHBvc3PDqGRlIGwndW5lIGRlcyBQaWVycmVzIEluc29saXRlcyBxdWUgdHUgY2hlcmNoZXMgIQ==
+        - 17, 198 :[name=Palbolsky]:And, unless I'm mistaken and you don't care about
+          that, I possess one of the Intriguing Stones you seek!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDE5OSA6W25hbWU9UGFsYm9sc2t5XTpKZSBuZSBjb21wdGUgcGFzIHRlIGxhIGRvbm5lciBjb21tZSDDp2EsIHR1IHRlIGRvdXRlcyBiaWVuLi4uIEMnZXN0IHBvdXJxdW9pIGplIHRlIHByb3Bvc2UgdW4gcGV0aXQgZMOpZmku
+        - 17, 199 :[name=Palbolsky]:I don't intend to give it to you like that, you
+          can imagine... That is why I propose you a little challenge.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIwMCA6W25hbWU9UGFsYm9sc2t5XTpMYSBjb25zb2xlIMOgIGPDtHTDqSBkdSBQQyBwZXJtZXQgZGUgImNvbW1hbmRlciIgdW4gY29tYmF0IGNvbnRyZSBsJ3VuIGRlIG1lcyBhcHByZW50aXMuIEJhdHMtbGVzIHRvdXMsIGV0IGplIHRlIGxhaXNzZXJhaSBtZSBkw6lmaWVyIGF2ZWMgZW4gamV1IG1hIFBpZXJyZSBJbnNvbGl0ZSAh
+        - 17, 200 :[name=Palbolsky]:The console aside of the PC allows us to "order"
+          a battle against one of my apprentices. Beat them all, and I'll let you
+          challenge me with my Intriguing Stone in play!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIwMSA6W25hbWU9UGFsYm9sc2t5XTpKZSBuZSBzdWlzIHBhcyBwcmVzc8OpLCBkb25jIHByZW5kcyB0b24gdGVtcHMgcG91ciBhcHByZW5kcmUgY29ycmVjdGVtZW50ICEgQm9uIGNvdXJhZ2UgcG91ciB0ZXMgZnV0dXJzIGNvbWJhdHMgIQ==
+        - 17, 201 :[name=Palbolsky]:I'm in no hurry, so take your time to correctly
+          learn! Good luck for future battles!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 17, 202 :[name=Palbolsky]:Oh et tiens, avant que je n'oublie !
+        - 17, 202 :[name=Palbolsky]:Before I forget, I want to give this to you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9659,20 +9602,20 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIwMyA6W25hbWU9UGFsYm9sc2t5XTpTaSB0dSBhcyB1biBQb2vDqW1vbiDDoCBmYWlyZSBtw6lnYS3DqXZvbHVlciwgdHUgbGUgcG91cnJhcyBhdmVjIGNldCBvYmpldCAh
+        - 17, 203 :[name=Palbolsky]:If you have a Pokémon to Mega Evolve, you'll be
+          able to with this item!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIwNCA6W25hbWU9UGFsYm9sc2t5XTpQb3VyIGluZm9ybWF0aW9uLCBuJ2ltcG9ydGUgcXVlbCBvYmpldCAiTcOpZ2EiIHN1ZmZpdC4gRG9uYyB0dSBwZXV4IGF1c3NpIHV0aWxpc2VyIGxlcyBNw6lnYS1MdW5ldHRlcywgcGFyIGV4ZW1wbGUgIQ==
+        - 17, 204 :[name=Palbolsky]:For the info, any "Mega" item does the trick.
+          So you can even use the Mega-Glasses , for example!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIyNyA6W25hbWU9UGFsYm9sc2t5XTpPaCwgZXQgY29tbWUgdHUgbWUgcGxhaXMgYmllbiwgamUgdCdvZmZyZSBjZWNpIGVuIGNhZGVhdSBkJ2Fycml2w6llIGRhbnMgY2V0dGUgYXLDqG5lICE=
+        - 17, 227 :[name=Palbolsky]:Oh, and because I quite like you, I'm giving you
+          this as an arrival gift in this arena!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -9688,38 +9631,37 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIyOCA6W25hbWU9UGFsYm9sc2t5XTpDZSBSaW9sdSBhdmFpdCBsJ2FpciBkZSBiZWF1Y291cCB0J2FwcHLDqWNpZXIsIGlsIGRldnJhaXQgw6l2b2x1ZXIgdHLDqHMgdml0ZSAh
+        - 17, 228 :[name=Palbolsky]:That Riolu seemed to like you a lot, so it should
+          grow up very quickly!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIyOSA6W25hbWU9UGFsYm9sc2t5XTpQZW5zZSDDoCByZWdhcmRlciBsJ29iamV0IHF1J2lsIHRpZW50LCBkJ2FpbGxldXJzICE=
+        - 17, 229 :[name=Palbolsky]:Don't forget to look at the object it's holding!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIwNSA6W25hbWU9UGFsYm9sc2t5XTpTdXIgY2UsIGplIHZhaXMgYWxsZXIgbWUgcmVwb3NlciBsZXMgY29yZGVzIHZvY2FsZXMsIGZhaXJlIGwnYXJiaXRyZSBldCBsZSBwcsOpc2VudGF0ZXVyIGVuIG3Dqm1lIHRlbXBzIMOnYSB1c2UuLi4=
+        - 17, 205 :[name=Palbolsky]:You'll excuse me, I have to go rest my vocal cords.
+          Endosing the role of the referee and the announcer is tiring...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIzMCA6W25hbWU9UGFsYm9sc2t5XTpEZXJuaWVyIHBldGl0IGNvbnNlaWwgY2VsYSBkaXQuLi4gU2kgdHUgbidhcyBwYXMgZW5jb3JlIGV4cGxvcsOpIGxhIFRvdXIsIGplIHRlIGNvbnNlaWxsZSBkZSBsZSBmYWlyZSBhdmFudCBkZSB0ZSBmcm90dGVyIMOgIGwnQXLDqG5lLi4u
+        - 17, 230 :[name=Palbolsky]:A final word of advice... If you haven't explored
+          the Tower yet, I suggest you do so before tackling the Arena...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIzMSA6W25hbWU9UGFsYm9sc2t5XTpIaXN0b2lyZSBxdWUgdHUgcHVpc3NlcyBnYWduZXIgZW4gZXhww6lyaWVuY2UgZXQgdGUgY29uc3RydWlyZSB1bmUgcGV0aXRlIMOpcXVpcGUgIQ==
+        - 17, 231 :[name=Palbolsky]:So you can gain experience and build up a small
+          team!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTcsIDIzMiA6W25hbWU9UGFsYm9sc2t5XTpNYWlzIHNpIHR1IHRlIHNlbnMgcHLDqnQgZGUgc3VpdGUsIGFsb3JzIGplIHRlIHNvdWhhaXRlIGJvbm5lIGNoYW5jZSAhIFN1ciBjZSwgaid5IHZhaXMgIQ==
+        - 17, 232 :[name=Palbolsky]:But if you feel up to it right away, then I wish
+          you the best of luck! On that note, I'm off!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map017.rxdata.yml
+++ b/Data/Map017.rxdata.yml
@@ -6163,7 +6163,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - bi.battle_bgm = 'audio/bgm/TeruTeruSky_Zinnia_HGSS'
+        - bi.battle_bgm = 'audio/bgm/teruterusky_zinnia_hgss'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand

--- a/Data/Map018.rxdata.yml
+++ b/Data/Map018.rxdata.yml
@@ -695,14 +695,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDAgQm9uam91ciwgZXQgYmllbnZlbnVlIGF1IGNvbXB0b2lyIGRlcyDDqWNoYW5nZXMgZW4gbGlnbmUgIQ==
+        - 18, 0 Hello, and welcome to the Online Trade counter!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDEgTWFsaGV1cmV1c2VtZW50LCBub3VzIG5lIHByb3Bvc29ucyBwYXMgZW5jb3JlIGNldHRlIGZvbmN0aW9ubmFsaXTDqSwgbWFpcyBub3VzIGVzcMOpcm9ucyBxdWUgbm91cyBwb3Vycm9ucyB2b3VzIGxhIGZvdXJuaXIgdW4gam91ci4gTWVyY2kgZGUgdm90cmUgcGF0aWVuY2UgIQ==
+        - 18, 1 Unfortunately, we're unable to propose this feature at the time, but
+          we hope to be able to offer it to you one day.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -753,13 +752,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 18, 2 Bonjour, et bienvenue au comptoir des combats en ligne !
+        - 18, 2 Hello, and welcome to the Online Battle counter!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDMgTWFsaGV1cmV1c2VtZW50LCBub3VzIG5lIHByb3Bvc29ucyBwYXMgZW5jb3JlIGNldHRlIGZvbmN0aW9ubmFsaXTDqSwgbWFpcyBub3VzIGVzcMOpcm9ucyBxdWUgbm91cyBwb3Vycm9ucyB2b3VzIGxhIGZvdXJuaXIgdW4gam91ci4gTWVyY2kgZGUgdm90cmUgcGF0aWVuY2UgIQ==
+        - 18, 3 Unfortunately, we're unable to propose this feature at the time, but
+          we hope to be able to offer it to you one day.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -810,14 +809,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDQgU2FsdXQgISBKJ2FpIGF0dHJhcMOpIHVuIFBva8OpbW9uIMOpdHJhbmdlIHF1aSBzZSBiYWxhZGFpdCBkZXJyacOocmUgbGVzIHNlcnZldXJzIGR1IExhYm9yYXRvaXJlLCBtYWlzIGlsIG5lIG0naW5zcGlyZSBwYXMgY29uZmlhbmNlLi4u
+        - 18, 4 Hey! I caught a weird Pokémon that was hiding behind the servers of
+          the Laboratory, but I don't really trust it...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDUgVCdhdXJhaXMgcGFzIHVuIEfDqW9saXRoZSDDoCBtJ8OpY2hhbmdlciDDoCBsYSBwbGFjZSA/IEplIHQnb2ZmcmlyYWkgbGEgam9saWUgcGllcnJlIGFyYy1lbi1jaWVsIHF1ZSBqJ2FpIHRyb3V2w6kgYXZlYyAh
+        - 18, 5 Do you have a Boldore to trade me?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -989,8 +987,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDYgRWggISBNYWlzIGlsIMOpdGFpdCBjZW5zw6kgw6l2b2x1ZXIgIQ==
+        - 18, 6 Huh! It was supposed to evolve!
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1000,14 +997,12 @@ events:
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDggVHUgbHVpIGFzIGRvbm7DqSB1bmUgUGllcnJlIFN0YXNlID8h
+        - 18, 8 You gave it an Everstone?!
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDkgRmF1dCDDqnRyZSBzYWNyw6ltZW50IHZpY2lldXggIQ==
+        - 18, 9 That's pretty vicious!
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1020,14 +1015,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDEwIFN1cGVyICEgVG9uIEfDqW9saXRoZSBhIMOpdm9sdcOpICE=
+        - 18, 10 Great! Your Boldore evolved!
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDExIEplIHN1aXMgbWFpbnRlbmFudCBsJ2hldXJldXggcHJvcHJpw6l0YWlyZSBkJ3VuIHNwbGVuZGlkZSBHaWdhbGl0aGUgIQ==
+        - 18, 11 I'm now the happy owner of a splendid Gigalith!
         indent: 4
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1040,7 +1033,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 18, 12 Et parce qu'un deal est un deal... Tiens, prends cette pierre !
+        - 18, 12 A deal's a deal...
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1064,8 +1057,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDEzIEVoLCBtYWlzIGMnZXN0IHBhcyB1biBHw6lvbGl0aGUgIQ==
+        - 18, 13 Wait, it's not a Boldore!
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1086,7 +1078,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 18, 14 Bon, tant pis...
+        - 18, 14 Well, too bad...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1109,8 +1101,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDE1IE1haXMgaidlbiB2ZXV4IHBhcyBkZSBjZSBQb2vDqW1vbiAh
+        - 18, 15 But I don't want this Pokémon!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1163,20 +1154,19 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDE2IEMnZXN0IGFzc2V6IHNpbXBsZSBkZSBjb25maWd1cmVyIHVuIFxjWzVdw6ljaGFuZ2UgaW50ZXJuZVxjWzBdIGF2ZWMgUG9rw6ltb25TREsu
+        - 18, 16 It's fairly easy to setup an \c[5]internal trade\c[0] with PokémonSDK.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDE3IElsIHN1ZmZpdCBkJ1xjWzVdYXBwZWxlciBsZSBtZW51IGRlIGwnw6lxdWlwZVxjWzBdIGV0IGRlIHbDqXJpZmllciBxdWUgbGUgUG9rw6ltb24gc8OpbGVjdGlvbm7DqSBlc3QgY2VsdWkgdm91bHUgcG91ciBsJ8OpY2hhbmdlLg==
+        - 18, 17 You just need to \c[5]call the party menu\c[0] and to check that
+          the selected Pokémon is the one needed for the trade.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDE4IEVuc3VpdGUgdHUgcmVudHJlcyBsZXMgY2FyYWN0w6lyaXN0aXF1ZXMgZHUgUG9rw6ltb24gw6ljaGFuZ8OpLCBwdWlzIHR1IHV0aWxpc2VzIGxhIGNvbW1hbmRlIFxjWzVdIm5wY190cmFkZV9zZXF1ZW5jZSJcY1swXS4=
+        - 18, 18 Then, you enter the parameters of the traded Pokémon, and then use
+          the \c[5]"npc_trade_sequence"\c[0] command.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1552,13 +1542,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 18, 19 Bonjour, et bienvenue au comptoir de la GTS !
+        - 18, 19 Hello, and welcome to the GTS counter!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDIwIENlcyBiw6J0aW1lbnRzIGRlcm5pZXJzIGNyaXMgdm91cyBwZXJtZXR0cm9udCBkJ8OpY2hhbmdlciBuJ2ltcG9ydGUgcXVlbCBQb2vDqW1vbiBhdmVjIG4naW1wb3J0ZSBxdWVsIHV0aWxpc2F0ZXVyIGRlIGNldHRlIGTDqW1vICE=
+        - 18, 20 This state-of-the-art system will allow you to trade any Pokémon
+          with any user of this demo!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1570,8 +1560,9 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDIxIFNpIHZvdXMgdmVuZXogw6AgdXRpbGlzZXIgY2Ugc3lzdMOobWUgZGFucyB2b3RyZSBwcm9wcmUgamV1LCBNYWtlciwgcGVuc2V6IMOgIHJlZ2FyZGVyIGxlIGNvZGUgcmVzcG9uc2FibGUgcG91ciB2b2lyIGxhIHByb2PDqWR1cmUgbsOpY2Vzc2FpcmUgcG91ciBhZGFwdGVyIGNldHRlIGZlYXR1cmUgw6Agdm90cmUgamV1ICE=
+        - 18, 21 If you are using this system for your own fangame, Maker, please
+          check the responsible code for the necessary procedure to adapt this feature
+          to your game!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1590,8 +1581,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDIyIFZvdWxlei12b3VzIGFjY8OpZGVyIMOgIGxhIEdUUyA/
+        - 18, 22 Do you want to access the GTS?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1609,7 +1599,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 18, 23 Tout de suite !
+        - 18, 23 Alright!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1629,8 +1619,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDI0IEF1Y3VuIHByb2Jsw6htZSwgcmV2ZW5leiBtZSB2b2lyIHNpIHZvdXMgY2hhbmdleiBkJ2F2aXMgIQ==
+        - 18, 24 No problem, please come back if you change your mind!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1791,8 +1780,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDI1IEplIHZhaXMgZmFpcmUgdW5lIGZhcmNlIMOgIG1vbiBwb3RlIGVuIGx1aSBlbnZveWFudCB1biBNYWNob3BldXIgdGVuYW50IHVuZSBQaWVycmUgU3Rhc2UgY29udHJlIHNvbiBTcGVjdHJ1bSwgY29tbWUgw6dhIGplIHBvdXJyYWkgbGUgbmFyZ3VlciBjYXIgaidhdXJhaSBsZSBtZWlsbGV1ciBQb2vDqW1vbiAh
+        - 18, 25 I'm going to prank my friend by trading him a Machoke with an Everstone
+          for his Haunter.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1843,8 +1832,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTgsIDI2IEplIHZhaXMgcGnDqWdlciBtb24gYW1pIGVuIGx1aSBlbnZveWFudCB1biBTcGVjdHJ1bSB0ZW5hbnQgdW5lIFBpZXJyZSBTdGFzZSBjb250cmUgc29uIE1hY2hvcGV1ciwgY29tbWUgw6dhIGplIHNlcmFpIGxlIHNldWwgw6AgYXZvaXIgdW4gUG9rw6ltb24gw6l2b2x1w6kgIQ==
+        - 18, 26 I'll trick my friend by sending him a Haunter holding an Everstone
+          for his Machoke, this way I'll be the only one with a powerful Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map019.rxdata.yml
+++ b/Data/Map019.rxdata.yml
@@ -736,14 +736,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDAgSmUgY29tcHRlIHZlbmRyZSBjZXJ0YWlucyBkZXMgUG9rw6ltb24gZGUgbWEgZmVybWUgY2FyIGonZW4gYWkgdHJvcCwgbWFpcyBqJ2F0dGVuZHMgbCdhdXRvcmlzYXRpb24gb2ZmaWNpZWxsZSBkdSBTdGFmZiBkZSBsYSBUb3VyLi4u
+        - 19, 0 I'm planning to sell some of my farm's Pokémon as I have too many,
+          but the Tower's Staff has yet to give me the official approval...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEgUmV2aWVucyBtZSB2b2lyIHBsdXMgdGFyZCBzaSDDp2EgdCdpbnTDqXJlc3NlICE=
+        - 19, 1 Come back again later if you're interested!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -801,8 +800,8 @@ events:
         code: 123
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDIgSidhaSBlbmZpbiBvYnRlbnUgbCdhdXRvcmlzYXRpb24gZHUgU3RhZmYgZGUgbGEgVG91ciBwb3VyIHZlbmRyZSBtZXMgUG9rw6ltb24gZW4gdHJvcCAh
+        - 19, 2 I finally got the approval from the Tower's Staff to sell my extra
+          Pokémon!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -815,8 +814,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDMgQmllbnZlbnVlIMOgIG1vbiDDqWNob3BwZSwgcGV0aXRcRSAh
+        - 19, 3 Welcome to my stall, pal!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -844,8 +842,8 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDQgLi4uIEonYXVyYWlzIGFpbcOpIHBvdXZvaXIgdCdhaWRlciwgbWFpcyBqZSBuJ2FpIHBsdXMgZGUgUG9rw6ltb24gw6AgdGUgdmVuZHJlLg==
+        - 19, 4 ... I would have liked to help you, but I don't have any Pokémon left
+          to sell.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -864,8 +862,7 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDUgVmV1eC10dSB2b2lyIGxlcyBQb2vDqW1vbiBkb250IGplIG1lIHPDqXBhcmUgPw==
+        - 19, 5 Want to have a look at the Pokémon I'm selling away?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -883,7 +880,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 6 Tout de suite, petit\E !
+        - 19, 6 Here you go, pal!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -942,8 +939,7 @@ events:
         code: 404
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDcgTidow6lzaXRlIHBhcyDDoCByZXZlbmlyLCBtZXMgUG9rw6ltb24gbidhdHRlbmRlbnQgcXVlIHRvaSAh
+        - 19, 7 Don't hesitate to come back, my Pokémon only wait for you!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1002,14 +998,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDggTGUgcGxhbnQgZGUgYmFpZXMgT3JhbiBhIGRyw7RsZW1lbnQgYmllbiBwb3Vzc8OpLCDDp2EgZmFpdCBwbGFpc2lyIMOgIHZvaXIgIQ==
+        - 19, 8 The Oran Berry plant has grown very fast, it puts a smile on my face!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDkgSWwgbWFucXVlIGVuY29yZSB1biBwZXUgZGUgdGVtcHMgYXZhbnQgcXVlIGNlbHVpIGRlIGJhaWVzIFNpdHJ1cyBuJ2Fycml2ZSDDoCBtYXR1cml0w6ksIGNlbGEgZGl0Li4u
+        - 19, 9 With that said, there's still some time left until the Sitrus Berries
+          grow into maturity...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1057,49 +1052,46 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEwIE9oIHBhcmRvbiwgamUgbmUgdCdhaSBwYXMgZW50ZW5kdVxFIGFycml2ZXIsIGonw6l0YWlzIHRyb3AgYWJzb3Jiw6llIGRhbnMgbWEgY29udGVtcGxhdGlvbiBkZSBjZXMgbWVydmVpbGxldXggcGxhbnRzIGRlIGJhaWVzICE=
+        - 19, 10 Oh sorry, I didn't hear you there, I was too lost in thought about
+          these Berry trees!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDExIFZvaXMtdHUsIFBva8OpbW9uU0RLIGVzdCBjYXBhYmxlIGRlIFxjWzVdZ8OpcmVyIGRpcmVjdGVtZW50IGxlcyBiYWllcyBldCBsZXVyIGNyb2lzc2FuY2VcY1swXS4=
+        - 19, 11 You see, PokémonSDK is capable of \c[5]directly managing Berries
+          and their growth\c[0].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEyIElsIGVzdCByZWNvbW1hbmTDqSBkJ1xjWzVdaW5pdGlhbGlzZXIgbGVzIHBsYW50cyBkZSBiYWllc1xjWzBdIGRpcmVjdGVtZW50IGRhbnMgdG9uIGludHJvZHVjdGlvbi4=
+        - 19, 12 It's recommended to directly \c[5]initialize the Berry trees\c[0]
+          inside your introduction.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEzIFVuIHBldSDDoCBsYSBtYW5pw6hyZSBkZSBjZXR0ZSBkw6ltbyAh
+        - 19, 13 As does this demo!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE0IFBlbnNlIMOgIGpldGVyIHVuIMWTaWwgw6AgbCdpbnRybyBkZSBjZXR0ZSBkw6ltbyBwb3VyIHZvaXIgY29tbWVudCBjJ2VzdCBmYWl0Lg==
+        - 19, 14 You can have a look at the intro of this demo to see how it's done.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 15 Si tu veux cueillir celles-ci, je t'en prie, fais donc !
+        - 19, 15 If you want to harvest these trees, feel free to do so!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE2IEplIHZhaXMgYXVzc2kgdGUgZG9ubmVyIGNlY2ksIMOnYSB0ZSBwZXJtZXR0cmEgZCdhcnJvc2VyIGxlcyBwbGFudHMgZGUgYmFpZXMsIHNpIHR1IGVuIHJlcGxhbnRlcy4=
+        - 19, 16 I also want to give you this, it will allow you to water Berry plants,
+          if you replant some.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE3IFR1IHBvdXJyYXMgYXVzc2kgYXJyb3NlciBsZXMgYmFpZXMgU2l0cnVzIGp1c3RlIMOgIGPDtHTDqSwgcG91ciBsZXMgYWlkZXIgw6AgcG91c3NlciB1biBwZXUgcGx1cyB2aXRlICE=
+        - 19, 17 You also can water this Sitrus Berries here to help fasten its growth!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1109,8 +1101,8 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE4IEplIHRlIGxhaXNzZSB0J2FtdXNlciDDoCBwbGFudGVyIGRlcyBiYWllcywgbW9pIGplIHZhaXMgZW4gY2hlcmNoZXIgZGFucyBsZXMgY29pbnMgaW5leHBsb3LDqXMgZGUgbCfDjmxlICE=
+        - 19, 18 Have fun planting Berries, I'll go search some more in the unexplored
+          part of the Island!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1397,13 +1389,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE5IEonYWkgZGVzIG9iamV0cyByYXJlcyBldCBzdXBlciB1dGlsZXMgw6AgdmVuZHJlLCBtYWlzIG9uIG0nYSBkaXQgZCdhdHRlbmRyZSBxdWUgbGUgZGVybmllciBhcnJpdmFudCBzZSByZW5kZSDDoCBsYSBUb3VyLi4u
+        - 19, 19 I have some very rare and useful items to sell, but I was told to
+          wait for the last comer to go to the Tower...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Tu sais de qui il s'agit ?
+        - Any idea who it might be?
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1455,8 +1447,8 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDIwIExlIGRlcm5pZXIgYXJyaXZhbnQgcydlc3QgcHLDqXNlbnTDqSDDoCBsYSBUb3VyLCBjZSBxdWkgdmV1dCBkaXJlIHF1ZSBqZSBwZXV4IGVuZmluIG91dnJpciBtYSBib3V0aXF1ZSAh
+        - 19, 20 The last comer got to the Tower, so this means I can finally open
+          my shop!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1475,7 +1467,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 21 Je me fournis chez des pro des combats !
+        - 19, 21 I buy from some real battle professionnals!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1488,7 +1480,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 22 Je te montre de suite ce que je vends.
+        - 19, 22 Let me show you my stock right now.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1629,14 +1621,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDIzIETDqXNvbMOpLCBqZSBuJ2FpIHBsdXMgcmllbiDDoCB0ZSB2ZW5kcmUu
+        - 19, 23 Sorry, got nothing left to sell.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          UmVwYXNzZSB1bmUgYXV0cmUgZm9pcywgcGV1dC3DqnRyZSA/
+        - Come back another time maybe?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1668,13 +1658,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDI0IFZpc2libGVtZW50LCByaWVuIGRlIGNlIHF1ZSBqZSB2ZW5kcyBuZSB0J2ludMOpcmVzc2Uu
+        - 19, 24 Clearly, nothing I sell seems to interest you.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Tant pis, repasse me voir si tu changes d'avis !
+        - Ah, nevermind, come back again if you change your mind!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1712,8 +1701,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDI1IE1lcmNpIHBvdXIgdG9uIGFjaGF0LCDDoCB1bmUgcHJvY2hhaW5lIGZvaXMgIQ==
+        - 19, 25 Thank you for your purchase, until next time!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1756,8 +1744,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDI2IE1lcmNpIHBvdXIgdGVzIGFjaGF0cywgZW4gZXNww6lyYW50IHRlIHJldm9pciBiaWVudMO0dCAh
+        - 19, 26 Thank you for your purchases, I hope to see you again soon!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1794,14 +1781,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDI3IFR1IGFzIGFjaGV0w6kgdG91dCBtb24gc3RvY2sgIQ==
+        - 19, 27 You bought my whole stock!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          SmUgbidhaSBwbHVzIHJpZW4gw6AgdGUgdmVuZHJlIGR1IGNvdXAsIHJlcGFzc2UgbWUgdm9pciDDoCBsJ29jY2FzaW9uICE=
+        - Well, I don't have anything left to sell you, come see me again sometime!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1860,14 +1845,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDI4IFNhbHV0LCBncmHDrm5lIGRlIHN0cmF0w6hnZSAh
+        - 19, 28 Hello, budding strategist!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDI5IEplIHZlbmRzIGRlcyBDYXBzdWxlcyBUZWNobmlxdWVzIGRlIGZvdSBmdXJpZXV4LCBsZSBnZW5yZSBkJ2F0dGFxdWVzIG7DqWNlc3NhaXJlIHBvdXIgZmFpcmUgZCd1biBNYXJhaXN0ZSBsZSBtZWlsbGV1ciBkZXMgc3RhbGxlcnMgIQ==
+        - 19, 29 I sell some furiously mind-busting TMs, the kind of move necessary
+          to transform a Quagsire into the best of stallers!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1882,7 +1866,7 @@ events:
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 31 Tu comprends de quoi je parle, au moins ?
+        - 19, 31 You do understand what I'm saying, right?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1900,13 +1884,12 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDMyIEFoIMOnYSwgw6dhIG1lIHBsYcOudCAh
+        - 19, 32 Ah, this puts a smile on my face!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Tu connais les vraies strats, toi !
+        - You're a fellow strategist of culture I see!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1927,14 +1910,13 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDMzIEFoLi4uIETDqXNvbMOpLCBqZSBtZSBzdWlzIGVuZmxhbW3DqSBwb3VyIHJpZW4u
+        - 19, 33 Oh, sorry then, I got all fired up over nothing,
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDM0IENvbmNyw6h0ZW1lbnQsIGplIHZlbmRzIGRlcyBDVCBxdWkgdGUgcGVybWV0dHJvbnQgZCdhcHByZW5kcmUgZGUgbm91dmVsbGVzIGNhcGFjaXTDqXMgw6AgdGVzIFBva8OpbW9uLCBtb3llbm5hbnQgcXUnaWxzIHNvaWVudCBhcHRlcyDDoCBsZXMgYXBwcmVuZHJlLg==
+        - 19, 34 Concretely, I sell TMs which allow you to teach new moves to your
+          Pokémon, as long as they are able to learn it.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1947,14 +1929,12 @@ events:
         code: 404
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 35 Quoiqu'il en soit, je dois attendre encore un peu avant d'ouvrir
-          boutique.
+        - 19, 35 Anyway, I have to wait a bit before opening my shop.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDM2IFJldmllbnMgbWUgdm9pciBwbHVzIHRhcmQgc2kgdCdlcyBpbnTDqXJlc3PDqVxFLg==
+        - 19, 36 Come back again later if you're interested.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2006,19 +1986,17 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDM3IEhleSwgamUgdGUgcmVjb25uYWlzLCB0J2VzIFxmW21hwqdtb25dIHBvdGUgcHJvIGRlIGxhIHN0cmF0w6lnaWUgIQ==
+        - 19, 37 Hey, I remember you! You're my fellow strategist of culture!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 38 Je peux enfin ouvrir mon magasin, tu vas voir j'ai des CT trop pratiques.
+        - 19, 38 I finally can open my shop.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDM5IEV0IGNvbW1lIHQnZXMgXGZbdW5lIGZpbGxlwqd1biBnYXJzXSBiaWVuLCBqZSB0ZSBmYWlzIHVuZSByaXN0b3VybmUgc3VyIGxlcyBwcml4Lg==
+        - 19, 39 And as you seem like a nice \f[girl§guy], I'll give you a discount.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2076,8 +2054,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDQwIEJvbmpvdXIgamV1bmUgXGZbZHJlc3NldXNlwqdkcmVzc2V1cl0gISBJbnTDqXJlc3PDqVxFIHBhciBtZXMgQ1QgPw==
+        - 19, 40 Hello young trainer! Interested in my TMs?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2186,25 +2163,25 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDQxIFVuZSBydW1ldXIgcXVpIGNpcmN1bGUgc3VyIGwnw45sZSBkaXQgcXUnYXBwYXJlbW1lbnQsIGVsbGUgYSBtaXMgcGx1c2lldXJzIGFubsOpZXMgYSDDqnRyZSBjb25zdHJ1aXRlLg==
+        - 19, 41 There's a rumor going around about the Tower, apparently it took
+          years to build it.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDQyIENlcyBydW1ldXJzIGRpc2VudCBhdXNzaSBxdSdhdSBkw6lwYXJ0LCBlbGxlIGRldmFpdCDDqnRyZSB1bmUgcGV0aXRlIHLDqWdpb24gw6AgcGFydCBlbnRpw6hyZSwgbWFpcyBxdWUgbGVzIGNvbmNlcHRldXJzIG9udCBqdWfDqSBjZWxhIHRyb3AgYW1iaXRpZXV4Li4u
+        - 19, 42 Those rumors also say that in the beginning, it was supposed to be
+          a small region, but their conceptors thought it was too ambitious...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDQzIEQnYXV0cmVzIHJ1bWV1cnMgZGlzZW50IHF1J2FwcGFyZW1tZW50LCBsZSBwcm9qZXQgZGUgcsOpZ2lvbiBuJ2EgcGFzIMOpdMOpIGFiYW5kb25uw6kgcG91ciBhdXRhbnQgIQ==
+        - 19, 43 But some other rumors say that apparently, this region project wasn't
+          given up on!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 44 Mais bon, ce ne sont que des rumeurs...
+        - 19, 44 But, well, those are rumors at the end of the day...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2259,8 +2236,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDQ1IExlIHByb2Jsw6htZSBkdSB0ZW1wcywgYydlc3QgdW4gbm9uLXByb2Jsw6htZS4uLg==
+        - 19, 45 The problem of time isn't one to begin with...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2293,7 +2269,8 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 46 Je savais que tu viendrais...
+        - 19, 46 I knew you'd come... You see, I possess powers beyond anything you
+          could ever imagine.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2304,35 +2281,35 @@ events:
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 47 Manipuler le temps est un jeu d'enfant pour moi...
+        - 19, 47 Warping time is child's play for me...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 48 Je peux t'en faire profiter si tu veux.
+        - 19, 48 I can share it with you if you want.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDQ5IEplIHN1aXMgcGFyIGV4ZW1wbGUgY2FwYWJsZSBkZSBjaGFuZ2VyIGxlIHLDqWbDqXJlbnRpZWwgdGVtcG9yZWwgZGUgbm90cmUgcsOpYWxpdMOpLg==
+        - 19, 49 For instance, I'm able to change the frame of reference of time in
+          our reality.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDUwIEplIHBldXggY2hvaXNpciBkZSBwYXNzZXIgbGUgdGVtcHMgc3VyIHVuZSBcY1s1XWhvcmxvZ2UgcsOpZWxsZVxjWzBdLCBkb25jIGNlbGxlIGRlIHRvbiBQQywgb3Ugc3VyIHVuZSBcY1s1XWhvcmxvZ2UgdmlydHVlbGxlXGNbMF0uLi4=
+        - 19, 50 I can choose to swap time to a \c[5]real clock\c[0], so your PC's,
+          or a \c[5]virtual clock\c[0].
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDUxIEwnaG9ybG9nZSB2aXJ0dWVsbGUgaXJhIGF1IHJ5dGhtZSBkJ3VuZSBtaW51dGUgw6ljb3Vsw6llIHRvdXRlcyBsZXMgMTAgc2Vjb25kZXMuLi4=
+        - 19, 51 The virtual clock will flow at a rythm of one minute spent every
+          10 seconds...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 52 Viens me parler si tu veux changer le cours du temps.
+        - 19, 52 Come talk to me if you want to change the flow of time.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2383,7 +2360,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 53 Ainsi, tu souhaites toi aussi manipuler le temps...
+        - 19, 53 So, you wish to manipulate time.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2400,13 +2377,12 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDU0IEFjdHVlbGxlbWVudCwgbm90cmUgdW5pdmVycyB1dGlsaXNlIGwnaG9ybG9nZSByw6llbGxlLi4u
+        - 19, 54 Currently, our universe uses the real clock...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Veux-tu passer sur l'horloge virtuelle ?
+        - Do you want to swap to the virtual clock?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2429,8 +2405,8 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDU1IFRyw6hzIGJpZW4sIG5vdHJlIHVuaXZlcnMgdmEgcydhY2PDqWzDqXJlciBkYW5zIDMuLi5bV0FJVCA0MF0gMi4uLltXQUlUIDQwXSAxLi4uIFtXQUlUIDQwXQ==
+        - 19, 55 Very well, our universe will accelerate in 3...[WAIT 40] 2...[WAIT
+          40] 1... [WAIT 40]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2492,26 +2468,23 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDU2IFZvaWzDoC4uLg==
+        - 19, 56 Done...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          TGEgZmFicmlxdWUgdGVtcG9yZWxsZSBkZSBub3RyZSB1bml2ZXJzIGEgY2hhbmfDqS4uLg==
+        - The time fabric of our universe has changed...
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDU3IEwnaG9ybG9nZSB2aXJ0dWVsbGUgaXJhIGF1IHJ5dGhtZSBkJ3VuZSBtaW51dGUgw6ljb3Vsw6llIGNoYXF1ZSBzZWNvbmRlLg==
+        - 19, 57 The virtual clock will flow at a rythm of one minute spent each 10
+          seconds...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDU4IEonYWkgZml4w6kgbCdoZXVyZSDDoCAxMmgwMC4=
+        - 19, 58 I fixed the time at 12am.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2535,33 +2508,32 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"19, 168 Matin",'
+        - '"19, 168 Morning",'
         indent: 2
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"19, 169 Jour",'
+        - '"19, 169 Midday",'
         indent: 2
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"19, 170 Soir",'
+        - '"19, 170 Evening",'
         indent: 2
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"19, 171 Nuit",'
+        - '"19, 171 Night",'
         indent: 2
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '"19, 172 Retour")'
+        - '"19, 172 Return")'
         indent: 2
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDU5IFNvdWhhaXRlcy10dSB0ZSByZW5kcmUgw6AgdW4gbW9tZW50IGRlIGxhIGpvdXJuw6llIGVuIHBhcnRpY3VsaWVyID8=
+        - 19, 59 Do you wish to wait until a specific time of the day?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2575,8 +2547,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDYwIEplIHBhc3NlIGwnaGV1cmUgw6AgN2gwMC4=
+        - 19, 60 I want to wait until 7am.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2648,8 +2619,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDYxIEplIHBhc3NlIGwnaGV1cmUgw6AgMTFoMDAu
+        - 19, 61 I want to wait until 11am.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2721,8 +2691,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDYyIEplIHBhc3NlIGwnaGV1cmUgw6AgMTloMDAu
+        - 19, 62 I want to wait until 7pm.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2794,8 +2763,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDYzIEplIHBhc3NlIGwnaGV1cmUgw6AgMjJoMDAu
+        - 19, 63 I want to wait until 10pm.
         indent: 3
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2906,13 +2874,12 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 64 Actuellement, notre univers utilise l'horloge virtuelle...
+        - 19, 64 Currently, our universe uses the virtual clock...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          VmV1eC10dSBsYWlzc2VyIGxlIHRlbXBzIHJlZGV2bmlyIG1hw650cmUgZXQgcmV0b3VybmVyIMOgIGwnaG9ybG9nZSByw6llbGxlID8=
+        - Do you want to swap to the real clock?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -2935,8 +2902,8 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDY1IFRyw6hzIGJpZW4sIG5vdHJlIHVuaXZlcnMgdmEgZMOpY8OpbMOpcmVyIGRhbnMgMy4uLltXQUlUIDQwXSAyLi4uW1dBSVQgNDBdIDEuLi4gW1dBSVQgNDBd
+        - 19, 65 Very well, our universe will decelerate in 3...[WAIT 40] 2...[WAIT
+          40] 1... [WAIT 40]
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2971,20 +2938,17 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDY2IFZvaWzDoC4uLg==
+        - 19, 66 Done...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          TGEgZmFicmlxdWUgdGVtcG9yZWxsZSBkZSBub3RyZSB1bml2ZXJzIGEgY2hhbmfDqS4uLg==
+        - The time fabric of our universe has changed...
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDY3IEwnaG9ybG9nZSByw6llbGxlIHN1aXQgZXhhY3RlbWVudCBsJ2hldXJlIGRlIHRvbiBQQy4=
+        - 19, 67 The real clock strictly follows your system's clock.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3020,8 +2984,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDY4IFJldmllbnMgbWUgdm9pciBzaSB0dSB2ZXV4IMOgIG5vdXZlYXUgbW9kaWZpZXIgbGUgdGVtcHMuLi4=
+        - 19, 68 Come see me back if you want to change time again...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3119,13 +3082,12 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 69 :[name=Marissa]:Oh, tu es de retour...
+        - 19, 69 :[name=Marissa]:Oh, you're back...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          VHUgYXMgY2hhbmfDqSBkJ2F2aXMgPw==
+        - Did you change your mind?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3138,19 +3100,18 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDcwIFNpIHNldWxlbWVudCBqZSBuZSBtJ8OpdGFpcyBwYXMgcGVuY2jDqWUgcG91ciB2b2lyIGNldHRlIHNhdGFuw6llIHNpbGhvdWV0dGUgaHVtYW5vw69kZS4uLg==
+        - 19, 70 Why did I have to bend over to see this damned humanoid figure...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 71 Je serais encore vivante et je vivrais mon idylle...
+        - 19, 71 I would still be alive and living my perfect love life...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDcyIFNpIGplIHBvdXZhaXMgYXR0cmFwZXIgY2V0dGUgY2hvc2UgZXQgbHVpIGZhaXJlIGdvw7t0ZXIgw6AgbWVzIGJhZmZlcyBmYW50b21hdGlxdWVzLCBqZSBuZSBtZSBnw6puZXJhaXMgcGFzLi4u
+        - 19, 72 If only I could just catch this thing and make it taste some of my
+          ghostly slaps, I wouldn't be shy about doing that...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3198,36 +3159,34 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 73 Tu... Tu peux me voir ? Et m'entendre ?!
+        - 19, 73 You... You can see me? And hear me?!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - C'est formidable !
+        - It's amazing!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDc0IEplIHBlbnNhaXMgcXVlIGonw6l0YWlzIGNvbmRhbW7DqWUgw6AgZXJyZXIgw6l0ZXJuZWxsZW1lbnQsIMOgIHJlZ2FyZGVyIGxlIHZpZGUgZGFucyBsZXF1ZWwgamUgc3VpcyB0b21iw6llLCBldCDDoCByZXNzYXNzZXIgbWVzIHJlZ3JldHMuLi4=
+        - 19, 74 I thought I was doomed to wander eternally and watch the void I fell
+          into, as well as rehash my regrets...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDc1IE9oIG1haXMgcGFyZG9uLCBqZSBuZSBtZSBzdWlzIHBhcyBwcsOpc2VudMOpZS4uLg==
+        - 19, 75 Oh, sorry, where are my manners...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDc2IEplIG0nYXBwZWxsZSBNYXJpc3NhLCBldCBjb21tZSB0dSBwZXV4IGxlIGNvbnN0YXRlciwgamUgc3VpcyB1biBmYW50w7RtZSBxdWUgcGVyc29ubmUgbmUgdm9pdC4=
+        - 19, 76 :[name=Marissa]:I'm Marissa, and as you can notice, I'm a ghost nobody
+          sees.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDc3IDpbbmFtZT1NYXJpc3NhXTpNYWlzLi4uIENvbW1lIHR1IGVzIGzDoCBldCBxdWUgdHUgcGV1eCBtZSB2b2lyLi4uIA==
+        - 19, 77 :[name=Marissa]:But... As you're here and you can see me....
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3240,8 +3199,7 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDc4IDpbbmFtZT1NYXJpc3NhXTpUdSB2ZXV4IGJpZW4gYWNjw6lkZXIgw6AgcXVlbHF1ZXMgdW5lcyBkZSBtZXMgZGVtYW5kZXMgPw==
+        - 19, 78 :[name=Marissa]:Would you be so kind as to access some of my demands?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3259,31 +3217,30 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '19, 79 :[name=Marissa]:Merci mille fois ! '
+        - 19, 79 :[name=Marissa]:Thank you very much!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 80 :[name=Marissa]:Je vais avoir besoin que tu fasses deux choses pour
-          moi.
+        - 19, 80 :[name=Marissa]:I will need you to do two things for me.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDgxIDpbbmFtZT1NYXJpc3NhXTpUb3V0IGQnYWJvcmQsIGplIHZvdWRyYWlzIHF1ZSB0dSBhaWxsZXMgcGFybGVyIMOgIG1vbiBhbW91cmV1eCDigJMgZW5maW4gZXgtYW1vdXJldXgsIHZ1IHF1ZSBqZSBzdWlzIG1vcnRlLiA=
+        - 19, 81 :[name=Marissa]:First, I'd like you to talk to my lover – well, ex-lover,
+          as I'm dead.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 82 :[name=Marissa]:Je n'ai jamais pu lui dire "Je t'aime", et c'est
-          pour moi un immense regret.
+        - 19, 82 :[name=Marissa]:I never was able to tell him "I love you", and it's
+          an immense regret.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDgzIDpbbmFtZT1NYXJpc3NhXTpKJ2FpbWVyYWlzIGRvbmMgcXVlIHR1IGFpbGxlcyBsdWkgZGlyZSBwb3VyIG1vaSwgdW5lIHNvcnRlIGRlIGTDqWNsYXJhdGlvbiBwb3N0LW1vcnRlbS4uLg==
+        - 19, 83 :[name=Marissa]:So I would like you to tell him for me, a sort of
+          post-mortem confession...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3333,54 +3290,52 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 84 :[name=Marissa]:Tu le trouveras dans la Tour, au niveau de la balustrade.
+        - 19, 84 :[name=Marissa]:You'll find him in the Tower, around the balustrade.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 85 :[name=Marissa]:Il s'appelle Jules, tu ne peux pas le louper.
+        - 19, 85 :[name=Marissa]:His name is Jules, you can't miss him.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDg2IDpbbmFtZT1NYXJpc3NhXTpFdCBlbmZpbiwgaidhcHByw6ljaWVyYWlzIHF1ZSB0dSBtZSBjYXB0dXJlcyB1biBQb2vDqW1vbiBTcGVjdHJlLg==
+        - 19, 86 :[name=Marissa]:And finally, I would like you to catch a Ghost Pokémon.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDg3IDpbbmFtZT1NYXJpc3NhXTpWb2lzLXR1LCBqJ2FpIHRvdWpvdXJzIHLDqnbDqSBkJ2VuIGF2b2lyIHVuLCBtYWlzIGplIG4nYWkgamFtYWlzIGZyYW5jaGkgbGUgcGFzLg==
+        - 19, 87 :[name=Marissa]:See, I always dreamed of having one, but I never
+          took the plunge.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDg4IDpbbmFtZT1NYXJpc3NhXTpFdCBzaSBjJ2VzdCB1biBQb2vDqW1vbiBTcGVjdHJlLCBpbCB5IGEgZGUgZ3JhbmRlcyBjaGFuY2VzIHF1J2lsIHB1aXNzZSBtZSBzdWl2cmUgZGUgbCdhdXRyZSBjw7R0w6ksIGplIG5lIHNlcmFpIGRvbmMgcGFzIHNldWxlLg==
+        - 19, 88 :[name=Marissa]:And if it's a Ghost Pokémon, there's a huge chance
+          it will be able to follow me to the other side, so I won't be alone then.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDg5IDpbbmFtZT1NYXJpc3NhXTpEJ2FwcsOocyBkZXMgb3XDry1kaXJlLCBpbCB5IGF1cmFpdCB1biBQb2vDqW1vbiBTcGVjdHJlIHF1aSBoYW50ZSBsJ8OpdGFnZSBkZSBsYSBUb3VuZHJhIDogYydlc3QgY2VsdWktbMOgIHF1ZSBqZSB2ZXV4Lg==
+        - '19, 89 :[name=Marissa]:According to hearsay, there is a Ghost Pokémon haunting
+          the Toundra floor: I want this one.'
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDkwIDpbbmFtZT1NYXJpc3NhXTpTaSDDp2EgcGV1dCB0J2FpZGVyLCBqZSBjcm9pcyBxdSdpbCBzJ2FnaXQgZCd1biBNb21hcnRpay4=
+        - 19, 90 :[name=Marissa]:If it can help, I believe it's called a Froslass.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDkxIDpbbmFtZT1NYXJpc3NhXTpKZSBuZSBzYWlzIHBhcyDDoCBxdW9pIMOnYSByZXNzZW1ibGUsIG1haXMgdHUgZXMgXGZbdW5lIERyZXNzZXVzZcKndW4gRHJlc3NldXJdIGRlIFBva8OpbW9uLCBjZWxhIG5lIGRldnJhaXQgcGFzIHRlIHBvc2VyIGRlIHByb2Jsw6htZSAh
+        - 19, 91 :[name=Marissa]:I don't know what it looks like, but you're a Pokémon
+          Trainer, so it shouldn't cause you any problem.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDkyIDpbbmFtZT1NYXJpc3NhXTpKZSB0ZSBsYWlzc2UgZ8OpcmVyIMOnYSwgcmV2aWVucyBtZSB2b2lyIHF1YW5kIHR1IGF1cmFzIGZpbmkgIQ==
+        - 19, 92 :[name=Marissa]:I will let you handle it, come see me back when you're
+          done!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3464,13 +3419,12 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 93 :[name=Marissa]:Je... Je comprends...
+        - 19, 93 :[name=Marissa]:I... I understand...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDk0IDpbbmFtZT1NYXJpc3NhXTpRdWkgYWlkZXJhaXQgdW4gZmFudMO0bWUgZGUgc29uIHBsZWluIGdyw6kgPw==
+        - 19, 94 :[name=Marissa]:Who in their right mind would help a ghost?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3480,13 +3434,12 @@ events:
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 95 :[name=Marissa]:Reviens me voir si tu changes d'avis...
+        - 19, 95 :[name=Marissa]:Come back if you change your mind...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDk2IDpbbmFtZT1NYXJpc3NhXTpBcHLDqHMgdG91dCwgaidhaSBsJ8OpdGVybml0w6kgZGV2YW50IG1vaS4uLg==
+        - 19, 96 :[name=Marissa]:After all, I have eternity ahead of me...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3646,54 +3599,48 @@ events:
         code: 223
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 97 :[name=Marissa]:Ne dis rien, ton regard me dit tout.
+        - 19, 97 :[name=Marissa]:Say nothing, your eyes tell me everything.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDk4IDpbbmFtZT1NYXJpc3NhXTpHcsOiY2Ugw6AgdG9pLCBqZSB2YWlzIHBvdXZvaXIgcGFydGlyIGVuIHBhaXgu
+        - 19, 98 :[name=Marissa]:Thanks to you, I will be able to leave with peace
+          of mind.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDk5IDpbbmFtZT1NYXJpc3NhXTpBbG9ycyBkaXMtbW9pLCBxdSdhIGRpdCBtb24gYmllbi1haW3DqSA/
+        - 19, 99 :[name=Marissa]:So tell me, what did my beloved say?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 100 :[name=Marissa]:.[WAIT 20].[WAIT 20].[WAIT 20] Pardon ?
+        - 19, 100 :[name=Marissa]:.[WAIT 20].[WAIT 20].[WAIT 20] I beg your pardon?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEwMSA6W25hbWU9TWFyaXNzYV06SWwgYSBwZW5zw6kgcXVlIHR1IGNoZXJjaGFpcyDDoCBsZSBtYXVkaXJlID8=
+        - 19, 101 :[name=Marissa]:He thought you tried to curse him?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEwMiA6W25hbWU9TWFyaXNzYV06TW9uIGFtb3VyIG4nZXN0IHF1J3VuZSBtYWzDqWRpY3Rpb24gcG91ciBsdWkuLi4/
+        - 19, 102 :[name=Marissa]:So my love was only a curse to him..?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEwMyA6W25hbWU9TWFyaXNzYV06SmUuLi4gSmUgbSdhdHRlbmRhaXMgw6AgdG91dCwgc2F1ZiDDoCDDp2EuLi4=
+        - 19, 103 :[name=Marissa]:I was ready for anything but that...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 104 :[name=Marissa]:Il n'y a donc vraiment plus rien qui me retienne
-          ici.
+        - 19, 104 :[name=Marissa]:So there's definitely nothing that keeps me here.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEwNSA6W25hbWU9TWFyaXNzYV06TWFpcyBhdSBtb2lucywgamUgdmFpcyBwYXJ0aXIgYXZlYyB1biBub3V2ZWwgYW1pLiBUdSBtZSBsZSBwcsOpc2VudGVzID8=
+        - 19, 105 :[name=Marissa]:At least, I will be able to leave with a new friend.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3831,23 +3778,22 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 106 :[name=Marissa]:Que... qu'est ce que...?!
+        - 19, 106 :[name=Marissa]:What... What the hell...?!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEwNyA6W25hbWU9TWFyaXNzYV06Qydlc3QgbGEgc2lsaG91ZXR0ZSDDoCBjYXVzZSBkZSBsYXF1ZWxsZSBqZSBzdWlzIHRvbWLDqWUgIQ==
+        - 19, 107 :[name=Marissa]:That's the figure I bent over to see!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 108 :[name=Marissa]:C'est une blague ?!
+        - 19, 108 :[name=Marissa]:It's a joke, right?!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Parce qu'elle me fait pas rire du tout...
+        - Because it isn't funny at all!
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3857,48 +3803,44 @@ events:
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          Qydlc3QgbGUgUG9rw6ltb24gcXVpIGhhbnRhaXQgbCfDqXRhZ2UgZGUgbGEgVG91bmRyYSA/
+        - It's the Pokémon that was haunting the Tundra floor?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDExMCA6W25hbWU9TWFyaXNzYV06UXVvaSA/IExlIHByZW5kcmUgcXVhbmQgbcOqbWUgYXZlYyBtb2kgPw==
+        - 19, 110 :[name=Marissa]:What? Take it with me anyway?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Pour qu'il me rappelle constamment ma mort honteuse ?
+        - I don't want to be remembered of my shameful death.
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDExMSA6W25hbWU9TWFyaXNzYV06SG9ubsOqdGVtZW50LCBwbHV0w7R0IG1vdXJpciBxdWUgZGUgcHJlbmRyZSBjZSBQb2vDqW1vbiBhdmVjIG1vaSwgZXQgw6dhIHRvbWJlIGJpZW4gcGFyY2UgcXVlIGplIHN1aXMgZMOpasOgIG1vcnRlLg==
+        - 19, 111 :[name=Marissa]:Honestly, I'd rather die than take this Pokémon
+          with me, and it's good because I'm already dead.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDExMiA6W25hbWU9TWFyaXNzYV06TWVyY2kgbWFsZ3LDqSB0b3V0IHBvdXIgdG9uIGFpZGUsIFxmW0RyZXNzZXVzZcKnRHJlc3NldXJdLg==
+        - 19, 112 :[name=Marissa]:Thanks for your help anyway, Trainer.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDExMyA6W25hbWU9TWFyaXNzYV06TGVzIHLDqXN1bHRhdHMgZMOpc2FzdHJldXggZGUgdGVzIGVmZm9ydHMgbidvbnQgcmllbiDDoCB2b2lyIGF2ZWMgdG9pLCDDp2EgZG9pdCB2ZW5pciBkZSBtb24ga2FybWEgb3UgcXVlbHF1ZSBjaG9zZSBjb21tZSDDp2EuLi4=
+        - 19, 113 :[name=Marissa]:The disastrous results of your efforts aren't your
+          fault, that has to be my karma or something like that....
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDExNCA6W25hbWU9TWFyaXNzYV06SmUgbidvdWJsaWUgcGFzIHRlcyByw6ljb21wZW5zZXMgYmllbiBlbnRlbmR1Lg==
+        - 19, 114 :[name=Marissa]:I won't forget your rewards, of course.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Les voici.
+        - Here, take these.
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3943,20 +3885,17 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDExNSA6W25hbWU9TWFyaXNzYV06SmUgdm9pcyBsYSBsdW1pw6hyZSBkZSBsJ2F1LWRlbMOgLg==
+        - 19, 115 :[name=Marissa]:I can see the light.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDExNiA6W25hbWU9TWFyaXNzYV06w4l0cmFuZ2VtZW50LCBlbGxlIGVzdCBlbiBjb250cmViYXMsIGzDoCBvw7kgamUgc3VpcyBtb3J0ZS4uLg==
+        - 19, 116 :[name=Marissa]:Weirdly, it is there, in the void, where I'm dead...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          TGUgaGFzYXJkIGZhaXQgdHLDqHMgbWFsIGxlcyBjaG9zZXMu
+        - '"Luck would have it" they say? I beg to differ...'
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -3981,13 +3920,13 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDExNyA6W25hbWU9TWFyaXNzYV06SmV1bmUgXGZbZmlsbGXCp2hvbW1lXSwgamUgdGUgc291aGFpdGUgdW5lIHZpZSBwcm9zcMOocmUgZXQgbW9pbnMgY2hhb3RpcXVlIHF1ZSBsYSBtaWVubmUu
+        - 19, 117 :[name=Marissa]:Young \f[woman§man], I wish you a prosperous and
+          less chaotic life than mine.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Adieu.
+        - Farewell.
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -4109,8 +4048,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDExOCBNb21hcnRpayBhIGwnYWlyIGTDqcOndS4uLg==
+        - 19, 118 Froslass seems kind of sad...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4185,13 +4123,12 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 119 :[name=Marissa]:Merci de prendre le temps de m'aider !
+        - 19, 119 :[name=Marissa]:Thanks for taking the time to help!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEyMCA6W25hbWU9TWFyaXNzYV06TmUgdGUgcHJlc3NlIHBhcyBzdXJ0b3V0LCBqZSBwZXV4IGF0dGVuZHJlIHVuZSDDqXRlcm5pdMOpIHMnaWwgbGUgZmF1dCAh
+        - 19, 120 :[name=Marissa]:Take your time, I can wait an eternity if needed!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4527,7 +4464,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 121 Je ferais mieux de revenir plus tard...
+        - 19, 121 I better come back later...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4887,7 +4824,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 122 Je ferais mieux de revenir plus tard...
+        - 19, 122 I better come back later...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5302,7 +5239,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 123 Je ferais mieux de revenir plus tard...
+        - 19, 123 I better come back later...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -5937,7 +5874,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 124 Je ferais mieux de revenir plus tard...
+        - 19, 124 I better come back later...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6297,14 +6234,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEyNSBUdSB2ZXV4IGTDqWrDoCB0J2VuIGFsbGVyID8=
+        - 19, 125 You already want to leave ?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEyNiBNb2kgaidzdWlzIHBhcyBwcsOocyBkZSBsZXZlciBsJ2FuY3JlICE=
+        - 19, 126 I'm not ready at all to weigh anchor!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6931,31 +6866,27 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEyNyBGaW91LCBzYWNyw6kgdHJhamV0ICE=
+        - 19, 127 Phew, what a journey!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 128 Pas trop le mal de mer ?
+        - 19, 128 Not too sea sick?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEyOSBNZXJjaSBkJ2F2b2lyIHV0aWxpc8OpIG5vcyBzZXJ2aWNlcyBwb3VyIHRlIHJlbmRyZSBpY2kuIE1haXMgdHLDqnZlIGRlIGJhdmFyZGFnZXMsIGonYWkgY3J1IGNvbXByZW5kcmUgcXVlIHQnw6l0YWlzIGF0dGVuZHVcRSA/
+        - 19, 129 Thanks for using our service to come here!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEzMCBGYXVkcmFpdCBwYXMgdHJvcCBsZXMgZmFpcmUgcGF0aWVudGVyLCB0J2FzIGp1c3RlIMOgIHRlIHJlbmRyZSDDoCBsYSBUb3VyIHRvdXQgYXUgbm9yZCwgw6AgbGEgc29ydGllIGR1IHBvbnRvbi4=
+        - 19, 130 You shouldn't make them wait for too long.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEzMSBEJ2FpbGxldXJzLCBvbiBtJ2EgZGVtYW5kw6kgZGUgdGUgZm91cm5pciBjZWNpLg==
+        - 19, 131 Oh, before I forget, here's something they asked me to give you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -6965,20 +6896,17 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEzMiBDJ2VzdCB1biBqb3VybmFsIGRlIHF1w6p0ZXMuIMOHYSB0ZSBwZXJtZXQgZGUgdsOpcmlmaWVyIHRlcyBxdcOqdGVzIGVuIGNvdXJzLCBldCBsZXMgb2JqZWN0aWZzIGRlIGNlcyBxdcOqdGVzLg==
+        - 19, 132 It's a Quest book.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEzMyBKZXR0ZXMteSB1biBvZWlsLCDDp2EgdGUgc2VyYSBwcm9iYWJsZW1lbnQgdXRpbGUgIQ==
+        - 19, 133 Have a look at it, it might be useful!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEzNCBCb24gc8Opam91ciBpY2ksIG1vdXNzYWlsbG9uICE=
+        - 19, 134 Have a nice stay, you landlubber!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7058,14 +6986,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEzNSBVbiBhbWkgbSdhIGRpdCBxdSdvbiBuZSBwb3V2YWl0IHBhcyBww6pjaGVyIGF1IG5pdmVhdSBkZSBjZSBwb250b24u
+        - 19, 135 I was told by a friend that we can't fish on the dock.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEzNiBVbmUgaGlzdG9pcmUgZGUgXGNbNV0iU3lzdGVtIFRhZyBkZSBtZXIiXGNbMF0gcGFzIGFwcGxpcXXDqSwgb3UgdW4gdHJ1YyBkdSBnZW5yZS4uLg==
+        - 19, 136 Something about a \c[5]"Sea System Tag"\c[0] not applied, or something
+          like that...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7335,43 +7262,41 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEzNyBNYWlzIGVuZmluIFxmW21hbGhldXJldXNlwqdtYWxoZXVyZXV4XSwgb24gdCdhIGphbWFpcyBhcHByaXMgw6AgbmUgcGFzIGFsbGVyIHN1ciB1bmUgUm91dGUgc2FucyBQb2vDqW1vbiA/IQ==
+        - 19, 137 Hey you, are you insane?!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 138 ... Je plaisante !
+        - 19, 138 ... I'm joking!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          RW5maW4sIMOgIG1vaXRpw6kuLi4=
+        - Well, half-joking...
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDEzOSBWb2lzLXR1LCBQb2vDqW1vblNESyBuZSB0ZSByZW52ZXJyYSBwYXMgZCdlcnJldXIgc2kgdHUgbidhcyBwYXMgZGUgUG9rw6ltb24gc3VyIHRvaSwgbWFpcyBpbCBuZSBsYW5jZXJhIGF1Y3VuIGNvbWJhdCBub24gcGx1cy4=
+        - 19, 139 See, PokémonSDK won't raise any error if you don't have any Pokémon
+          on you, but it won't launch any battle either.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE0MCBUdSBkb2lzIGRvbmMgdCdhc3N1cmVyIGRlIGRvbm5lciBkZXMgUG9rw6ltb24gw6AgdGVzIGpvdWV1cnMgYXZhbnQgcXUnaWxzIG4nYWllbnQgYWNjw6hzIMOgIGRlcyBjb21iYXRzIG91IGRlcyBoYXV0ZXMgaGVyYmVzLg==
+        - 19, 140 So it's your job to give a Pokémon to your player before they can
+          gain access to trainer battles or to tall grass.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE0MSBKZSBwb3VycmFpcyB0ZSBsYWlzc2VyIHBhc3NlciwgbWFpcyBwb3VyIHF1ZSBjZXR0ZSBkw6ltbyBzZSBkw6lyb3VsZSBiaWVuLCBpbCB2YXVkcmFpdCBtaWV1eCBxdWUgdHUgcsOpY3Vww6hyZXMgdW4gb3UgcGx1c2lldXJzIFBva8OpbW9uLg==
+        - 19, 141 I could let you pass, but for the sake of this demo, you should
+          retrieve one or more Pokémon.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE0MiBJbCB5IGEgZGUgZ3JhbmRlcyBjaGFuY2VzIHF1ZSBTaXJNYWxvIHQnYXR0ZW5kZSDDoCBsYSBUb3VyLCB0dSBkZXZyYWlzIHQneSByZW5kcmUgIQ==
+        - 19, 142 There's a high chance SirMalo is waiting for you at the Tower, you
+          should go to it.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7495,19 +7420,19 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 143 Bonjour Maker !
+        - 19, 143 Hello Maker!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE0NCBDb21tZSB0dSBwZXV4IGxlIGNvbnN0YXRlciwgamUgbW9udGUgbGEgZ2FyZGUgcG91ciBtJ2Fzc3VyZXIgcXVlIHF1aWNvbnF1ZSBcQ1s1XW5lIHBvc3PDqWRhbnQgcGFzIGRlIFBva8OpbW9uXENbMF0gbmUgcHVpc3NlIHBhc3Nlci4=
+        - 19, 144 As you can see, I stand guard to make sure that anyone \c[5]who
+          doesn't have a Pokémon\c[0] can't get through.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE0NSBKZSBzZXJhaSBvYmxpZ8OpIGRlIHQnYXJyw6p0ZXIgc2kgdHUgZXNzYXllcyBkZSB0ZSByZW5kcmUgc3VyIGNldHRlIHJvdXRlIHNhbnMgUG9rw6ltb24gIQ==
+        - 19, 145 I will have to stop you if you try to head to the Route without
+          a Pokémon!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7586,13 +7511,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE0NiBPaCwgamUgdm9pcyBxdWUgdHUgYXMgZGVzIFBva8OpbW9uIHN1ciB0b2ku
+        - 19, 146 Oh, I see you have Pokémon with you.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 147 Amuse-toi bien sur la Route !
+        - 19, 147 Have fun on the Route then!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -7976,37 +7900,36 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 148 :[name=SirMalo]:Hey \N[1] !
+        - 19, 148 :[name=SirMalo]:Hey \N[1]!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Ravi de te rencontrer en chair et en os !
+        - Glad to meet you in the flesh!
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE0OSA6W25hbWU9U2lyTWFsb106TGUgdHJhamV0IHMnZXN0IGJpZW4gcGFzc8OpLCBqZSBwcsOpc3VtZSA/
+        - 19, 149 :[name=SirMalo]:The trip went well, I assume?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - - 19, 150 Franchement, oui !
-          - 19, 151 Honnêtement, non...
+        - - 19, 150 Frankly, yes!
+          - 19, 151 Honestly, no...
         - 2
         indent: 0
         code: 102
       - !ruby/object:RPG::EventCommand
         parameters:
         - 0
-        - Franchement, oui !
+        - 19, 150 Frankly, yes!
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 152 :[name=SirMalo]:On refera appel aux services de cette compagnie
-          pour les prochains makers dans ce cas !
+        - 19, 152 :[name=SirMalo]:We will use the services of this company again for
+          the next Makers in this case!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8016,20 +7939,19 @@ events:
       - !ruby/object:RPG::EventCommand
         parameters:
         - 1
-        - !binary |-
-          SG9ubsOqdGVtZW50LCBub24uLi4=
+        - 19, 151 Honestly, no...
         indent: 0
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE1MyA6W25hbWU9U2lyTWFsb106TWluY2UsIG1vaSBxdWkgY3JveWFpcyBxdWUgw6dhIHNlcmFpdCBsYSBib25uZSBjb21wYWduaWUgY2V0dGUgZm9pcy4uLg==
+        - 19, 153 :[name=SirMalo]:Damn, and here I thought it was the right one this
+          time...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 154 :[name=SirMalo]:On en changera pour les prochains makers, merci
-          de ta franchise !
+        - 19, 154 :[name=SirMalo]:We will change it for the next Makers, thanks for
+          your honesty!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8042,26 +7964,25 @@ events:
         code: 404
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE1NSA6W25hbWU9U2lyTWFsb106UXVvaSBxdSdpbCBlbiBzb2l0LCBqZSB2b3VsYWlzIGp1c3RlIG0nYXNzdXJlciBxdWUgdHUgw6l0YWlzIGJpZW4gYXJyaXbDqVxFLCBldCBjJ2VzdCBsZSBjYXMgIQ==
+        - 19, 155 :[name=SirMalo]:Anyway, I wanted to make sure you arrived safely,
+          and that's the case!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE1NiA6W25hbWU9U2lyTWFsb106SidhdXJhaXMgcHUgdGUgZG9ubmVyIHRvbiBjYWRlYXUgZCdhcnJpdsOpZSB0b3V0IGRlIHN1aXRlLCBtYWlzIGlsIHNlbWJsZXJhaXQgcXVlIGplIGwnYWllIG91Ymxpw6kgZGFucyBsYSBUb3VyLi4uIE91cHMgIQ==
+        - 19, 156 :[name=SirMalo]:I could have given you your welcome gift right now,
+          but it seems like I forgot it in the Tower... Oopsie!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE1NyA6W25hbWU9U2lyTWFsb106SmUgdCdhdHRlbmRzIMOgIGxhIFRvdXIgcG91ciB0ZSBsZSBkb25uZXIsIGlsIGZhbGxhaXQgYmllbiBxdWUgdHUgdCd5IHJlbmRlcyBkZSB0b3V0ZSBtYW5pw6hyZS4=
+        - 19, 157 :[name=SirMalo]:I will wait for you at the Tower to give it to you,
+          you have to go there at some point anyways.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE1OCA6W25hbWU9U2lyTWFsb106w4AgdG91dCDDoCBsJ2hldXJlLCBNYWtlciAh
+        - 19, 158 :[name=SirMalo]:See you later, Maker!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8266,8 +8187,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE1OSBUdSBuJ2VzIHBhcyBlbmNvcmUgcGFzc8OpXEUgcGFyIGxhIFRvdXIgPyBRdSdlc3QgY2UgcXVlIHR1IGF0dGVuZHMgPw==
+        - 19, 159 Didn't you get to the Tower yet?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8280,8 +8200,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE2MCBTYWx1dCBqZXVuZSBncmFpbmUgZGUgXGZbcMOqY2hldXNlwqdww6pjaGV1cl0gISBKZSB2ZW5kcyBtZXMgdG91dGVzIGRlcm5pw6hyZXMgcHJpc2VzLCDDp2EgdCdpbnTDqXJlc3NlID8=
+        - 19, 160 Hello young fisherman in the making!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8299,13 +8218,12 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE2MSBKZSB0ZSBtb250cmUgbW9uIHN0b2NrIGRlLi4uIEF0dGVuZHMsIGplIHZvaXMgcXVlIHR1IG4nZXMgcGFzIHBhc3PDqVxFIHBhciBsYSBUb3VyLCBqZSBuZSBwZXV4IGRvbmMgcGFzIHRlIG1vbnRyZXIgbW9uIHN0b2NrIGRlIHN1aXRlLg==
+        - 19, 161 Here's my stock of...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 162 Passes-y et je pourrais te montrer mes prises !
+        - 19, 162 Stop by it and come see me again so I can show my catches!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8320,13 +8238,12 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE2MyBEb21tYWdlICEgQXR0ZW5kcy4uLiBUdSBuJ2VzIHBhcyBwYXNzw6lcRSDDoCBsYSBUb3VyID8gSmUgbidhdXJhaSByaWVuIHB1IHRlIHZlbmRyZSBkZSB0b3V0ZSBtYW5pw6hyZSAh
+        - 19, 163 Too bad! Wait, you didn't go to the Tower yet?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 19, 164 Passes-y et je pourrai te montrer mes plus belles prises !
+        - 19, 164 Stop by it and come see me again so I can show my catches!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8400,8 +8317,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE2NSBSZWJvbmpvdXIgISBKZSB2b2lzIHF1ZSB0dSBlcyBlbmZpbiBkaXNwb3PDqVxFIMOgIHZvaXIgbW9uIHN0b2NrLCDDp2EgdCdpbnTDqXJlc3NlID8=
+        - 19, 165 Welcome back! I see you are finally ready to see my stuff?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8414,8 +8330,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE2NiBTYWx1dCBqZXVuZSBncmFpbmUgZGUgXGZbcMOqY2hldXNlwqdww6pjaGV1cl0gISBKZSB2ZW5kcyBtZXMgdG91dGVzIGRlcm5pw6hyZXMgcHJpc2VzLCDDp2EgdCdpbnTDqXJlc3NlID8=
+        - 19, 166 Hello young fisherman in the making!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -8444,8 +8359,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MTksIDE2NyBKZSBww6pjaGUgYmVhdWNvdXAsIGRvbmMgamUgbmUgc2VyYWkgamFtYWlzIGVuIG1hbnF1ZSBkZSBQb2vDqW1vbiDDoCB0ZSB2ZW5kcmUu
+        - 19, 167 I'm fishing a lot, so I'll never run out of Pokémon to sell you.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map020.rxdata.yml
+++ b/Data/Map020.rxdata.yml
@@ -583,7 +583,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 0 :[name=Chrysacier]:Ziaaaaoum[WAIT 60]
+        - 20, 0 :[name=Metapod]:Ziaaaaoum[WAIT 60]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -593,8 +593,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDEgVm91cyBhdmV6IHLDqXZlaWxsw6kgbGVzIFBva8OpbW9uIEluc2VjdGUgIQ==
+        - 20, 1 You've awakened the Bug Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -783,7 +782,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 2 :[name=Coconfort]:...[WAIT 90]
+        - 20, 2 :[name=Kakuna]:...[WAIT 90]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -793,8 +792,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDMgVm91cyBhdmV6IHLDqXZlaWxsw6kgbGVzIFBva8OpbW9uIEluc2VjdGUgIQ==
+        - 20, 3 You've awakened the Bug Pokémon!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1038,14 +1036,14 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 4 Je sais pas si tu sais comment cacher un objet et le rendre cherchable
-          par le Cherch'Objet ?
+        - 20, 4 Do you know how to hide an item and make it searchable using the Dowsing
+          Machine?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 5 Pour ce faire, le nom de l'event en question doit commencer par \c[5]"invisible_"\c[0]
-          ou se nommer \c[5]"OBJ_INVISIBLE"\c[0] exactement.
+        - 20, 5 To do that, the name of the event needs to start with \c[5]"invisible_"\c[0]
+          or be exactly named \c[5]"OBJ_INVISIBLE"\c[0].
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1058,25 +1056,24 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDYgU2FsdXQsIGpldW5lIFxmW2V4cGxvcmF0cmljZcKnZXhwbG9yYXRldXJdICE=
+        - 20, 6 Hello, young explorer!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          VG9pIGF1c3NpIHR1IGNoZXJjaGVzIGxlcyB0csOpc29ycyBxdWkgam9uY2hlbnQgbGUgc29sID8=
+        - Are you also interested in the treasures that litters the ground?
         indent: 1
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDcgT24gbSdhcHBlbGxlIGxlIENoZXJjaGV1ciBkJ09iamV0cyBzdXIgY2V0dGUgw45sZSwgbm9tIHF1aSBtJ2Egw6l0w6kgZG9ubsOpIHBvdXIgbWVzIG5vbWJyZXVzZXMgaGV1cmVzIMOgIGNoZXJjaGVyIGRlcyByYXJldMOpcyBkYW5zIGxhIG5hdHVyZS4uLg==
+        - 20, 7 Everyone on this Island calls me the "Item Finder," name of which
+          was given to me for the countless hours I spent searching rarities in the
+          wild...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 8 ... avec l'aide de mon merveilleux Cherch'Objet !
+        - 20, 8 ... with the help of my marvelous Dowsing Machine!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1087,8 +1084,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDkgLi4uIEFoIG1haXMuLi4gVHUgZW4gYXMgdW4gYXVzc2kgPyBKZSB2b2lzIHF1ZSB0dSBlcyB0b2kgYXVzc2kgXGZbdW5lIGNoZXJjaGV1c2XCp3VuIGNoZXJjaGV1cl0gZGUgY3VsdHVyZSAh
+        - 20, 9 ... Wait... You have one too?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1101,24 +1097,22 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 10 Il a l'air de te plaire.
+        - 20, 10 You seem to like it.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          VG9pIGF1c3NpIHR1IHZldXggcGFydGljaXBlciDDoCBjZXR0ZSBiZWxsZSBjaGFzc2UgPw==
+        - Do you also want to be part of this great hunt?
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDExIEFsbGV6LCB0aWVucywgcHJlbmRzIMOnYSAh
+        - 20, 11 Here, take this!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Fais-en bon usage !
+        - Put it to good use!
         indent: 2
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1136,14 +1130,14 @@ events:
         code: 412
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 12 Je sais pas si tu sais comment cacher un objet et le rendre cherchable
-          par le Cherch'Objet ?
+        - 20, 12 Do you know how to hide an item and make it searchable using the
+          Dowsing Machine?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 13 Pour ce faire, le nom de l'event en question doit commencer par \c[5]"invisible_"\c[0]
-          ou se nommer \c[5]"OBJ_INVISIBLE"\c[0] exactement.
+        - 20, 13 To do that, the name of the said event needs to start with \c[5]"invisible_"\c[0]
+          or be exactly named \c[5]"OBJ_INVISIBLE"\c[0].
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1325,14 +1319,13 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDE0IDpbbmFtZT1SZXldOlR1IGwnYXMgcsOpY3Vww6lyw6kgPyBDaGFwZWF1LCBjJ2VzdCBwb3VydGFudCBwYXMgc2ltcGxlIGRlIHRyb3V2ZXIgdW4gUG9rw6ltb24gRW9uIHZ1IGxldXJzIGNhcGFjaXTDqXMu
+        - 20, 14 :[name=Rey]:Did you catch it? Good job! It's really not easy to find
+          an Eon Pokémon with their abilities.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDE1IDpbbmFtZT1SZXldOkR1IGNvdXAgYnJhdm8sIHZvaWzDoCBtYSBQaWVycmUgSW5zb2xpdGUgIQ==
+        - 20, 15 :[name=Rey]:Well, congratulations then, here's my Intriguing Stone!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1342,8 +1335,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDE2IDpbbmFtZT1SZXldOlZvaWzDoCBNYWtlciwgdHUgZW4gYXMgZmluaSBhdmVjIG1vaSwgY29udGludWUgY29tbWUgw6dhLCB0J2VzIHN1ciBsYSBib25uZSB2b2llIHBvdXIgcsOpY3Vww6lyZXIgdG91dGVzIGxlcyBQaWVycmVzIEluc29saXRlcyAh
+        - 20, 16 :[name=Rey]:Well then Maker, seems like we are done!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1383,19 +1375,18 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDE3IDpbbmFtZT1SZXldOkFoLCBqZSB2b2lzIHF1ZSB0dSBhcyB1biBwZXUgdHJvcCBtYXJ0eXJpc8OpIGxhIHBhdXZyZSBwZXRpdGUgYsOqdGUsIMOgIHRlbGxlIHBvaW50IHF1ZSB0dSBsJ2FzIG1pc2UgS08uLi4=
+        - 20, 17 :[name=Rey]:Oh, well, seems like someone might have been a little
+          too hard on the poor beast, to the point of defeating it...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDE4IDpbbmFtZT1SZXldOkMnZXN0IGRlcyBjaG9zZXMgcXVpIGFycml2ZW50LCBuZSB0J2lucXVpw6h0ZXMgcGFzLiBKZSB2YWlzIG0nYXNzdXJlciBkZSBsYSBzb2lnbmVyIHBvdXIgbSdhc3N1cmVyIHF1ZSB0dSBwdWlzc2VzIGxhIHJlY3JvaXNlciBzdXIgbCfDjmxlICE=
+        - 20, 18 :[name=Rey]:These things happen, don't worry.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 19 :[name=Rey]:C'est parti pour faire de la magie !
+        - 20, 19 :[name=Rey]:Time for a magic trick!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1458,8 +1449,7 @@ events:
         code: 655
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDIwIDpbbmFtZT1SZXldOkV0IHZvaWzDoCwgdHUgcGV1eCByZXBhcnRpciBsJ2VzcHJpdCB0cmFucXVpbGxlICE=
+        - 20, 20 :[name=Rey]:And done! You can go back to it with peace of mind!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1472,8 +1462,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDIxIDpbbmFtZT1SZXldOkhleSBcTlsxXSAhIEFsb3JzLCBwYXMgdHJvcCBsYSBnYWzDqHJlIGNldHRlIHBldGl0ZSBjaGFzc2UgYXUgZnV5YXJkID8gTmUgYmFpc3NlIHBhcyBsZXMgYnJhcywgdHUgZmluaXJhcyBwYXIgbCdhdm9pciAh
+        - 20, 21 :[name=Rey]:Hey \N[1]! So, hopefully not having too much trouble
+          with this little runaway Pokémon hunt?
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1538,14 +1528,13 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDIyIDpbbmFtZT1SZXldOlR1IHRlIHJlbmRzIGNvbXB0ZSBxdWFuZCBtw6ptZSA/IFR1IGZhaXMgcGFydGllIGRlcyBkZXV4IHNldWxlcyBwZXJzb25uZXMgZGUgY2V0dGUgw45sZSDDoCBhdm9pciB1biBsw6lnZW5kYWlyZS4=
+        - 20, 22 :[name=Rey]:Can you believe it?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDIzIDpbbmFtZT1SZXldOlF1aSBlc3QgbCdhdXRyZSA/IEEgw6dhLCBqZSBwZXV4IHBhcyB0ZSBsZSBkaXJlLCDDoCB0b2kgZGUgZMOpY291dnJpciBwYXIgdG9pIG3Dqm1lICE=
+        - 20, 23 :[name=Rey]:Who's the other? I can't tell you that, you'll have to
+          find by yourself!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1739,8 +1728,7 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          dHJhaW5lcl9leWVfc2VxdWVuY2UoIjIwLCA2MyBDJ8OpdGFpdCB1bmUgZW1idXNjYWRlICEiLA==
+        - trainer_eye_sequence("20, 63 I was waiting to ambush you!",
         indent: 0
         code: 355
       - !ruby/object:RPG::EventCommand
@@ -1881,8 +1869,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDY0IETDqXNvbMOpLCBqJ2F1cmFpcyBwYXMgZMO7LCBjJ8OpdGFpdCBwYXMgc3ltcGEuLi4=
+        - 20, 64 Sorry, that was a mean thing to do...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1943,7 +1930,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 24 Vei-veinard !
+        - 20, 24 Chan-chansey!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2146,8 +2133,7 @@ events:
         code: 249
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDI1IExldmVpbmFyZCBzb2lnbmUgdm90cmUgw6lxdWlwZS5bV0FJVCA5MF0=
+        - 20, 25 Chansey heals your team.[WAIT 90]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2337,8 +2323,8 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          dHJhaW5lcl9leWVfc2VxdWVuY2UoIjIwLCA2MCBDJ2VzdCBtb2kgb3UgdW4gUG9rw6ltb24gbMOpZ2VuZGFpcmUgdmllbnQgZGUgcGFzc2VyIGRldmFudCBtb2kgw6AgbCdpbnN0YW50ID8hIiw=
+        - trainer_eye_sequence("20, 60 Wait, did a legendary Pokémon just fly in front
+          of me just now?!",
         indent: 0
         code: 355
       - !ruby/object:RPG::EventCommand
@@ -2391,20 +2377,18 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDI2IFR1IHRlIGRlbWFuZGVzIGNvbW1lbnQgamUgdCdhaSByZW1hcnF1w6kgPyBHcsOiY2Ugw6AgdHJhaW5lcl9zcG90dGVkKDQpLCBqZSBzdWlzIGNhcGFibGUgZGUgdGUgZMOpdGVjdGVyIMOgIDQgY2FzZXMgZGUgZGlzdGFuY2UgIQ==
+        - 20, 26 Wondering how I spotted you?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDI3IFBhciBjb250cmUgamUgbmUgbSdhdHRlbmRhaXMgcGFzIMOgIG1lIGZhaXJlIGJhdHRyZS4uLg==
+        - 20, 27 However, I didn't expect to lose...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 28 Les prochains dresseurs sont forts mais tu peux les esquiver si tu
-          es suffisamment rapide !
+        - 20, 28 The next trainers are strong, but you can dodge them if you are fast
+          enough!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2417,8 +2401,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDI5IFR1IHRlIGRlbWFuZGVzIGNvbW1lbnQgamUgdCdhaSByZW1hcnF1w6kgPyBHcsOiY2Ugw6AgdHJhaW5lcl9zcG90dGVkKDQpLCBqZSBzdWlzIGNhcGFibGUgZGUgdGUgZMOpdGVjdGVyIMOgIDQgY2FzZXMgZGUgZGlzdGFuY2UgIQ==
+        - 20, 29 Wondering how I spotted you?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2428,19 +2411,18 @@ events:
         code: 108
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDMwIFNpbm9uLCBtYWxncsOpIGxlIGZhaXQgcXVlIGplIHQnYWkgYmF0dHUsIGplIHZhaXMgdOKAmcOpdml0ZXIgdG91dCBsZSB0cmFqZXQganVzcXXigJlhdSBDZW50cmUgUG9rw6ltb24u
+        - 20, 30 By the way, despite the fact I beat you, I will heal your team to
+          save you the trip to the Pokémon Center.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 31 Les prochains dresseurs de la Route ne seront pas aussi gentils cela
-          dit !
+        - 20, 31 With that said, the next trainers of the Route won't be as kind.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 32 Tu peux cependant les esquiver si tu es suffisamment rapide !
+        - 20, 32 You can however dodge them if you're fast enough!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2463,7 +2445,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 33 Viens me parler si tu souhaites m'affronter de nouveau !
+        - 20, 33 Come talk to me if you want to challenge me again!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2571,8 +2553,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDM0IEF1IGZpbmFsLCBpbCBlc3QgZGV2ZW51IHF1b2kgbGUgUG9rw6ltb24gbMOpZ2VuZGFpcmUgPw==
+        - 20, 34 In the end, what became of the legendary Pokémon?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2617,7 +2598,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 35 Tu souhaites avoir ta revanche ?
+        - 20, 35 You want to have a rematch?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2698,8 +2679,7 @@ events:
         code: 111
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDM2IEplIG5lIG0nYXR0ZW5kYWlzIHBhcyDDoCBtZSBmYWlyZSBiYXR0cmUuLi4=
+        - 20, 36 I didn't expect to lose...
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2724,8 +2704,8 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDM3IEplIHQnYWkgYmF0dHUgZGUgbm91dmVhdSwgbWFpcyBjb21tZSBqZSB0cm91dmUgY291cmFnZXV4IHF1ZSB0dSBzb2lzIHZlbnUgcHJlbmRyZSB0YSByZXZhbmNoZSwgamUgdmFpcyBkZSBub3V2ZWF1IHNvaWduZXIgdG9uIMOpcXVpcGUgIQ==
+        - 20, 37 I won again, and as you're courageous enough to come for a rematch,
+          I will heal you team once again!
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2753,7 +2733,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 38 Reviens me parler si tu souhaites m'affronter de nouveau.
+        - 20, 38 Come talk to me if you want to challenge me again.
         indent: 2
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2776,8 +2756,7 @@ events:
         code: 402
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDM5IFBhcyBkZSBwcm9ibMOobWUsIGplIGNvbXByZW5kcy4gUmV2aWVucyBtZSB2b2lyIHNpIHR1IGNoYW5nZXMgZCdhdmlzLg==
+        - 20, 39 No problem, I understand.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2941,8 +2920,8 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          dHJhaW5lcl9leWVfc2VxdWVuY2UoIjIwLCA2MSBUdSBsZSB0cm91dmVzIHBhcyB0cm9wIGJlYXUgY2UgZ3JvcyBQb2vDqW1vbiBsw6AgPyIs
+        - trainer_eye_sequence("20, 61 Don't you think this huge Pokémon is just too
+          cute?",
         indent: 0
         code: 355
       - !ruby/object:RPG::EventCommand
@@ -3029,8 +3008,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDQwIEF1IGZpbmFsLCBpbCBlc3QgZGV2ZW51IHF1b2kgbGUgUG9rw6ltb24gbMOpZ2VuZGFpcmUgPw==
+        - 20, 40 In the end, what became of the legendary Pokémon?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3182,8 +3160,8 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          dHJhaW5lcl9leWVfc2VxdWVuY2UoIjIwLCA2MiBKZSB2aWVucyBkZSBtZSBmYWlyZSBmcsO0bGVyIHBhciB1biBncm9zIHRydWMgISBDJ2VzdCBzYW5zIGRvdXRlIHVuIFBva8OpbW9uIHJhcmUgISIs
+        - trainer_eye_sequence("20, 62 I was just grazed by a huge beast!\nlIt's certainly
+          a rare Pokémon!",
         indent: 0
         code: 355
       - !ruby/object:RPG::EventCommand
@@ -3238,7 +3216,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 41 Je devrais faire le plein d'Hyper Balls...
+        - 20, 41 I should refill my Ultra Balls stock...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3904,101 +3882,95 @@ events:
         code: 210
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 42 Hey ! Toi aussi tu l'as vu ?
+        - 20, 42 :[name=???]:Hey, did you see that too?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDQzIFN1aXMtamUgYsOqdGUsIGZvcmPDqW1lbnQgcXVlIHR1IGwnYXMgdnUsIHB1aXNxdSdpbCBzZW1ibGFpdCB2b3Vsb2lyIHRlIGd1aWRlciBqdXNxdSdpY2kgIQ==
+        - 20, 43 :[name=???]:Sorry, rhetorical question, of course you saw it, as
+          it was guiding you here!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDQ0IEplIG0nYXBwZWxsZSBSZXksIGV0IGplIHN1aXMgbGUgUmFuZ2VyIGF0dGl0csOpIGRlIGwnw45sZSAh
+        - 20, 44 :[name=Rey]:My name's Rey, I'm the titular Ranger of the Island!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - '20, 45 :[name=Rey]:En d''autres termes : j''aide un peu tout le monde.'
+        - '20, 45 :[name=Rey]:In other terms: I help everyone.'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDQ2IDpbbmFtZT1SZXldOlR1IG1lIGNvbm5haXNzYWlzIGTDqWrDoCA/
+        - 20, 46 :[name=Rey]:Did you know about me already?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDQ3IDpbbmFtZT1SZXldOk9oLCBqZSB2b2lzLCBTaXJNYWxvIGEgZMO7IHRlIHBhcmxlciBkZSBtb2ku
+        - 20, 47 :[name=Rey]:I see, SirMalo talked to you about me, right?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDQ4IDpbbmFtZT1SZXldOlR1IGRvaXMgZG9uYyDDqnRyZSBcZltsYSBub3V2ZWxsZcKnbGUgbm91dmVhdV0gTWFrZXIgIQ==
+        - 20, 48 :[name=Rey]:Then you should be the new Maker!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDQ5IDpbbmFtZT1SZXldOkV0IGonZW4gZMOpZHVpcyBkb25jIHF1ZSB0dSBkb2lzIMOqdHJlIGVuIHRyYWluIGRlIGZhaXJlIGxlIHRvdXIgZGUgbCfDjmxlIHBvdXIgcsOpY29sdGVyIGxlcyBQaWVycmVzIEluc29saXRlcy4uLg==
+        - 20, 49 :[name=Rey]:And I deduct that you are doing your tour of the Island
+          to collect the Intriguing Stones...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDUwIDpbbmFtZT1SZXldOkJpZW4gZW50ZW5kdSwgaidlbiBhaSB1bmUgc3VyIG1vaSBhdXNzaSwgbWFpcyBqZSBuZSBwZXV4IHBhcyB0ZSBsYSBjw6lkZXIgY29tbWUgw6dhLi4u
+        - 20, 50 :[name=Rey]:Of course, I have one on me, but I can't give it to you
+          just like that...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 51 :[name=Rey]:Oh, je sais !
+        - 20, 51 :[name=Rey]:Oh, I know what to do!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDUyIDpbbmFtZT1SZXldOlZvaWzDoCBjZSBxdWUgamUgdGUgcHJvcG9zZSA6IHR1IGF0dHJhcGVzIGxlIFtQT0tFTU9OXSBldCB0dSBtZSBsZSBtb250cmVzLCBldCBqZSB0ZSBkb25uZSBtYSBQaWVycmUgSW5zb2xpdGUgIQ==
+        - '20, 52 :[name=Rey]:Here''s the deal I propose to you: you catch the [POKEMON]
+          and show it to me, and I''ll give you my Intriguing Stone!'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDUzIDpbbmFtZT1SZXldOkZyYW5jaGVtZW50LCB0dSBlcyBnYWduYW50IHN1ciB0b3VzIGxlcyBwb2ludHMgOiB0dSBham91dGVzIHVuIFBva8OpbW9uIHN1cGVyIHJhcmUgw6AgdG9uIMOpcXVpcGUgZXQgdHUgcsOpY3Vww6hyZXMgbGEgUGllcnJlLg==
+        - '20, 53 :[name=Rey]:Honestly, you are winning on every point: you add a
+          super rare Pokémon to your team and you get the Stone.'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDU0IDpbbmFtZT1SZXldOkQnYWlsbGV1cnMsIGF1IGNhcyBvw7kgdHUgbWV0dHJhaXMgSy5PLiBsYSBwYXV2cmUgYmVzdGlvbGUgc2FucyBwb3V2b2lyIGxhIGNhcHR1cmVyLCB2aWVucyBtZSB2b2lyIGV0IGplIGZlcmFpIHVuIHBldSBkZSBtYWdpZS4=
+        - 20, 54 :[name=Rey]:Also, in case you were to knock out the poor thing without
+          being able to catch it, come see me and I'll do a bit of magic.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDU1IDpbbmFtZT1SZXldOlBvdXIgZmluaXIsIHNpIHR1IHJlZ2FyZGVzIHRhIGNhcnRlLCB0dSBwb3VycmFzIGZhY2lsZW1lbnQgc2F2b2lyIG/DuSBzZSB0cm91dmUgdW4gUG9rw6ltb24gZnV5YXJkLg==
+        - 20, 55 :[name=Rey]:Finally, if you take a look at the \c[5]Map\c[0], you'll
+          be able to easily see where the roaming Pokémon are.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDU2IDpbbmFtZT1SZXldOk1haXMgcG91ciDDqnRyZSBob25uw6p0ZSwgamUgbidpbWFnaW5lIFtQT0tFTU9OXSBzZSBiYWxhZGVyIHF1J2ljaSBldCDDoCBsJ8OpdGFnZSBkZSBsYSBQcmFpcmllIFJ1aXNzZWxhbnRlLi4u
+        - 20, 56 :[name=Rey]:Generally, it likes to hang out around this place and
+          those with encounters in the left wing of the Tower!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDU3IDpbbmFtZT1SZXldOlR1IGRldnJhaXMgZG9uYyBwb3V2b2lyIHQnZW4gc29ydGlyIHNhbnMgYXVjdW4gcHJvYmzDqG1lICE=
+        - 20, 57 :[name=Rey]:So you should be able to find it quite easily.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjAsIDU4IDpbbmFtZT1SZXldOkFsbGV6LCDDoCBsYSBjaGFzc2UsIE1ha2VyICE=
+        - 20, 58 :[name=Rey]:Alright, go hunting, Maker!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -4200,7 +4172,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 20, 59 :[name=Rattata]:Krkrkrk ![WAIT 45]
+        - 20, 59 :[name=Rattata]:Krkrkrkr![WAIT 45]
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/Map020.rxdata.yml
+++ b/Data/Map020.rxdata.yml
@@ -2323,13 +2323,13 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - trainer_eye_sequence("20, 60 Wait, did a legendary Pokémon just fly in front
-          of me just now?!",
+        - !binary |-
+          dHJhaW5lcl9leWVfc2VxdWVuY2UoIjIwLCA2MCBXYWl0LCBkaWQgYSBsZWdlbmRhcnkgUG9rw6ltb24ganVzdCBmbHkgaW4gZnJvbnQgb2YgbWUganVzdCBub3c/ISIs
         indent: 0
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 'eye_bgm: ''audio/bgm/Spotted - Youngster.ogg'')'
+        - 'eye_bgm: ''audio/bgm/spotted - youngster.ogg'')'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
@@ -2920,13 +2920,13 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - trainer_eye_sequence("20, 61 Don't you think this huge Pokémon is just too
-          cute?",
+        - !binary |-
+          dHJhaW5lcl9leWVfc2VxdWVuY2UoIjIwLCA2MSBEb24ndCB5b3UgdGhpbmsgdGhpcyBodWdlIFBva8OpbW9uIGlzIGp1c3QgdG9vIGN1dGU/Iiw=
         indent: 0
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 'eye_bgm: ''audio/bgm/Spotted - Lass.ogg'')'
+        - 'eye_bgm: ''audio/bgm/spotted - lass.ogg'')'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand
@@ -3160,13 +3160,13 @@ events:
         code: 408
       - !ruby/object:RPG::EventCommand
         parameters:
-        - trainer_eye_sequence("20, 62 I was just grazed by a huge beast!\nlIt's certainly
-          a rare Pokémon!",
+        - !binary |-
+          dHJhaW5lcl9leWVfc2VxdWVuY2UoIjIwLCA2MiBJIHdhcyBqdXN0IGdyYXplZCBieSBhIGh1Z2UgYmVhc3QhXG5sSXQncyBjZXJ0YWlubHkgYSByYXJlIFBva8OpbW9uISIs
         indent: 0
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 'eye_bgm: ''audio/bgm/Spotted - Youngster.ogg'')'
+        - 'eye_bgm: ''audio/bgm/spotted - youngster.ogg'')'
         indent: 0
         code: 655
       - !ruby/object:RPG::EventCommand

--- a/Data/Map021.rxdata.yml
+++ b/Data/Map021.rxdata.yml
@@ -839,8 +839,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDAgOltuYW1lPT8/P106bGwgbmUgbWUgcmVzdGUgcGx1cyBxdSfDoCBiaW5kZXIgw6dhIGF2ZWMgY2VjaSBldC4uLg==
+        - 21, 0 :[name=???]:Now the only thing left is to bind this to that and...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -913,13 +912,13 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDEgOltuYW1lPT8/P106Q2EgdmEgcGFzIGxhIHTDqnRlIGRlIHZlbmlyIGNvbW1lIMOnYSBkYW5zIGxlIGRvcyBkZXMgZ2VucyBzYW5zIHQnYW5ub25jZXIgPyE=
+        - 21, 1 :[name=???]:Are you crazy, scaring people like that without announcing
+          yourself?!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 2 :[name=???]:J'ai failli faire une attaque cardiaque...
+        - 21, 2 :[name=???]:I almost had a heart attack...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -929,43 +928,40 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDMgOltuYW1lPT8/P106T0ssIGMnZXN0IGJvbiwgaidzdWlzIGNhbG3DqS4uLiBCb24sIHR1IGVzIHF1aSBleGFjdGVtZW50ID8=
+        - 21, 3 :[name=???]:Alright, okay, I'm calm now...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDQgOltuYW1lPT8/P106XE5bMV0gPyDDh2EgbWUgZGl0IHF1ZWxxdWUgY2hvc2UuLi4gRW5maW4gYnJlZiwgcGFzc29ucy4=
+        - 21, 4 :[name=???]:\N[1]? It does ring a bell...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 5 :[name=Scor]:Moi, c'est Scorbutics. Mais tu peux m'appeler Scor.
+        - 21, 5 :[name=Scor]:The name's Scorbutics, but you can call me Scor.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDYgOltuYW1lPVNjb3JdOkplIHN1aXMgY2UgcXUnb24gYXBwZWxsZSB1biBkZXYgZGUgbCdvbWJyZS4uLiBFdCBqZSBuZSBkaXMgcGFzIMOnYSBwYXJjZSBxdSdvbiBlc3QgZGFucyB1bmUgc2FsbGUgcGxvbmfDqWUgZGFucyBsZSBub2lyLCBtYWlzIGJpZW4gcGFyY2UgcXVlIGplIHRyYXZhaWxsZSBzdXIgZGVzIGNoYW50aWVycyBpbXBvcnRhbnRzIHNhbnMgZm9yY8OpbWVudCB0cm9wIGVuIHBhcmxlciBlbiBwdWJsaWMu
+        - 21, 6 :[name=Scor]:I'm what you might call a "shadow-dev"...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDcgOltuYW1lPVNjb3JdOkVuIHBhcmxhbnQgZGUgc2FsbGUgc29tYnJlLCBqJ2VzcMOocmUgcXVlIHR1IGFwcHLDqWNpZXMgbGUgRHluYW1pY0xpZ2h0ID8=
+        - 21, 7 :[name=Scor]:Talking about dark rooms, I hope you like the \c[5]DynamicLight\c[0]?
+          Nuri Yuri made it.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDggOltuYW1lPVNjb3JdOkMnZXN0IHVuZSBmZWF0dXJlIHN1cGVyIGNvb2wgZGUgUG9rw6ltb25TREsgcXVpIHBlcm1ldCBkJ2F2b2lyIGRlIGxhICJsdW1pw6hyZSIgZHluYW1pcXVlLCBjb21tZSBzb24gbm9tIGwnaW5kaXF1ZS4=
+        - 21, 8 :[name=Scor]:It's a very cool feature of PokémonSDK that lets you
+          create dynamic "lighting", as indicated by its name.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDkgOltuYW1lPVNjb3JdOkQnYWlsbGV1cnMsIGplIHJlbWFycXVlIHF1ZSBwb3VyIHVuZSByYWlzb24gcXVlIGonaWdub3JlLCB0dSBhcyB1biBwbHVzIHBldGl0IGNlcmNsZS4gQm91Z2UgcGFzLCBqZSB2YWlzIGFycmFuZ2VyIMOnYS4=
+        - 21, 9 :[name=Scor]:By the way, for an unknown reason, it seems like your
+          light isn't the same size as mine...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -985,20 +981,19 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDEwIDpbbmFtZT1TY29yXTpWb2lsw6AsIG9uIGEgbWFpbnRlbmFudCBsYSBtw6ptZSB0YWlsbGUgZGUgbHVtacOocmUgIQ==
+        - 21, 10 :[name=Scor]:Right, now we have the same light size!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDExIDpbbmFtZT1TY29yXTpCb24gcGFyIGNvbnRyZSwgYydlc3QgYmllbiBzeW1wYSB0b3V0ZXMgY2VzIHTDqW7DqGJyZXMsIG1haXMgw6dhIGZhdGlndWUgbGVzIHlldXguIENhIHRlIGRpcmFpdCBxdSdvbiBhaWxsZSBkw6lzYWN0aXZlciBjZSBxdWkgY2F1c2Ugw6dhID8=
+        - 21, 11 :[name=Scor]:On the other hand, all this darkness is fun, but it's
+          tiring my poor eyes.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDEyIDpbbmFtZT1TY29yXTpZJ2EgdW5lIHNhbGxlIGF1IHN1ZC1lc3QgZCdpY2kuIFR1IHkgZXMgcGV1dC3DqnRyZSBkw6lqw6AgYWxsw6lcRSA/IFJldHJvdXZlLW1vaSBsw6AtYmFzLg==
+        - 21, 12 :[name=Scor]:There's another room to the south-east. Maybe you've
+          already gone there?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1008,7 +1003,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 13 :[name=Scor]:Si tu veux bien te pousser ?
+        - 21, 13 :[name=Scor]:If you could step aside...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1244,13 +1239,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDE0IExhIHTDqWzDqXZpc2lvbiBzY2ludGlsbGUgZGUgbWFuacOocmUgw6l0cmFuZ2UuLi4=
+        - 21, 14 The television flickers strangely...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Mieux vaut ne pas y toucher pour le moment.
+        - It's safer to not deal with it right now.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1316,14 +1310,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDE1IExhIHTDqWzDqXZpc2lvbiBzY2ludGlsbGUgZGUgbWFuacOocmUgw6l0cmFuZ2UuLi4=
+        - 21, 15 The television flickers strangely...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDE2IFZvdXMgc2VudGV6IHF1ZSBxdWVscXVlIGNob3NlIHZvdXMgcmVnYXJkZSBkZXB1aXMgbCdpbnTDqXJpZXVyIGRlIGwnw6ljcmFuLg==
+        - 21, 16 You feel something watching you from inside the screen.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1338,8 +1330,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDE3IExhIGNyw6lhdHVyZSB2b3VzIGF0dGFxdWUgIQ==
+        - 21, 17 The creature attacks you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1408,8 +1399,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDE4IDpbbmFtZT1TY29yXTpUdSBsJ2FzIGNhcHR1csOpID8=
+        - 21, 18 :[name=Scor]:Did you catch it?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1464,8 +1454,7 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDE5IDpbbmFtZT1TY29yXTpDb21tZSBqZSBsZSBwZW5zYWlzLCBjJ8OpdGFpdCBkb25jIGJpZW4gdW4gTW90aXNtYS4gTWFpbnRlbmFudCBxdSdpbCBuZSBwb21wZSBwbHVzIGwnw6luZXJnaWUgZHUgZ8OpbsOpcmF0ZXVyIHByaW5jaXBhbCwgbGEgbHVtacOocmUgZGV2cmFpdCByZXZlbmlyLi4u
+        - 21, 19 :[name=Scor]:As I thought, it was a Rotom.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1485,7 +1474,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 20 :[name=Scor]:Maintenant.
+        - 21, 20 :[name=Scor]:Now.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1495,19 +1484,18 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDIxIDpbbmFtZT1TY29yXTpDJ8OpdGFpdCByYXBpZGUu
+        - 21, 21 :[name=Scor]:That was fast.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDIyIDpbbmFtZT1TY29yXTpNZXJjaSBwb3VyIGxlIGNvdXAgZGUgbWFpbiwgw6dhIGF1cmFpdCDDqXTDqSBjb21wbGlxdcOpIHNldWwsIHN1cnRvdXQgdnUgbGUgbm9tYnJlIGRlIFBva8OpbW9uIHNhdXZhZ2VzIHF1aSBvbnQgdGVudMOpIGRlIHMnaW50cm9kdWlyZSBpY2ku
+        - 21, 22 :[name=Scor]:Thanks for the helping hand, alone it would have been
+          a much harder task, with all the wild Pokémon that tried to enter the room!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 23 :[name=Scor]:Tiens, un petit cadeau en gage de remerciement.
+        - 21, 23 :[name=Scor]:Here, take this gift as a token of thanks.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1517,14 +1505,14 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDI0IDpbbmFtZT1TY29yXTpQZW5kYW50IHF1ZSBqJ3kgcGVuc2UsIGlsIG1lIHNlbWJsZSBxdSfDoCBsJ8OpdGFnZSBkdSBMYWJvcmF0b2lyZSwgdW4gY2hlcmNoZXVyIGEgYW1lbsOpIGRpdmVycyBhcHBhcmVpbHMuLi4gVHUgcG91cnJhaXMgcGV1dC3DqnRyZSBhbGxlciB2b2lyIMOnYSBhdmVjIE1vdGlzbWEgPw==
+        - 21, 24 :[name=Scor]:Now that I think about it, I believe a scientist brought
+          a lof of different devices to the Laboratory floor...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDI1IDpbbmFtZT1TY29yXTpTaSB0dSB2ZXV4IHJldmVuaXIgbWUgdm9pciwgZW4gdG91dCBjYXMsIHR1IHNhaXMgb8O5IG1lIHRyb3V2ZXIgIQ==
+        - 21, 25 :[name=Scor]:If you want to come see me again, you know where to
+          find me!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1577,8 +1565,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDI2IExlIFBva8OpbW9uIHJldG91cm5lIGRhbnMgbGEgdMOpbMOpdmlzaW9uIHBvdXIgcmVnYWduZXIgZGVzIGZvcmNlcy4=
+        - 21, 26 The Pokémon returns to the television to gain back its strength.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1651,8 +1638,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDI3IFNhbnMgTW90aXNtYSDDoCBsJ2ludMOpcmlldXIsIGxhIHTDqWzDqXZpc2lvbiBlc3QgbWFpbnRlbmFudCB0b3RhbGVtZW50IMOpdGVpbnRlLg==
+        - 21, 27 Without Rotom inside, the television is now completely out of order.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1704,13 +1690,12 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDI4IExhIHTDqWzDqXZpc2lvbiBzY2ludGlsbGUgZGUgbWFuacOocmUgw6l0cmFuZ2UuLi4=
+        - 21, 28 The television flickers strangely...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - Mieux vaut ne pas y toucher pour le moment.
+        - It's safer to not deal with it right now.
         indent: 0
         code: 401
       - !ruby/object:RPG::EventCommand
@@ -1776,14 +1761,12 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDI5IExhIHTDqWzDqXZpc2lvbiBzY2ludGlsbGUgZGUgbWFuacOocmUgw6l0cmFuZ2UuLi4=
+        - 21, 29 The television flickers strangely...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDMwIFZvdXMgc2VudGV6IHF1ZSBxdWVscXVlIGNob3NlIHZvdXMgcmVnYXJkZSBkZXB1aXMgbCdpbnTDqXJpZXVyIGRlIGwnw6ljcmFuLg==
+        - 21, 30 You feel something watching you from inside the screen.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1798,8 +1781,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDMxIExhIGNyw6lhdHVyZSB2b3VzIGF0dGFxdWUgIQ==
+        - 21, 31 The creature attacks you!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1868,8 +1850,7 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDMyIDpbbmFtZT1TY29yXTpUdSBsJ2FzIGNhcHR1csOpID8=
+        - 21, 32 :[name=Scor]:Did you catch it?
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1924,8 +1905,7 @@ events:
         code: 509
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDMzIDpbbmFtZT1TY29yXTpDb21tZSBqZSBsZSBwZW5zYWlzLCBjJ8OpdGFpdCBkb25jIGJpZW4gdW4gTW90aXNtYS4gTWFpbnRlbmFudCBxdSdpbCBuZSBwb21wZSBwbHVzIGwnw6luZXJnaWUgZHUgZ8OpbsOpcmF0ZXVyIHByaW5jaXBhbCwgbGEgbHVtacOocmUgZGV2cmFpdCByZXZlbmlyLi4u
+        - 21, 33 :[name=Scor]:As I thought, it was a Rotom.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1945,7 +1925,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 34 :[name=Scor]:Maintenant.
+        - 21, 34 :[name=Scor]:Now.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1955,19 +1935,18 @@ events:
         code: 106
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDM1IDpbbmFtZT1TY29yXTpDJ8OpdGFpdCByYXBpZGUu
+        - 21, 35 :[name=Scor]:That was fast.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDM2IDpbbmFtZT1TY29yXTpNZXJjaSBwb3VyIGxlIGNvdXAgZGUgbWFpbiwgw6dhIGF1cmFpdCDDqXTDqSBjb21wbGlxdcOpIHNldWwsIHN1cnRvdXQgdnUgbGUgbm9tYnJlIGRlIFBva8OpbW9uIHNhdXZhZ2VzIHF1aSBvbnQgdGVudMOpIGRlIHMnaW50cm9kdWlyZSBpY2ku
+        - 21, 36 :[name=Scor]:Thanks for the helping hand, alone it would have been
+          a much harder task, with all the wild Pokémon that tried to enter the room!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 37 :[name=Scor]:Tiens, un petit cadeau en gage de remerciement.
+        - 21, 37 :[name=Scor]:Here, take this gift as a token of thanks.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -1977,14 +1956,14 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDM4IDpbbmFtZT1TY29yXTpQZW5kYW50IHF1ZSBqJ3kgcGVuc2UsIGlsIG1lIHNlbWJsZSBxdSfDoCBsJ8OpdGFnZSBkdSBMYWJvcmF0b2lyZSwgdW4gY2hlcmNoZXVyIGEgYW1lbsOpIGRpdmVycyBhcHBhcmVpbHMuLi4gVHUgcG91cnJhaXMgcGV1dC3DqnRyZSBhbGxlciB2b2lyIMOnYSBhdmVjIE1vdGlzbWEgPw==
+        - 21, 38 :[name=Scor]:Now that I think about it, I believe a scientist brought
+          a lof of different devices to the Laboratory floor...
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDM5IDpbbmFtZT1TY29yXTpTaSB0dSB2ZXV4IHJldmVuaXIgbWUgdm9pciwgZW4gdG91dCBjYXMsIHR1IHNhaXMgb8O5IG1lIHRyb3V2ZXIgIQ==
+        - 21, 39 :[name=Scor]:If you want to come see me again, you know where to
+          find me!
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2037,8 +2016,7 @@ events:
         code: 411
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDQwIExlIFBva8OpbW9uIHJldG91cm5lIGRhbnMgbGEgdMOpbMOpdmlzaW9uIHBvdXIgcmVnYWduZXIgZGVzIGZvcmNlcy4=
+        - 21, 40 The Pokémon returns to the television to gain back its strength.
         indent: 1
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2111,8 +2089,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDQxIFNhbnMgTW90aXNtYSDDoCBsJ2ludMOpcmlldXIsIGxhIHTDqWzDqXZpc2lvbiBlc3QgbWFpbnRlbmFudCB0b3RhbGVtZW50IMOpdGVpbnRlLg==
+        - 21, 41 Without Rotom inside, the television is now completely out of order.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2164,7 +2141,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 42 Une vieille radio. Elle semble ne plus avoir de batterie.
+        - 21, 42 An old radio. It seems like it doesn't have any charge left.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2262,36 +2239,32 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDQzIEMnZXN0IMOpdHJhbmdlIGNldHRlIG1hbmllIHF1J29udCBsZXMgZ2VucyBkZSBmb3VpbGxlciBkYW5zIGxlcyBwb3ViZWxsZXMuLi4=
+        - 21, 43 Dumpster diving is such a weird obsession...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 44 Vous pensez que toutes les poubelles contiennent des choses ?
+        - 21, 44 Do you believe all dumpsters contain things?
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDQ1IEVoIGJpZW4sIG5hdnLDqSwgbWFpcyBjZSBuJ2VzdCBwYXMgbGUgY2FzIGRlIGNlbGxlLWNpLg==
+        - 21, 45 Well, sorry not sorry, this one does not.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDQ2IEVsbGUgbmUgY29udGllbnQgcGFzIGQnb2JqZXQgaW50w6lyZXNzYW50LCBtYWlzIGVsbGUgY29udGllbnQgZGVzIG1vdHMu
+        - 21, 46 It does not contain any interesting item, but it contains words.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDQ3IEJlYXVjb3VwIGRlIG1vdHMuIERlcyBtb3RzIHF1ZSB2b3VzIMOqdGVzIGVuIHRyYWluIGRlIGxpcmUu
+        - 21, 47 A lot of words.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 48 ... Oh, tiens, un CD au fond de la poubelle.
+        - 21, 48 ... Oh, wait, there's a CD at the bottom of the dumpster.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2301,8 +2274,7 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDQ5IExhIHBvdWJlbGxlIHNlIHRhaXQgw6AgamFtYWlzLg==
+        - 21, 49 The dumpster is now forever silent.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2358,7 +2330,7 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 50 Un ordinateur portable. Il ne semble plus avoir de charge.
+        - 21, 50 A laptop.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2414,74 +2386,72 @@ events:
         code: 355
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDUxIDpbbmFtZT1TY29yXTpBaCwgdGUgdm9pbMOgLiBKZSBwcsOpZsOpcmFpcyB0J2F0dGVuZHJlLCBoaXN0b2lyZSBxdSdvbiBzb2l0IGRldXggcG91ciByw6lnbGVyIGxlIHNvdWNpLg==
+        - 21, 51 :[name=Scor]:Ah, there you are.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDUyIDpbbmFtZT1TY29yXTpMZXMgbHVtacOocmVzIGfDqW7DqXJhbGVzIGR1IHNvdXMtc29sIHNvbnQgdG91dGVzIMOpdGVpbnRlcyBldCB0b3VzIGxlcyBhcHBhcmVpbHMgZGUgY2V0dGUgcGnDqGNlIG4nb250IHBsdXMgZGUgY291cmFudC4=
+        - 21, 52 :[name=Scor]:The general lights of this basement and all the devices
+          in here are out of power.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDUzIDpbbmFtZT1TY29yXTpTZXVsZXMgbGVzIGx1bWnDqHJlcyBzZWNvbmRhaXJlcyBkdSBzb3VzLXNvbCBzb250IGVuY29yZSBhbGx1bcOpZXMsIHBhcmNlIHF1J2VsbGVzIHNvbnQgYnJhbmNow6llcyBzdXIgdW4gZ8OpbsOpcmF0ZXVyIGF1eGlsaWFpcmUuLi4gRXQgeSdhIGNldHRlIHTDqWzDqXZpc2lvbi4=
+        - 21, 53 :[name=Scor]:Only the basement's secondary lights are still on, as
+          they're connected to an auxiliary generator...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDU0IDpbbmFtZT1TY29yXTpUdSBzZXJhcyBkJ2FjY29yZCBhdmVjIG1vaSwgw6dhIG5lIGZhaXQgYXVjdW4gc2VucyBkZSBicmFuY2hlciB1bmUgdMOpbMOpIHN1ciB1biBnw6luw6lyYXRldXIgYXV4aWxpYWlyZS4=
+        - '21, 54 :[name=Scor]:I''m sure you''ll agree with me: it makes no sense
+          to plug a television to an auxiliary generator.'
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDU1IDpbbmFtZT1TY29yXTpPbiBwZXV0IGRvbmMgZW4gZMOpZHVpcmUgcXVlIGxlIHNvdWNpIHZpZW50IGRlIGxhIHTDqWzDqS4uLiBPdSBwbHVzIHBhcnRpY3VsacOocmVtZW50IGRlIGNlIHF1aSBsJ2hhYml0ZS4=
+        - 21, 55 :[name=Scor]:So we can deduce the problem is caused by this television..
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDU2IDpbbmFtZT1TY29yXTpKJ2FpIG1vbiBhdmlzIHN1ciBsYSBxdWVzdGlvbiwgbWFpcyBqZSBwcsOpZsOocmUgbmUgcGFzIG0nYXZhbmNlci4=
+        - 21, 56 :[name=Scor]:I have my own theory, but I prefer to keep it to myself
+          for now.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDU3IDpbbmFtZT1TY29yXTpDZSBxdWkgZXN0IHPDu3IsIGMnZXN0IHF1ZSBub3VzIGF2b25zIGFmZmFpcmUgw6AgdW4gUG9rw6ltb24gw4lsZWN0cmlrLiDDh2EgZXhwbGlxdWVyYWl0IHBvdXJxdW9pIGxlIGfDqW7DqXJhdGV1ciBwcmluY2lwYWwgZXN0IEtPIGV0IHBvdXJxdW9pIGxhIHTDqWzDqXZpc2lvbiBjb250aW51ZSBkZSBmb25jdGlvbm5lci4=
+        - 21, 57 :[name=Scor]:The only sure thing is, it must be an Electric Pokémon.
+          It would explain why the main generator is down and why the television is
+          still working.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDU4IDpbbmFtZT1TY29yXTpKZSBjb3V2cmUgdGVzIGFycmnDqHJlcywgb2NjdXBlIHRvaSBkZSBjZSBQb2vDqW1vbi4gQXR0ZW50aW9uIGNlbGEgZGl0IDogdHUgdmFzIGRldm9pciBsZSBjYXB0dXJlci4=
+        - 21, 58 :[name=Scor]:I'm covering you, you take care of this Pokémon.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDU5IDpbbmFtZT1TY29yXTpTaSB0dSBsZSBtZXRzIEtPIG91IHF1ZSB0dSBmdWlzLCBpbCBuJ2F1cmEgcXUnw6AgcmVudHJlciBkYW5zIGxhIHTDqWzDqXZpc2lvbiBwb3VyIHJlZmFpcmUgbGUgcGxlaW4gZCfDqW5lcmdpZS4=
+        - 21, 59 :[name=Scor]:If you defeat it or if you flee, it will need to enter
+          the television again to recharge its batteries.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDYwIDpbbmFtZT1TY29yXTpFdCBwdWlzLCBjJ2VzdCBjZXJ0YWluZW1lbnQgdW4gYm9uIFBva8OpbW9uLCBxdWkgcGx1cyBlc3QgcmFyZS4gw4dhIHNlcmFpdCBkb21tYWdlIGRlIHNlIHByaXZlciBkJ3VuZSB0ZWxsZSBjYXB0dXJlICE=
+        - 21, 60 :[name=Scor]:And, well, it's certainly a good Pokémon, a rare one
+          at that.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDYxIDpbbmFtZT1TY29yXTpQYXJsZSDDoCBsYSB0w6lsw6l2aXNpb24gZMOocyBxdWUgdHUgdGUgc2VucyBwcsOqdCwgZXQgbidvdWJsaWUgcGFzIGRlIHByZW5kcmUgZGVzIFBva8OpIEJhbGxzICE=
+        - 21, 61 :[name=Scor]:Check the television when you feel ready, and don't
+          forget to bring some Poké Balls!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDYyIDpbbmFtZT1TY29yXTpKZSB2YWlzIG1lIHBvc3RlciBqdXN0ZSBkZXZhbnQgbCdlbnRyw6llIHBvdXIgbSdvY2N1cGVyIGRlcyBQb2vDqW1vbiBzYXV2YWdlcyBxdWkgcG91cnJhaWVudCDDqnRyZSBhdHRpcsOpcyBwYXIgbGUgYnJ1aXQu
+        - 21, 62 :[name=Scor]:I'll stand over there to deal with the wild Pokémon
+          attracted by the noise.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -2636,8 +2606,8 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDYzIDpbbmFtZT1TY29yXTpQYXJsZSDDoCBsYSB0w6lsw6l2aXNpb24gZMOocyBxdWUgdHUgdGUgc2VucyBwcsOqdCDDoCBjYXB0dXJlciBjZSBQb2vDqW1vbiwgamUgY291dnJlIHRlcyBhcnJpw6hyZXMgIQ==
+        - 21, 63 :[name=Scor]:Talk to the television when you feel ready to catch
+          this Pokémon, I've got your back!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
@@ -3368,19 +3338,19 @@ events:
       list:
       - !ruby/object:RPG::EventCommand
         parameters:
-        - 21, 64 :[name=Scor]:Oh, tiens, \N[1], sympa de venir me rendre visite !
+        - 21, 64 :[name=Scor]:Oh, well, \N[1], thanks for visiting me!
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDY1IDpbbmFtZT1TY29yXTpKZSBib3NzZSBzdXIgdW4gcHJvamV0IHNlY3JldCBkw6lmZW5zZSwgZG9uYyBqZSBwZXV4IHBhcyB0cm9wIHQnZW4gcGFybGVyLi4u
+        - 21, 65 :[name=Scor]:I'm working on a top-secret project, so I can't speak
+          about it here...
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand
         parameters:
-        - !binary |-
-          MjEsIDY2IDpbbmFtZT1TY29yXTpIw6lzaXRlIHBhcyDDoCByZXZlbmlyIG1lIHZvaXIgw6AgbCdvY2Nhc2lvbiwgb24gc2Ugc2VudCByYXBpZGVtZW50IGVzc2V1bMOpIGljaS4=
+        - 21, 66 :[name=Scor]:Please come back to see me again when you have some
+          time, it's quite lonely here.
         indent: 0
         code: 101
       - !ruby/object:RPG::EventCommand

--- a/Data/MapInfos.rxdata.yml
+++ b/Data/MapInfos.rxdata.yml
@@ -60,7 +60,7 @@
   name: Cave
   expanded: false
   order: 7
-  scroll_y: 1921
+  scroll_y: 961
   parent_id: 0
 13: !ruby/object:RPG::MapInfo
   scroll_x: 809
@@ -81,7 +81,7 @@
   name: Exterior
   expanded: false
   order: 19
-  scroll_y: 910
+  scroll_y: 2008
   parent_id: 0
 8: !ruby/object:RPG::MapInfo
   scroll_x: 809
@@ -102,7 +102,7 @@
   name: Hub
   expanded: false
   order: 3
-  scroll_y: 459
+  scroll_y: 1515
   parent_id: 0
 20: !ruby/object:RPG::MapInfo
   scroll_x: 768

--- a/Data/System.rxdata.yml
+++ b/Data/System.rxdata.yml
@@ -56,7 +56,7 @@ variables:
 - Battle lost X coordinate
 - Battle lost Y coordinate
 - Battle Mode
-- "--- Reserved"
+- Current player ID (for multi-protag)
 - "--- Reserved"
 - "--- Reserved"
 - "--- Reserved"
@@ -514,7 +514,7 @@ battle_end_me: !ruby/object:RPG::AudioFile
   name: ''
   volume: 100
   pitch: 100
-magic_number: 34748347
+magic_number: 73720733
 escape_se: !ruby/object:RPG::AudioFile
   name: Fleee
   volume: 80
@@ -582,7 +582,7 @@ switches:
 - "=== Deprecated"
 - "=== Deprecated"
 - "=== Deprecated"
-- "=== Deprecated"
+- Wild Pokemon fled last battle
 - Player fled last battle
 - Lost last battle
 - Won last battle
@@ -599,7 +599,7 @@ switches:
 - Authorize defeat nuzlocke
 - Party Menu Reminder
 - AI can win
-- "--- Reserved"
+- Map change don't reset battle background
 - !binary |-
   UG9rw6ltb24gZXhwIHNjYWxl
 - Water Reflection Disabled
@@ -627,7 +627,7 @@ switches:
 - "--- Reserved"
 - "--- Reserved"
 - player_spotted? disabled
-- "--- Reserved"
+- Can't leave bike
 - Poison KO on overworld
 - "--- Reserved"
 - "--- Reserved"
@@ -1058,7 +1058,7 @@ decision_se: !ruby/object:RPG::AudioFile
   name: select
   volume: 80
   pitch: 100
-edit_map_id: 17
+edit_map_id: 15
 battle_start_se: !ruby/object:RPG::AudioFile
   name: ''
   volume: 80

--- a/Data/Text/Dialogs/15.csv
+++ b/Data/Text/Dialogs/15.csv
@@ -108,7 +108,7 @@ Kirlia utilise \c[1]Téléport \c[0]!,Kirlia uses \c[1]Teleport\c[0]!
 T'aimes pas les sensations fortes ?,Don't you like thrilling sensations?
 :[name=Kirlia]:Kiii ![WAIT 50],:[name=Kirlia]:Kiii ![WAIT 50]
 Bonjour !,Hello!
-"J'ai le \c[5]nametag $ \c[0]dans mon nom, donc mon apparence reste la même sur toutes les pages qui composent mon évènement.","I've got the \c[5]nametag $\c[0] in my event's name, so my graphics stay the same on all the pages of my event."
+"J'ai le \c[5]nametag $\c[0] dans mon nom, donc mon apparence reste la même sur toutes les pages qui composent mon évènement.","I've got the \c[5]nametag $\c[0] in my event's name, so my graphics stay the same on all the pages of my event."
 Tu en penses quoi ?,What do you think about that?
 C'est pratique,It's handy
 C'est utile,It's useful


### PR DESCRIPTION
### PR Description
- This PR updates all the RMXP texts to ensure english is the main language by default.
- This PR updates:
  - Text commands
  - Choice commands
  - Branch texts (from choice commands)
  - Eligible strings in the script commands
- Note that a MR on PSDK will be opened to make the switcher used for this change available for everyone so that users will be able to select the language of their demo
- This PR also updates some RMXP variables/switches names

### Before testing
- Make sure you have run the command "psdk --util=restore" after checking out this PR

### Tests to realize
- [ ] Open RMXP, check the texts for any errors (said errors shouldn't be grammar related, we aren't checking the accuracy of translations): the test is validated if you can't find any error
- [ ] Open the game, check the texts ingame for any errors (same as above... in this case, a problem that "could" happen is any text becoming untranslated): the test is validated if you can't find any error