### PR TITLE
Fix wooden platform's behaviour in Rocket HQ after a PSDK update changed the behaviour of the z= event nametag

### DIFF
--- a/Data/Map011.rxdata.yml
+++ b/Data/Map011.rxdata.yml
@@ -1377,7 +1377,7 @@ events:
       move_speed: 3
       through: false
     name: !binary |-
-      wqdbej01XVtvZmZzZXRfeT02NF1QbGF0Zm9ybQ==
+      wqdbej0wXVtvZmZzZXRfeT02NF1QbGF0Zm9ybQ==
     y: 31
     x: 22
     id: 11


### PR DESCRIPTION
### PR Description
- This PR corrects an issue that appeared after a recent PSDK update
- The issue was causing the wooden platform in the Rocket HQ to be unusable, thus the demo couldn't be completed

### Before testing
- Make sure to not be in the map when loading the save as you will be loading the old event data.
- Make sure to properly run the `convert_yml_to_rxdata` file after checking out the branch or else you won't have the right map

### Tests to realize
- [x] Go to the Rocket HQ map, do the event of this map in the right order then try to use the wooden platform: you should be able to walk on it without any issue, and you shouldn't have any Z-fighting issue
- [x] Do the same test, but this time use the CTRL button to walk through walls and head directly for the wooden platform: you should be able to walk on it without any issue, and you shoudn't have any Z-fighting issue

<!-- if appliable !-->
### Sources related to this MR
- [Discord link of the support](https://ptb.discord.com/channels/143824995867557888/1371124276559872112)