### PR TITLE
Replaced clamp(x,0.0,1.0) functions by min(max(x,0.0)1.0) in shaders

### DIFF
--- a/graphics/shaders/hq2x.txt
+++ b/graphics/shaders/hq2x.txt
@@ -58,10 +58,10 @@ void main() {
   float lc1 = k / (0.12 * dot(c10 + c12 + c11, dt) + lum_add);
   float lc2 = k / (0.12 * dot(c01 + c21 + c11, dt) + lum_add);
 
-  w1 = clamp(lc1 * dot(abs(c11 - c10), dt) + mx, min_w, max_w);
-  w2 = clamp(lc2 * dot(abs(c11 - c21), dt) + mx, min_w, max_w);
-  w3 = clamp(lc1 * dot(abs(c11 - c12), dt) + mx, min_w, max_w);
-  w4 = clamp(lc2 * dot(abs(c11 - c01), dt) + mx, min_w, max_w);
+  w1 = min(max(lc1 * dot(abs(c11 - c10), dt) + mx, min_w), max_w);
+  w2 = min(max(lc2 * dot(abs(c11 - c21), dt) + mx, min_w), max_w);
+  w3 = min(max(lc1 * dot(abs(c11 - c12), dt) + mx, min_w), max_w);
+  w4 = min(max(lc2 * dot(abs(c11 - c01), dt) + mx, min_w), max_w);
 
   vec4 frag;
   frag.xyz = w1 * c10 + w2 * c21 + w3 * c12 + w4 * c01 + (1.0 - w1 - w2 - w3 - w4) * c11;

--- a/graphics/shaders/overlay_fog.frag
+++ b/graphics/shaders/overlay_fog.frag
@@ -71,7 +71,7 @@ vec4 fog(vec2 pixPos){
   float energy = noise1.r * noise2.r;
   vec4 color_intensity = sample_color;
 
-  return vec4(color_intensity.rgb,clamp(0.0,1.0,energy+dist));
+  return vec4(color_intensity.rgb,min(max(dist+energy,0.0),1.0));
 }
 
 // Account for opacity in blend modes

--- a/graphics/shaders/overlay_godrays.frag
+++ b/graphics/shaders/overlay_godrays.frag
@@ -105,7 +105,7 @@ vec4 godrays(vec2 pixPos)
   ray2 *= cut;
 
   // Apply the noise pattern (i.e. create the rays)
-  float rays = clamp(noise_gen(ray1) + (noise_gen(ray2) * ray2_intensity), 0., 1.);
+  float rays = min(max(noise_gen(ray1) + (noise_gen(ray2) * ray2_intensity), 0.), 1.);
 
   // Fade out edges
   rays *= smoothstep(0.0, falloff, (pixPos.y)); // Bottom

--- a/graphics/shaders/overlay_ripple.frag
+++ b/graphics/shaders/overlay_ripple.frag
@@ -63,12 +63,12 @@ vec4 ripple(vec2 pixPos)
   float map = outer_map * inner_map;
 
   // Fading factor with distance
-  float fade = clamp(1.2 - spread,0.0,1.0);
+  float fade = min(max(1.2 - spread,0.0),1.0);
 
   // Normalize the result
   vec2 displacement = normalize(gl_TexCoord[0].xy - position) * amount * map * fade;
 
-  return texture2D(texture, clamp(gl_TexCoord[0].xy - displacement, vec2(0.0), vec2(1.0))) + map * sample_color * fade;
+  return texture2D(texture, min(max(gl_TexCoord[0].xy - displacement, vec2(0.0)), vec2(1.0))) + map * sample_color * fade;
 }
 
 // Account for opacity in blend modes

--- a/graphics/shaders/overlay_scroll.frag
+++ b/graphics/shaders/overlay_scroll.frag
@@ -54,7 +54,7 @@ float compute_distance(vec2 pixPos, vec2 to){
 // Scroll preset
 vec4 scroll(vec2 pixPos){
   // Modulate alpha channel according to distance to center and a factor so we can see the player
-  float dist = clamp(compute_distance(pixPos,CENTER) * dist_factor,0.0,1.0);
+  float dist = min(max(compute_distance(pixPos,CENTER) * dist_factor,0.0),1.0);
   return vec4(texture2D(extra_texture, mod(pixPos + direction1 * time,vec2(1.0))).rgb,dist);
 }
 

--- a/graphics/shaders/overlay_static_image.frag
+++ b/graphics/shaders/overlay_static_image.frag
@@ -52,7 +52,7 @@ float compute_distance(vec2 pixPos, vec2 to){
 // static_image preset
 vec4 static_image(vec2 pixPos){
   // Modulate alpha channel according to distance to center and a factor so we can see the player
-  float dist = clamp(compute_distance(pixPos,CENTER) * dist_factor,0.0,1.0);
+  float dist = min(max(compute_distance(pixPos,CENTER) * dist_factor,0.0),1.0);
 
   return vec4(texture2D(extra_texture, pixPos).rgb,dist);
 }


### PR DESCRIPTION
Verify that the clamp to min/max logic is equivalent and that it fixes [this issue](https://github.com/PokemonWorkshop/PSDKTechnicalDemo/issues/37#issue-3530301878)

### Current situation:
Certain shaders use the clamp function, but this causes abnormal behavior in some GPUs. Appears not to be universally supported.
See here:
[Discord support post](https://discord.com/channels/143824995867557888/1428868835762507816/1429517123520168028)
### Solution:

Replace the instances of clamp with min and max, which are logically equivalent and should be supported everywhere.
### Expected result:

Recovering same displayed behavior between GPUs.
Invatorzen and kyruno on discord should be able to test whether they still experience abnormal behavior after the update.
### How to test:

1. If testing this MR outside of the demo, make sure you have `noise_texture.png` and `water_color_gradient.png` in the fogs folder, and all seven of the overlay_(...) .frag files in the shaders folder.
2. Be one of the affected users
Can be easily tested with `start_overlay(:fog)` in the unfixed version:
- If you see a uniform screen and can't see the player, you are affected with this issue.
<img width="638" height="485" alt="image" src="https://github.com/user-attachments/assets/f8cba00a-676c-4abd-b41e-31cd5ef84bc2" />

- If you see a wispy gradient around the center of the screen, you are unaffected and cannot test this.
<img width="636" height="475" alt="image" src="https://github.com/user-attachments/assets/de3265da-5cd3-484c-925e-1fb0cd031865" />

3. Swap to the fix branch and test the map overlays look normal. You should always be able to see the player with no abnormal transparency. Note there may not be a visual _change_ compared to the old branch for certain overlays, that's fine as long as the end result is not broken.
Suggested visual tests:
```Ruby
start_overlay(:fog)
```
```Ruby
start_overlay(:godrays)
```
```Ruby
start_overlay(:ripple)
```
```Ruby
start_overlay(:scroll)
current_overlay_preset.extra_texture_name = 'water_color_gradient'
```
```Ruby
start_overlay(:static_image)
current_overlay_preset.extra_texture_name = 'water_color_gradient'
```
Not sure how to test the hq2x shader. I don't know where it's used, couldn't find it on VS Code.

- [x] Shader logic remains equivalent (code review)
- [x] Fog shader visuals normal
- [x] Godrays shader visuals normal
- [x] Ripple shader visuals normal
- [x] Scroll shader visuals normal
- [x] Static image shader visuals normal
- [x] hq2x shader visuals normal ?

