### PR TITLE
Fix PC sound effect playing twice and Trainers eye BGMs

### DIFF
--- a/Data/Map003.rxdata.yml
+++ b/Data/Map003.rxdata.yml
@@ -1,5 +1,4 @@
----
-!ruby/object:RPG::Map
+--- !ruby/object:RPG::Map
 autoplay_bgm: true
 autoplay_bgs: false
 bgm: !ruby/object:RPG::AudioFile
@@ -7,7 +6,7 @@ bgm: !ruby/object:RPG::AudioFile
   pitch: 100
   volume: 100
 bgs: !ruby/object:RPG::AudioFile
-  name: ""
+  name: ''
   pitch: 100
   volume: 100
 data: !ruby/object:Table
@@ -216,206 +215,206 @@ events:
     name: !binary |-
       wqcgZXhpdCBkb29y
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Arrow
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 242
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: door_exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &1
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &2
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *1
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *2
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We set the Map Return depending on the Nurse's position,
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - with a +2 to her Y position so that when we black out, we
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - appear directly on the right position.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 47
-              - 47
-              - 0
-              - 7
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 48
-              - 48
-              - 0
-              - 6
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 49
-              - 49
-              - 0
-              - 6
-              - 5
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 49
-              - 49
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This command turns on the self switch on the exterior door to enable the
-                opening door.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",1,map_id = 19)
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 19
-              - 31
-              - 31
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Arrow
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 242
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: door_exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 31
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 35
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 39
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &2 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 2
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 2
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *1
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *2
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We set the Map Return depending on the Nurse's position,
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - with a +2 to her Y position so that when we black out, we
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - appear directly on the right position.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 47
+        - 47
+        - 0
+        - 7
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 48
+        - 48
+        - 0
+        - 6
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 49
+        - 49
+        - 0
+        - 6
+        - 5
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 49
+        - 49
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This command turns on the self switch on the exterior door to enable the
+          opening door.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",1,map_id = 19)
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 19
+        - 31
+        - 31
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 31
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 35
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 39
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 2
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 2
+      walk_anime: false
     x: 28
     y: 48
   10: !ruby/object:RPG::Event
@@ -423,249 +422,249 @@ events:
     name: !binary |-
       wqcgYmFzZW1lbnQgd2FycCByaWdodA==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: door_exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &3
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &4
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &5
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &6
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &7
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *3
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *4
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *5
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *6
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *7
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This command turns on the self switch on the basement to settle the tone
-                and the followers.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",3,map_id = 17)
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 17
-              - 19
-              - 29
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: door_exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 31
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 35
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 39
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 2
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 2
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
+          - &3 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+            - 2
+          - &4 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &5 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &6 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &7 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *3
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *4
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *5
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *6
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *7
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This command turns on the self switch on the basement to settle the tone
+          and the followers.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",3,map_id = 17)
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 17
+        - 19
+        - 29
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 31
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 35
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 39
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 2
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 2
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 29
     y: 39
   11: !ruby/object:RPG::Event
@@ -673,401 +672,401 @@ events:
     name: !binary |-
       wqcgUG9rw6liYWxscyByaWdodFtvZmZzZXRfeT0wXQ==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 51
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: pokeballs on left
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'For the information, yes, the switch 51 is also used by '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'another system which disables the Reflection under the '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'map. This hasn''t posed any problem at all in 5 years and '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'is now too ingrained to be changed lightly. Just don''t think '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - about this and use these Nurse events as is.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 13
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 28
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 28
+        - 28
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &8 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 51
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: pokeballs on left
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *8
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 26
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 28
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 28
+        - 28
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &9 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *9
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 26
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 28
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 28
+        - 28
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &10 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *10
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Enabling the screen animation
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",14)
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemon Healed
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 0
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &11 !ruby/object:RPG::MoveCommand
+            code: 33
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *11
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 75
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &12 !ruby/object:RPG::MoveCommand
+            code: 34
+            parameters: []
+          - &13 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - &14 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *12
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *13
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *14
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(false,"A",14)
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 1
+        parameters:
+        - 51
+        - 51
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "For the information, yes, the switch 51 is also used by "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "another system which disables the Reflection under the "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "map. This hasn't posed any problem at all in 5 years and "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "is now too ingrained to be changed lightly. Just don't think "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - about this and use these Nurse events as is.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 13
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 28
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 28
-              - 28
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &8
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *8
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 26
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 28
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 28
-              - 28
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &9
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *9
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 26
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 28
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 28
-              - 28
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &10
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *10
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Enabling the screen animation
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",14)
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemon Healed
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 0
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &11
-                    code: 33
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *11
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 75
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &12
-                    code: 34
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &13
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand &14
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *12
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *13
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *14
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(false,"A",14)
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 1
-            parameters:
-              - 51
-              - 51
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 5
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 5
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 17
     y: 39
   12: !ruby/object:RPG::Event
@@ -1075,371 +1074,371 @@ events:
     name: !binary |-
       wqcgUG9rw6liYWxscyBsZWZ0W29mZnNldF95PTBd
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 51
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: pokeballs on right
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'For the information, yes, the switch 51 is also used by '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'another system which disables the Reflection under the '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'map. This hasn''t posed any problem at all in 5 years and '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'is now too ingrained to be changed lightly. Just don''t think '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - about this and use these Nurse events as is.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 27
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 27
+        - 27
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &15 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 51
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: pokeballs on right
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *15
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 26
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 27
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 27
+        - 27
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &16 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *16
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 26
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 27
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 27
+        - 27
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &17 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *17
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 13
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 0
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 33
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *18
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 75
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 34
+            parameters: []
+          - &20 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - &21 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *19
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *20
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *21
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "For the information, yes, the switch 51 is also used by "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "another system which disables the Reflection under the "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "map. This hasn't posed any problem at all in 5 years and "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "is now too ingrained to be changed lightly. Just don't think "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - about this and use these Nurse events as is.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 27
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 27
-              - 27
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &15
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *15
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 26
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 27
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 27
-              - 27
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &16
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *16
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 26
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 27
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 27
-              - 27
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &17
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *17
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 13
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 0
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &18
-                    code: 33
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *18
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 75
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &19
-                    code: 34
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &20
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand &21
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *19
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *20
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *21
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 5
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 5
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 16
     y: 39
   13: !ruby/object:RPG::Event
@@ -1447,221 +1446,197 @@ events:
     name: !binary |-
       wqcgQ29tcHV0ZXI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Computer-screen
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &22
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_on
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &23
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &24
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand &25
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &26
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &27
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &28
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *22
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *23
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *24
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *25
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *26
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *27
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *28
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_pc
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &29
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_off
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &30
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &31
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &32
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &33
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &34
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &35
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *29
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *30
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *31
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *32
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *33
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *34
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *35
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Computer-screen
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &22 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 3
+          - &23 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - &24 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &25 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &26 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &27 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *22
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *25
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *26
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *27
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_pc
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &28 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &29 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &32 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 0
+          - &33 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *30
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *31
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 21
     y: 39
   14: !ruby/object:RPG::Event
@@ -1669,774 +1644,774 @@ events:
     name: !binary |-
       wqcgUEMgU2NyZWVu
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 51
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 26
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_PC-Screen
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 51
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 26
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_PC-Screen
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 5
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 5
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 18
     y: 38
   15: !ruby/object:RPG::Event
     id: 15
     name: "[sprite=off] Warp destination"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 45
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 45
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 28
     y: 43
   16: !ruby/object:RPG::Event
     id: 16
     name: Cashier 2
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Seller-M
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Seller-M
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 0 Welcome! I'm selling Poké Balls for less than next door...
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'open_shop([:poke_ball, :great_ball], {:poke_ball => 180, :great_ball =>
+          550}, show_background: false)'
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Displaying a text if nothing was bought
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 1 I can assure you of their quality!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Displaying a text if a single type of item was bought
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 1
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 2 The paint might be peeled a bit, but you won't be disappointed in those
+          Balls!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Displaying a text if several items were bought
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 2
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 3 These are goods which fell of the truck, but still, it's high quality!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 0 Welcome! I'm selling Poké Balls for less than next door...
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "open_shop([:poke_ball, :great_ball], {:poke_ball => 180, :great_ball =>
-                550}, show_background: false)"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Displaying a text if nothing was bought
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 1 I can assure you of their quality!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Displaying a text if a single type of item was bought
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 1
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 2 The paint might be peeled a bit, but you won't be disappointed in those
-                Balls!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Displaying a text if several items were bought
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 2
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 3 These are goods which fell of the truck, but still, it's high quality!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 38
     y: 40
   17: !ruby/object:RPG::Event
     id: 17
     name: Cashier 1
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Seller-F
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Seller-F
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 26
+        - 26
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Welcoming text
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 4 \t[11, 3]
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,0]"
+          - "\\t[11,1]"
+          - "\\t[11,2]"
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,0]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Buy
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,1]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Sell
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 2
+        - "\\t[11,2]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Exit
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Back
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 26
+        - 26
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Showing a different text when exiting a "buy" or "sell" menu,
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - and geting back to the choice
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 5 \t[11,5]
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,0]"
+          - "\\t[11,1]"
+          - "\\t[11,2]"
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,0]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Buy
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,1]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Sell
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 2
+        - "\\t[11,2]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Exit
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Buy
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player has money
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 7
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 6 \t[11, 24]
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Back
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 1
+        parameters:
+        - 26
+        - 26
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Script command for the buying menu
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'open_shop([:poke_ball, :great_ball, :ultra_ball, :potion, :super_potion,
+          :revive, :antidote, :paralyze_heal, :awakening, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ":burn_heal, :ice_heal, :escape_rope, :repel, :super_repel], show_background:
+          false)"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Back
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Sell
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player has any item costing more than 0$
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - each_data_item.none? { |item| item.price > 0 && $bag.contain_item?(item.db_symbol)
+          }
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 7 You have nothing to sell!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Back
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 1
+        parameters:
+        - 26
+        - 26
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Script command for the selling menu
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - GamePlay::Bag.new(:shop).main
+      - !ruby/object:RPG::EventCommand
+        code: 222
+        indent: 1
+        parameters:
+        - ''
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Back
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Exit
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 26
+        - 26
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Exiting text
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 8 \t[11,4]
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 26
-              - 26
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Welcoming text
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 4 \t[11, 3]
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,0]"
-                - "\\t[11,1]"
-                - "\\t[11,2]"
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,0]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Buy
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,1]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Sell
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 2
-              - "\\t[11,2]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Exit
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Back
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 26
-              - 26
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Showing a different text when exiting a "buy" or "sell" menu,
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - and geting back to the choice
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 5 \t[11,5]
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,0]"
-                - "\\t[11,1]"
-                - "\\t[11,2]"
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,0]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Buy
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,1]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Sell
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 2
-              - "\\t[11,2]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Exit
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Buy
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player has money
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 7
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 6 \t[11, 24]
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Back
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 1
-            parameters:
-              - 26
-              - 26
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Script command for the buying menu
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "open_shop([:poke_ball, :great_ball, :ultra_ball, :potion, :super_potion,
-                :revive, :antidote, :paralyze_heal, :awakening, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ":burn_heal, :ice_heal, :escape_rope, :repel, :super_repel], show_background:
-                false)"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Back
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Sell
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player has any item costing more than 0$
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - each_data_item.none? { |item| item.price > 0 && $bag.contain_item?(item.db_symbol)
-                }
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 7 You have nothing to sell!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Back
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 1
-            parameters:
-              - 26
-              - 26
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Script command for the selling menu
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - GamePlay::Bag.new(:shop).main
-          - !ruby/object:RPG::EventCommand
-            code: 222
-            indent: 1
-            parameters:
-              - ""
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Back
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Exit
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 26
-              - 26
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Exiting text
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 8 \t[11,4]
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 37
     y: 39
   18: !ruby/object:RPG::Event
     id: 18
     name: Item
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-Pokeball
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-Pokeball
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 9 As this item is on the ground, you can use the \c[5]"pick_item"\c[0]
+          command to have the event deleted afterward.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:leftovers)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 9 As this item is on the ground, you can use the \c[5]"pick_item"\c[0]
-                command to have the event deleted afterward.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:leftovers)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 40
     y: 46
   19: !ruby/object:RPG::Event
     id: 19
     name: invisible_Item
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 10 As this item has the \c[5]"invisible_"\c[0] tag at the beginning of
+          its name, it does not have a shadow and can be detected by the Drowsing
+          Machine.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:stardust)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 10 As this item has the \c[5]"invisible_"\c[0] tag at the beginning of
-                its name, it does not have a shadow and can be detected by the Drowsing
-                Machine.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:stardust)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 34
     y: 38
   2: !ruby/object:RPG::Event
@@ -2444,4490 +2419,4490 @@ events:
     name: !binary |-
       wqcgRXNjYWxhdG9ycyB3YXJw
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 2
-          opacity: 0
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 6
-              - -1
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 42
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &36
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *36
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &37
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &38
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &39
-                    code: 2
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &40
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *37
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *38
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *39
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *40
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Disabling the shadow under the player.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - gp.shadow_disabled = true
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 7
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &41
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *41
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_escalator
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Animation of the escalator, which graphics' are on event 5.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - ge(7).animate_from_charset([2,3],40)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &42
-                    code: 32
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &43
-                    code: 29
-                    parameters:
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &44
-                    code: 15
-                    parameters:
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &45
-                    code: 5
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *42
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *43
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *44
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *45
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true,"A",1,map_id = 18)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 42
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &46
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *46
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 7
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &47
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *47
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 1
-            parameters:
-              - 0
-              - 18
-              - 24
-              - 18
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 2
+        opacity: 0
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 6
+        - -1
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 42
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
+          - &34 !ruby/object:RPG::MoveCommand
+            code: 42
             parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -238
-                gray: 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 42
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &48
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *48
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 7
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &49
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *49
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the escalator.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - ge(7).animate_from_charset([2,3],40,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &50
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &51
-                    code: 32
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &52
-                    code: 29
-                    parameters:
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &53
-                    code: 8
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &54
-                    code: 31
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *50
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *51
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *52
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *53
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *54
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 6
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Reenabling the shadow under the player.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - gp.shadow_disabled = false
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &55
-                    code: 31
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &56
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &57
-                    code: 3
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &58
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &59
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *55
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *56
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *57
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *58
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *59
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 7
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &60
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *60
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 42
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &61
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *61
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 255
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *34
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &35 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &36 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &37 !ruby/object:RPG::MoveCommand
+            code: 2
+            parameters: []
+          - &38 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *35
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *36
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *37
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *38
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Disabling the shadow under the player.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - gp.shadow_disabled = true
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 7
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &39 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *39
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_escalator
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Animation of the escalator, which graphics' are on event 5.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - ge(7).animate_from_charset([2,3],40)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &40 !ruby/object:RPG::MoveCommand
+            code: 32
+            parameters: []
+          - &41 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 1
+          - &42 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 1
+          - &43 !ruby/object:RPG::MoveCommand
+            code: 5
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *40
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *41
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *42
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *43
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true,"A",1,map_id = 18)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 42
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &44 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *44
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 7
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &45 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *45
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 1
+        parameters:
+        - 0
+        - 18
+        - 24
+        - 18
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -238
+          gray: 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 42
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &46 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *46
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 7
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &47 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *47
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the escalator.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - ge(7).animate_from_charset([2,3],40,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &48 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &49 !ruby/object:RPG::MoveCommand
+            code: 32
+            parameters: []
+          - &50 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 1
+          - &51 !ruby/object:RPG::MoveCommand
+            code: 8
+            parameters: []
+          - &52 !ruby/object:RPG::MoveCommand
+            code: 31
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *48
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *49
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *50
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *51
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *52
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 6
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Reenabling the shadow under the player.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - gp.shadow_disabled = false
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &53 !ruby/object:RPG::MoveCommand
+            code: 31
+            parameters: []
+          - &54 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &55 !ruby/object:RPG::MoveCommand
+            code: 3
+            parameters: []
+          - &56 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &57 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *53
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *54
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *55
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *56
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *57
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 7
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &58 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *58
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 42
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &59 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *59
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 17
     y: 46
   20: !ruby/object:RPG::Event
     id: 20
     name: Malo Cinematic
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 107
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 107
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 28
     y: 42
   21: !ruby/object:RPG::Event
     id: 21
     name: Starting Event
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 20
-              - 0
-              - 28
-              - 42
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &62
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &63
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &64
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *62
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *63
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *64
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &65
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &66
-                    code: 15
-                    parameters:
-                      - 15
-                  - !ruby/object:RPG::MoveCommand &67
-                    code: 45
-                    parameters:
-                      - "emotion(:exclamation, 0, oy_offset: 8)"
-                  - !ruby/object:RPG::MoveCommand &68
-                    code: 15
-                    parameters:
-                      - 20
-                  - !ruby/object:RPG::MoveCommand &69
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &70
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: true
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *65
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *66
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *67
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *68
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *69
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *70
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 11 :[name=SirMalo]:Ah, here you are!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Welcome to the Tower!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 12 :[name=SirMalo]:Sorry, I realized when I got here that I forgot to
-                give you these Running Shoes...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 13 :[name=SirMalo]:I hope you're not angry?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 14 :[name=SirMalo]:Anyway, here, slip these on.
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 53
-              - 53
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Obtained a Key Item!
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$scene.message_window.windowskin_overwrite = 'm_18'"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$scene.message_window.auto_skip = true"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 15 \c[18]\N[1] received a pair of \c[27]Running Shoes\c[18]! [WAIT 130]
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 16 :[name=SirMalo]:Do you want me to give you a tour of the Central Hub?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11, 27]"
-                - "\\t[11, 28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11, 27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 17 :[name=SirMalo]:Follow me, I will show you the different services
-                we offer.
-          - !ruby/object:RPG::EventCommand
-            code: 246
-            indent: 1
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 241
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Hurry Along
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Making the player follow the event number 20
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - get_character(20).set_follower(gp)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the escalator
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [18, 46])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &71
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &72
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *71
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *72
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &73
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &74
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &75
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *73
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *74
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *75
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 18 :[name=SirMalo]:This escalator leads to the Wi-Fi area, where you
-                can test the \c[5]online features\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 19 :[name=SirMalo]:But for now, not all features are available...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 20 :[name=SirMalo]:Do not hesitate to inspect the \c[5]elevator event\c[0]
-                to check how it works and to reuse these in your own game.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the Nurse
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [18, 42])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &76
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &77
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &78
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *76
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *77
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *78
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 21 :[name=SirMalo]:Here is the Pokémon Center counter.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 22 :[name=SirMalo]:You can heal your Pokémon for free!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 23 :[name=SirMalo]:The event is \c[5]dynamic\c[0] and displays as many
-                Poké Balls as Pokémon in your party.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 24 :[name=SirMalo]:It also permits you to \c[5]teleport yourself to the
-                last visited Center\c[0] in case of defeat.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &79
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *79
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 25 :[name=SirMalo]:You also have the PC just right there which allows
-                you to access the Pokémon \c[5]storage system\c[0],
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the battle area
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [28, 42])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &80
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &81
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &82
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *80
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *81
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *82
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &83
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &84
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *83
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *84
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 26 :[name=SirMalo]:If you take these stairs, you'll end up in the Battle
-                Arena.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 27 :[name=SirMalo]:This place allows you to \c[5]setup every type of
-                battle\c[0] permitted by PokémonSDK.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the shop
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [31, 42])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &85
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &86
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &87
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *85
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *86
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *87
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 28 :[name=SirMalo]:This part is the Pokémon Shop.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 29 :[name=SirMalo]:You can buy all sorts of products to help you in your
-                journey.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 30 :[name=SirMalo]:PokémonSDK allows you to setup a lot of different
-                \c[5]shop types\c[0], with limited stocks or not.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the 2nd floor
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [28, 35])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [28, 30])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &88
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &89
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &90
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *88
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *89
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *90
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 31 :[name=SirMalo]:Alright, on this floor we can find many other systems.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &91
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *91
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 32 :[name=SirMalo]:Behind the left counter, you'll find the \c[5]Move
-                Reminder\c[0] and the \c[5]Move Tutor\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &92
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *92
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 33 :[name=SirMalo]:Behind the right counter is the \c[5]Day Care\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 34 :[name=SirMalo]:You can leave there up to two Pokémon to have them
-                train on their side.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 35 :[name=SirMalo]:Who knows, you might even get an Egg!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &93
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *93
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 36 :[name=SirMalo]:The seated people in the relaxation area just here
-                might also teach you useful things.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 37 :[name=SirMalo]:Don't hesitate to have a talk with them!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the elevator on the left
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [19, 30])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &94
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &95
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &96
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *94
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *95
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *96
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 38 :[name=SirMalo]:This elevator here allows you to visit the \c[5]Environmental
-                Zones\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 39 :[name=SirMalo]:These maps showcase all the environments you can create
-                with PokémonSDK, and their associated features.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the elevator on the right
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [37, 30])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &97
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &98
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *97
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *98
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &99
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &100
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &101
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *99
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *100
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *101
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 40 :[name=SirMalo]:Finally, this elevator allows you to visit the \c[5]System
-                Zones\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 41 :[name=SirMalo]:Those are different maps which contain most features
-                permitted inside events by PokémonSDK.
-          - !ruby/object:RPG::EventCommand
-            code: 246
-            indent: 1
-            parameters:
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 40
-          - !ruby/object:RPG::EventCommand
-            code: 241
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Battle Frontier Calm
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11, 28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 42 :[name=SirMalo]:I see I'm talking to a professional!
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 20
+        - 0
+        - 28
+        - 42
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &60 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &61 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &62 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Stopping the player from following Malo
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - get_character(20).reset_follower
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:exclamation, 20, wait=34, oy_offset: 8)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 43 :[name=SirMalo]:Oh, I see you still don't have any Pokémon!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Wait a second...
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 1
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "@choice_result = []"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:squirtle, :ivysaur, :charizard].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 2
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:cyndaquil, :bayleef, :feraligatr].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 3
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:mudkip, :grovyle, :blaziken].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 4
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:piplup, :monferno, :torterra].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:tepig, :dewott, :serperior].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 6
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:chespin, :braixen, :greninja].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 7
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:popplio, :torracat, :decidueye].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 112
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "@choices = ["
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 147),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 148),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 149),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 150),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 151),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 152),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 153)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "]"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - choice(26, -1, *@choices)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 44 :[name=SirMalo]:Here, choose one of these teams.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - PFM::Text.set_variable("[TEAM]", @choices[gv[26] - 1])
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - PFM::Text.set_variable("[PKM1]", @choice_result[gv[26] - 1][0].name)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - PFM::Text.set_variable("[PKM2]", @choice_result[gv[26] - 1][1].name)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - PFM::Text.set_variable("[PKM3]", @choice_result[gv[26] - 1][2].name)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 45 :[name=SirMalo]:So, you have chosen the [TEAM] Team, which includes
-                [PKM1], [PKM2] and [PKM3]. Does this suit you?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 1
-            parameters:
-              - - 3, 46 Yes
-                - 3, 47 No
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 0
-              - 3, 46 Yes
-          - !ruby/object:RPG::EventCommand
-            code: 113
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 1
-              - 3, 47 No
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 413
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Received a Pokemon
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Changing the windowskin for the next message only
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - and making it end automatically (the "[WAIT]" at the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "end make it better) "
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$scene.message_window.windowskin_overwrite = 'm_18'"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$scene.message_window.auto_skip = true"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 48 \c[18]\N[1] obtains the \c[27][TEAM] \c[18]Team! [WAIT 150]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "@choice_result[gv[26] - 1].each { |pokemon| add_rename_pokemon(pokemon)
-                }"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$user_data[:player_team] = @choice_result[gv[26] - 1]"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "@choices = nil"
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 49 :[name=SirMalo]:Here, take this map of the Island.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - give_item(:town_map)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM::Text.reset_variables
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *60
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *61
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *62
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 50 :[name=SirMalo]:You are now ready to explore everything the Tower
-                has to show you!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 51 :[name=SirMalo]:Be curious, do not hesitate to interact with everything
-                you'll see.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 52 :[name=SirMalo]:By the way, every location on this Island possess
-                an item called \c[5]Intriguing Stone\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 53 :[name=SirMalo]:Picking up this item, or getting it from a NPC, means
-                that you should have experienced everything the map offers.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 54 :[name=SirMalo]:Come see me when you've got them all back, I'll be
-                there by the elevator on the left!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 55 :[name=SirMalo]:Well, I'm off.
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Have fun!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Moving Malo to its original position
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "get_character(20).find_path(to: [24, 34])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 20
-              - 0
-              - 16
-              - 34
-              - 6
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 107
-              - 107
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$quests.speak_to_npc(0, 0)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$quests.check_up_signal"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$quests.get_earnings(0)"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+          - &63 !ruby/object:RPG::MoveCommand
+            code: 16
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: C
-          self_switch_valid: false
-          switch1_id: 107
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+          - &64 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 15
+          - &65 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - 'emotion(:exclamation, 0, oy_offset: 8)'
+          - &66 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 20
+          - &67 !ruby/object:RPG::MoveCommand
+            code: 1
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+          - &68 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *63
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *64
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *65
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *66
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *67
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *68
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 11 :[name=SirMalo]:Ah, here you are!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Welcome to the Tower!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 12 :[name=SirMalo]:Sorry, I realized when I got here that I forgot to
+          give you these Running Shoes...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 13 :[name=SirMalo]:I hope you're not angry?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 14 :[name=SirMalo]:Anyway, here, slip these on.
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 53
+        - 53
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Obtained a Key Item!
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$scene.message_window.windowskin_overwrite = 'm_18'"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$scene.message_window.auto_skip = true"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 15 \c[18]\N[1] received a pair of \c[27]Running Shoes\c[18]! [WAIT 130]
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 16 :[name=SirMalo]:Do you want me to give you a tour of the Central Hub?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11, 27]"
+          - "\\t[11, 28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11, 27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 17 :[name=SirMalo]:Follow me, I will show you the different services
+          we offer.
+      - !ruby/object:RPG::EventCommand
+        code: 246
+        indent: 1
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 241
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Hurry Along
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Making the player follow the event number 20
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - get_character(20).set_follower(gp)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the escalator
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [18, 46])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &69 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &70 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *69
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *70
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &71 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &72 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - &73 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *71
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *72
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *73
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 18 :[name=SirMalo]:This escalator leads to the Wi-Fi area, where you
+          can test the \c[5]online features\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 19 :[name=SirMalo]:But for now, not all features are available...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 20 :[name=SirMalo]:Do not hesitate to inspect the \c[5]elevator event\c[0]
+          to check how it works and to reuse these in your own game.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the Nurse
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [18, 42])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &74 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &75 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &76 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *74
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *75
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *76
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 21 :[name=SirMalo]:Here is the Pokémon Center counter.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 22 :[name=SirMalo]:You can heal your Pokémon for free!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 23 :[name=SirMalo]:The event is \c[5]dynamic\c[0] and displays as many
+          Poké Balls as Pokémon in your party.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 24 :[name=SirMalo]:It also permits you to \c[5]teleport yourself to the
+          last visited Center\c[0] in case of defeat.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &77 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *77
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 25 :[name=SirMalo]:You also have the PC just right there which allows
+          you to access the Pokémon \c[5]storage system\c[0],
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the battle area
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [28, 42])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &78 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &79 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - &80 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *78
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *79
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *80
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &81 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - &82 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *81
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *82
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 26 :[name=SirMalo]:If you take these stairs, you'll end up in the Battle
+          Arena.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 27 :[name=SirMalo]:This place allows you to \c[5]setup every type of
+          battle\c[0] permitted by PokémonSDK.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the shop
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [31, 42])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &83 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &84 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &85 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *83
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *84
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *85
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 28 :[name=SirMalo]:This part is the Pokémon Shop.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 29 :[name=SirMalo]:You can buy all sorts of products to help you in your
+          journey.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 30 :[name=SirMalo]:PokémonSDK allows you to setup a lot of different
+          \c[5]shop types\c[0], with limited stocks or not.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the 2nd floor
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [28, 35])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [28, 30])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &86 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &87 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &88 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *86
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *87
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *88
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 31 :[name=SirMalo]:Alright, on this floor we can find many other systems.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &89 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *89
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 32 :[name=SirMalo]:Behind the left counter, you'll find the \c[5]Move
+          Reminder\c[0] and the \c[5]Move Tutor\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &90 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *90
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 33 :[name=SirMalo]:Behind the right counter is the \c[5]Day Care\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 34 :[name=SirMalo]:You can leave there up to two Pokémon to have them
+          train on their side.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 35 :[name=SirMalo]:Who knows, you might even get an Egg!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &91 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *91
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 36 :[name=SirMalo]:The seated people in the relaxation area just here
+          might also teach you useful things.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 37 :[name=SirMalo]:Don't hesitate to have a talk with them!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the elevator on the left
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [19, 30])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &92 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &93 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &94 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *92
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *93
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *94
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 38 :[name=SirMalo]:This elevator here allows you to visit the \c[5]Environmental
+          Zones\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 39 :[name=SirMalo]:These maps showcase all the environments you can create
+          with PokémonSDK, and their associated features.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the elevator on the right
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [37, 30])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &95 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &96 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *95
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *96
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &97 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &98 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - &99 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *97
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *98
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *99
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 40 :[name=SirMalo]:Finally, this elevator allows you to visit the \c[5]System
+          Zones\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 41 :[name=SirMalo]:Those are different maps which contain most features
+          permitted inside events by PokémonSDK.
+      - !ruby/object:RPG::EventCommand
+        code: 246
+        indent: 1
+        parameters:
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 40
+      - !ruby/object:RPG::EventCommand
+        code: 241
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Battle Frontier Calm
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11, 28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 42 :[name=SirMalo]:I see I'm talking to a professional!
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Stopping the player from following Malo
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - get_character(20).reset_follower
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:exclamation, 20, wait=34, oy_offset: 8)'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 43 :[name=SirMalo]:Oh, I see you still don't have any Pokémon!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Wait a second...
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 1
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "@choice_result = []"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:squirtle, :ivysaur, :charizard].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 2
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:cyndaquil, :bayleef, :feraligatr].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 3
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:mudkip, :grovyle, :blaziken].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 4
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:piplup, :monferno, :torterra].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:tepig, :dewott, :serperior].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 6
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:chespin, :braixen, :greninja].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 7
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:popplio, :torracat, :decidueye].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 112
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - "@choices = ["
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 147),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 148),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 149),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 150),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 151),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 152),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 153)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "]"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - choice(26, -1, *@choices)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 44 :[name=SirMalo]:Here, choose one of these teams.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - PFM::Text.set_variable("[TEAM]", @choices[gv[26] - 1])
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - PFM::Text.set_variable("[PKM1]", @choice_result[gv[26] - 1][0].name)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - PFM::Text.set_variable("[PKM2]", @choice_result[gv[26] - 1][1].name)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - PFM::Text.set_variable("[PKM3]", @choice_result[gv[26] - 1][2].name)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 45 :[name=SirMalo]:So, you have chosen the [TEAM] Team, which includes
+          [PKM1], [PKM2] and [PKM3]. Does this suit you?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 1
+        parameters:
+        - - 3, 46 Yes
+          - 3, 47 No
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 0
+        - 3, 46 Yes
+      - !ruby/object:RPG::EventCommand
+        code: 113
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 1
+        - 3, 47 No
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 413
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Received a Pokemon
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Changing the windowskin for the next message only
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - and making it end automatically (the "[WAIT]" at the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'end make it better) '
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$scene.message_window.windowskin_overwrite = 'm_18'"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$scene.message_window.auto_skip = true"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 48 \c[18]\N[1] obtains the \c[27][TEAM] \c[18]Team! [WAIT 150]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "@choice_result[gv[26] - 1].each { |pokemon| add_rename_pokemon(pokemon)
+          }"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$user_data[:player_team] = @choice_result[gv[26] - 1]"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "@choices = nil"
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 49 :[name=SirMalo]:Here, take this map of the Island.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - give_item(:town_map)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM::Text.reset_variables
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 50 :[name=SirMalo]:You are now ready to explore everything the Tower
+          has to show you!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 51 :[name=SirMalo]:Be curious, do not hesitate to interact with everything
+          you'll see.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 52 :[name=SirMalo]:By the way, every location on this Island possess
+          an item called \c[5]Intriguing Stone\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 53 :[name=SirMalo]:Picking up this item, or getting it from a NPC, means
+          that you should have experienced everything the map offers.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 54 :[name=SirMalo]:Come see me when you've got them all back, I'll be
+          there by the elevator on the left!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 55 :[name=SirMalo]:Well, I'm off.
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Have fun!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Moving Malo to its original position
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'get_character(20).find_path(to: [24, 34])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 20
+        - 0
+        - 16
+        - 34
+        - 6
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 107
+        - 107
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$quests.speak_to_npc(0, 0)"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$quests.check_up_signal"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$quests.get_earnings(0)"
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: C
+        self_switch_valid: false
+        switch1_id: 107
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 29
     y: 49
   22: !ruby/object:RPG::Event
     id: 22
     name: Move Reminder
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Scientist-M
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Scientist-M
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 56 Hello!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - I know everything about the moves a Pokémon can learn when growing.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 57 If you want, I can teach one of your companions a move they might
+          have forget during their growth.
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - !binary |-
+          Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - call_party_menu
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Checking if a move can be reminded
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 12
+        - can_move_reminder_be_called?
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - Checking if no move was reminded
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 2
+        parameters:
+        - 12
+        - "!move_reminder"
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 3
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 3
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 3, 58 Nothing suited you?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 2
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 3, 59 I'm sure your Pokémon will be stronger this way!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 2
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 3, 60 Unfortunately, there is nothing to teach to your Pokémon...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 61 You can sometimes come across unsuspected moves!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 56 Hello!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - I know everything about the moves a Pokémon can learn when growing.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 57 If you want, I can teach one of your companions a move they might
-                have forget during their growth.
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - !binary |-
-                Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - call_party_menu
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Checking if a move can be reminded
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 12
-              - can_move_reminder_be_called?
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - Checking if no move was reminded
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 2
-            parameters:
-              - 12
-              - "!move_reminder"
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 3
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 3
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 3, 58 Nothing suited you?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 2
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 3, 59 I'm sure your Pokémon will be stronger this way!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 2
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 3, 60 Unfortunately, there is nothing to teach to your Pokémon...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 61 You can sometimes come across unsuspected moves!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 24
     y: 28
   23: !ruby/object:RPG::Event
     id: 23
     name: Move Tutor
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Scientist-F
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Scientist-F
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 62 I can teach a very useful move to help you catch Pokémon.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 63 Are you interested?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 64 To which Pokémon do you want to teach it?
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - !binary |-
+          Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - !binary |-
+          VGhlIGNob3NlbiBQb2vDqW1vbiBpcyBzdG9yZWQgaW4gdmFyaWFibGUgNDMu
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - call_party_menu
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 1
+        - 43
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - !binary |-
+          VGhlbiwgd2UgY2hlY2sgaWYgdGhlIFBva8OpbW9uIGNhbiBsZWFybiBpdCBvciBub3Q=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - "(not in the moveset or already learnt)"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 2
+        parameters:
+        - 12
+        - gv[43] >= 0 && $actors[gv[43]].can_learn?(:false_swipe)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 3
+        parameters:
+        - Learning the move
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 3
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - skill_learn(gv[43], :false_swipe)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 3, 65 This move always leaves at least 1 HP to its target.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 3, 66 It's a must-have for any self-respecting Trainer, if you want my opinion.
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 3
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 3
+        parameters:
+        - !binary |-
+          SWYgdGhlIGNob3NlbiBQb2vDqW1vbiBjYW4ndCBsZWFybiB0aGUgbW92ZQ==
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 3
+        parameters:
+        - or has already learnt it
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 3, 67 Unfortunately, I can't teach this move to your Pokémon...
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 3
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - If the player exited the party menu without selecting a
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - !binary |-
+          UG9rw6ltb24=
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 3, 68 Did you change your mind?
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - Event end
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 69 But this move can be very useful for some very delicate catches.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 62 I can teach a very useful move to help you catch Pokémon.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 63 Are you interested?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 64 To which Pokémon do you want to teach it?
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - !binary |-
-                Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - !binary |-
-                VGhlIGNob3NlbiBQb2vDqW1vbiBpcyBzdG9yZWQgaW4gdmFyaWFibGUgNDMu
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - call_party_menu
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 1
-              - 43
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - !binary |-
-                VGhlbiwgd2UgY2hlY2sgaWYgdGhlIFBva8OpbW9uIGNhbiBsZWFybiBpdCBvciBub3Q=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - "(not in the moveset or already learnt)"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 2
-            parameters:
-              - 12
-              - gv[43] >= 0 && $actors[gv[43]].can_learn?(:false_swipe)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 3
-            parameters:
-              - Learning the move
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 3
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - skill_learn(gv[43], :false_swipe)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 3, 65 This move always leaves at least 1 HP to its target.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 3, 66 It's a must-have for any self-respecting Trainer, if you want my opinion.
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 3
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 3
-            parameters:
-              - !binary |-
-                SWYgdGhlIGNob3NlbiBQb2vDqW1vbiBjYW4ndCBsZWFybiB0aGUgbW92ZQ==
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 3
-            parameters:
-              - or has already learnt it
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 3, 67 Unfortunately, I can't teach this move to your Pokémon...
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 3
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - If the player exited the party menu without selecting a
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - !binary |-
-                UG9rw6ltb24=
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 3, 68 Did you change your mind?
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - Event end
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 69 But this move can be very useful for some very delicate catches.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 26
     y: 28
   24: !ruby/object:RPG::Event
     id: 24
     name: Daycare woman
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Woman-03
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Woman-03
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable allows you to have multiple daycares
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 46
+        - 46
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Calling this common event is enough to launch the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - Daycare management system.
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 16
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable allows you to have multiple daycares
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 46
-              - 46
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Calling this common event is enough to launch the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - Daycare management system.
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 16
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 30
     y: 28
   25: !ruby/object:RPG::Event
     id: 25
     name: Daycare man
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Man-06
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Man-06
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable allows you to have multiple daycares
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 46
+        - 46
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Calling this common event is enough to launch the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - Daycare status system.
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 17
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable allows you to have multiple daycares
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 46
-              - 46
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Calling this common event is enough to launch the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - Daycare status system.
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 17
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 28
   26: !ruby/object:RPG::Event
     id: 26
     name: Malo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 107
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 107
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 70 :[name=SirMalo]:Well, \N[1]!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - So, how is your exploration faring?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 71 :[name=SirMalo]:Just for the record, there is 16 Intriguing Stones
+          in this demo.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking the quantity of Intriguing Stones with this
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - command because it's a Rare Object
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$game_variables[26] = $bag.item_quantity(:intriguing_stone)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - PFM::Text.set_variable('[STONE]', gv[26].to_s)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 72 :[name=SirMalo]:And I see you have... [STONE] of these!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player has more than 16 stones and/or
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - if they got one in an inexpected way
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gv[26] >= 16 && get_self_switch('A', 17, 21) == false
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 73 :[name=SirMalo]:... I know someone who used the console!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 74 :[name=SirMalo]:It's very good to learn how to use it!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 75 :[name=SirMalo]:But be sure not to spoil you the game experience and
+          the fun learning moment we're offering with this demo.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 76 :[name=SirMalo]:If you already have completed this demo before, and
+          you just want to receive the reward again, you can continue!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 77 :[name=SirMalo]:Else, I invite you to continue playing the normal
+          way, you'll learn a lot more this way!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 78 :[name=SirMalo]:I'm still going to tell you my speech, just in case.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 16
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 79 :[name=SirMalo]:Congratulations!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - You have obtained every Intriguing Stones!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 80 :[name=SirMalo]:This means you should have memorized where each feature
+          is showed!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 81 :[name=SirMalo]:Thanks to that, you'll know which map you should refer
+          to when you have a doubt about a given feature.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 82 :[name=SirMalo]:Again, congrats!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - By the way, I have a small surprise for you, to commemorate the end of your
+          journey...
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - Follow me!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - 'NOTE: The events for the screenshot cinematic are'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - located on the top-left corner of this map
+      - !ruby/object:RPG::EventCommand
+        code: 231
+        indent: 1
+        parameters:
+        - 1
+        - black
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 1
+        parameters:
+        - 1
+        - 30
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 40
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, 'A', 41)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 13
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 83 :[name=SirMalo]:Just a little more effort, you're almost there!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 10
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 84 :[name=SirMalo]:You're on the right way!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 85 :[name=SirMalo]:Some are harder to find than others, but you can do
+          it!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 8
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 86 :[name=SirMalo]:You've done one half, well played!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - Don't let up in your efforts!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 6
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 87 :[name=SirMalo]:Not bad!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - You've almost done the first half!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - Keep it up!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 3
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 88 :[name=SirMalo]:You're progressing well!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 89 :[name=SirMalo]:Did you encounter some of my colleagues?
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - They all have an Intriguing Stone, so go on and find them!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 1
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 90 :[name=SirMalo]:So, do you enjoy the demo?
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - We gave it our all to make you have a nice moment on it!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 91 :[name=SirMalo]:Don't hesitate to explore and talk to everyone!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - You'll learn lots of things this way!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'Warning: you must ALWAYS reset the variables at the'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'end of the event with: PFM::Text.reset_variables'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM::Text.reset_variables
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 70 :[name=SirMalo]:Well, \N[1]!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - So, how is your exploration faring?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 71 :[name=SirMalo]:Just for the record, there is 16 Intriguing Stones
-                in this demo.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking the quantity of Intriguing Stones with this
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - command because it's a Rare Object
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$game_variables[26] = $bag.item_quantity(:intriguing_stone)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - PFM::Text.set_variable('[STONE]', gv[26].to_s)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 72 :[name=SirMalo]:And I see you have... [STONE] of these!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player has more than 16 stones and/or
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - if they got one in an inexpected way
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gv[26] >= 16 && get_self_switch('A', 17, 21) == false
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 73 :[name=SirMalo]:... I know someone who used the console!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 74 :[name=SirMalo]:It's very good to learn how to use it!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 75 :[name=SirMalo]:But be sure not to spoil you the game experience and
-                the fun learning moment we're offering with this demo.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 76 :[name=SirMalo]:If you already have completed this demo before, and
-                you just want to receive the reward again, you can continue!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 77 :[name=SirMalo]:Else, I invite you to continue playing the normal
-                way, you'll learn a lot more this way!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 78 :[name=SirMalo]:I'm still going to tell you my speech, just in case.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 16
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 79 :[name=SirMalo]:Congratulations!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - You have obtained every Intriguing Stones!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 80 :[name=SirMalo]:This means you should have memorized where each feature
-                is showed!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 81 :[name=SirMalo]:Thanks to that, you'll know which map you should refer
-                to when you have a doubt about a given feature.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 82 :[name=SirMalo]:Again, congrats!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - By the way, I have a small surprise for you, to commemorate the end of your
-                journey...
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - Follow me!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - "NOTE: The events for the screenshot cinematic are"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - located on the top-left corner of this map
-          - !ruby/object:RPG::EventCommand
-            code: 231
-            indent: 1
-            parameters:
-              - 1
-              - black
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 1
-            parameters:
-              - 1
-              - 30
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 40
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, 'A', 41)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 13
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 83 :[name=SirMalo]:Just a little more effort, you're almost there!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 10
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 84 :[name=SirMalo]:You're on the right way!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 85 :[name=SirMalo]:Some are harder to find than others, but you can do
-                it!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 8
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 86 :[name=SirMalo]:You've done one half, well played!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - Don't let up in your efforts!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 6
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 87 :[name=SirMalo]:Not bad!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - You've almost done the first half!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - Keep it up!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 3
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 88 :[name=SirMalo]:You're progressing well!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 89 :[name=SirMalo]:Did you encounter some of my colleagues?
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - They all have an Intriguing Stone, so go on and find them!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 1
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 90 :[name=SirMalo]:So, do you enjoy the demo?
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - We gave it our all to make you have a nice moment on it!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 91 :[name=SirMalo]:Don't hesitate to explore and talk to everyone!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - You'll learn lots of things this way!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "Warning: you must ALWAYS reset the variables at the"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "end of the event with: PFM::Text.reset_variables"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM::Text.reset_variables
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 92 :[name=SirMalo]:Oh hi \N[1], how are you? I hope you enjoyed this
+          little surprise, and you had fun playing this technical demo!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 93 :[name=SirMalo]:I also hope it'll be useful to you in the future,
+          if you're seeking some information for your own fangame!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 94 :[name=SirMalo]:Let us know if you happen to create your own!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 92 :[name=SirMalo]:Oh hi \N[1], how are you? I hope you enjoyed this
-                little surprise, and you had fun playing this technical demo!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 93 :[name=SirMalo]:I also hope it'll be useful to you in the future,
-                if you're seeking some information for your own fangame!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 94 :[name=SirMalo]:Let us know if you happen to create your own!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 16
     y: 34
   27: !ruby/object:RPG::Event
     id: 27
     name: Roughneck
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Maximo
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 95 Who's daddy's little good boy?
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:nocomment, 27, wait=70, oy_offset: 16)"
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &102
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &103
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *102
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *103
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 96 Erm, it's not what it looks like..!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &104
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &105
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &106
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *104
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *105
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *106
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 97 Rockruff, use Growl!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - emotion(:exclamation, 28, wait=70)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:rockruff)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 98 Good!
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Maximo
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 95 Who's daddy's little good boy?
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:nocomment, 27, wait=70, oy_offset: 16)'
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Maximo
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 99 My Rockruff is very strong, and it intimidates every Pokémon we're
-                battling!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+          - &100 !ruby/object:RPG::MoveCommand
+            code: 36
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &101 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *100
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *101
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 96 Erm, it's not what it looks like..!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &102 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - &103 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - &104 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *102
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *103
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *104
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 97 Rockruff, use Growl!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - emotion(:exclamation, 28, wait=70)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:rockruff)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 98 Good!
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Maximo
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 99 My Rockruff is very strong, and it intimidates every Pokémon we're
+          battling!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 33
   28: !ruby/object:RPG::Event
     id: 28
     name: Rockruff
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0744"
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 100 Would you like to pet the Rockruff?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11, 27]"
-                - "\\t[11, 28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11, 27]"
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &107
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &108
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &109
-                    code: 15
-                    parameters:
-                      - 15
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *107
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *108
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *109
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "emotion(:love, 28, wait=70, oy_offset: 8)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - cry_pokemon(:rockruff)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 101 Ruff! Ruff!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &110
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &111
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *110
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *111
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11, 28]"
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &112
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &113
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &114
-                    code: 15
-                    parameters:
-                      - 15
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *112
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *113
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *114
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "emotion(:sad, 28, wait=70, oy_offset: 8)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 102 Rockruff seems disappointed...
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &115
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &116
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *115
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *116
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0744'
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 100 Would you like to pet the Rockruff?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11, 27]"
+          - "\\t[11, 28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11, 27]"
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &105 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - &106 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &107 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 15
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *105
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *106
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *107
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'emotion(:love, 28, wait=70, oy_offset: 8)'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - cry_pokemon(:rockruff)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 101 Ruff! Ruff!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &108 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - &109 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *108
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *109
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11, 28]"
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &110 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - &111 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &112 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 15
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *110
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *111
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *112
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'emotion(:sad, 28, wait=70, oy_offset: 8)'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 102 Rockruff seems disappointed...
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &113 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - &114 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *113
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *114
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 32
     y: 33
   29: !ruby/object:RPG::Event
     id: 29
     name: "$Jules"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 101
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Roughneck
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 101
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Roughneck
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 103 :[name=Jules]:Do you know about this chick who fell off the other
+          side of the guardrail not long ago, behind the Tower?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 104 :[name=Jules]:No kidding, dying like that is wack, not even badass
+          or something...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 105 :[name=Jules]:Some people are saying her ghost haunts the grounds
+          at night since her death.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 106 :[name=Jules]:If I died the same way, I'd be too salty not to haunt
+          the area.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 107 :[name=Jules]:But well, revenants don't exist, the only ghosts are
+          the Pokémon, right..?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 103 :[name=Jules]:Do you know about this chick who fell off the other
-                side of the guardrail not long ago, behind the Tower?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 104 :[name=Jules]:No kidding, dying like that is wack, not even badass
-                or something...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 105 :[name=Jules]:Some people are saying her ghost haunts the grounds
-                at night since her death.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 106 :[name=Jules]:If I died the same way, I'd be too salty not to haunt
-                the area.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 107 :[name=Jules]:But well, revenants don't exist, the only ghosts are
-                the Pokémon, right..?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 101
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 108 :[name=Jules]:Ya want some help maybe?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 109 :[name=Jules]:... Yo, you got somethin' to say to me?
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Spit it out, I'm all ears.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 110 .[WAIT 10].[WAIT 10].[WAIT 30]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - emotion(:exclamation)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 40
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 111 :[name=Jules]:What you talkin' 'bout, fam?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 112 :[name=Jules]:Ayy, there's this chick Marissa lookin' to drop some
+          love letters on me?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 113 :[name=Jules]:I'm feelin' it, but like...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 114 :[name=Jules]:LMFAO, who's that?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 115 :[name=Jules]:Like, why ain't she come up and tell me herself?
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - I don't even know this Marissa chick.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 116 :[name=Jules]:Alright, if she's lookin' to get to know each other,
+          I'll make an effort, you know, being the classy gentleman I am and all that.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 117 :[name=Jules]:So where's she at then?
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - emotion(:nocomment, 0, wait=60, oy_offset:16)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 118 :[name=Jules]:Huh... What? She literally dead?!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Elle est morte ?!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 119 :[name=Jules]:Hold up, you ain't tellin' me she's the chick who went
+          down recently, right?!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 120 :[name=Jules]:Aight, I don't wanna know nothin' more, I'm out, peace.
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &115 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - &116 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 101
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *115
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *116
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$quests.speak_to_npc(2, 0)"
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 108 :[name=Jules]:Ya want some help maybe?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 109 :[name=Jules]:... Yo, you got somethin' to say to me?
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Spit it out, I'm all ears.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 110 .[WAIT 10].[WAIT 10].[WAIT 30]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - emotion(:exclamation)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 40
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 111 :[name=Jules]:What you talkin' 'bout, fam?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 112 :[name=Jules]:Ayy, there's this chick Marissa lookin' to drop some
-                love letters on me?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 113 :[name=Jules]:I'm feelin' it, but like...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 114 :[name=Jules]:LMFAO, who's that?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 115 :[name=Jules]:Like, why ain't she come up and tell me herself?
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - I don't even know this Marissa chick.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 116 :[name=Jules]:Alright, if she's lookin' to get to know each other,
-                I'll make an effort, you know, being the classy gentleman I am and all that.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 117 :[name=Jules]:So where's she at then?
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - emotion(:nocomment, 0, wait=60, oy_offset:16)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 118 :[name=Jules]:Huh... What? She literally dead?!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Elle est morte ?!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 119 :[name=Jules]:Hold up, you ain't tellin' me she's the chick who went
-                down recently, right?!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 120 :[name=Jules]:Aight, I don't wanna know nothin' more, I'm out, peace.
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &117
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &118
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *117
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *118
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$quests.speak_to_npc(2, 0)"
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 101
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 101
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 121 :[name=Jules]:Yo, stop talkin' to me, please. That ghost story of
+          yours is giving me the chills. I'm out.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 122 :[name=Jules]:Hope you ain't cursed me with that nonsense of yours.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 121 :[name=Jules]:Yo, stop talkin' to me, please. That ghost story of
-                yours is giving me the chills. I'm out.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 122 :[name=Jules]:Hope you ain't cursed me with that nonsense of yours.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 28
     y: 36
   3: !ruby/object:RPG::Event
@@ -6935,1228 +6910,1228 @@ events:
     name: !binary |-
       wqcgTGVmdCBlbGV2YXRvciBkb29y
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &119
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &120
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &121
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &122
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &123
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *119
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *120
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *121
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *122
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *123
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable tells the game from which floor the playe came inside the
-                elevator.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 4
-              - 12
-              - 16
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &124
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &125
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &126
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &127
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &128
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *124
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *125
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *126
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *127
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *128
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &117 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &118 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &119 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &120 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The animation will play in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &121 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *117
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *118
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *119
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *120
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *121
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable tells the game from which floor the playe came inside the
+          elevator.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 4
+        - 12
+        - 16
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &122 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &123 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &124 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &125 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &126 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *122
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *123
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *124
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *125
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *126
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The animation will play in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 19
     y: 29
   30: !ruby/object:RPG::Event
     id: 30
     name: EasterEggOWO
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 123 It's a promotional poster. A slogan is written on it.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 124 "You wanna be the very best, like no one ever was.
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - If catching the best is your real quest, and to train them is your cause,
+          join your local league!"
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 123 It's a promotional poster. A slogan is written on it.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 124 "You wanna be the very best, like no one ever was.
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - If catching the best is your real quest, and to train them is your cause,
-                join your local league!"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 22
     y: 38
   31: !ruby/object:RPG::Event
     id: 31
     name: Malo Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 0
     y: 0
   32: !ruby/object:RPG::Event
     id: 32
     name: Rey Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_ranger
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_ranger
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 1
     y: 0
   33: !ruby/object:RPG::Event
     id: 33
     name: Yuri Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Book-girl
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Book-girl
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 2
     y: 0
   34: !ruby/object:RPG::Event
     id: 34
     name: Aerun Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Hiker-03
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Hiker-03
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 3
     y: 0
   35: !ruby/object:RPG::Event
     id: 35
     name: Palbolsky Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Dragon-tamer-02
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Dragon-tamer-02
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 4
     y: 0
   36: !ruby/object:RPG::Event
     id: 36
     name: Walven Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Rich-Boy-2
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Rich-Boy-2
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 5
     y: 0
   37: !ruby/object:RPG::Event
     id: 37
     name: Scorbutics Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Veteran-02
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Veteran-02
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 6
     y: 0
   38: !ruby/object:RPG::Event
     id: 38
     name: Starter1 Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 0
     y: 1
   39: !ruby/object:RPG::Event
     id: 39
     name: Starter2 Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 1
     y: 1
   4: !ruby/object:RPG::Event
@@ -8164,1002 +8139,1002 @@ events:
     name: !binary |-
       wqcgcmlnaHQgZWxldmF0b3IgZG9vcg==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &129
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &130
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &131
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &132
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &133
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *129
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *130
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *131
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *132
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *133
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable tells the game from which floor the playe came
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - inside the elevator.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 12
-              - 12
-              - 16
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &134
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &135
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &136
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &137
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &138
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *134
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *135
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *136
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *137
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *138
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &127 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &128 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &129 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &130 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The animation will play in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &131 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *127
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *128
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *129
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *130
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *131
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable tells the game from which floor the playe came
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - inside the elevator.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 12
+        - 12
+        - 16
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &132 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &133 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &134 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &135 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &136 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *132
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *133
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *134
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *135
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *136
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The animation will play in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 37
     y: 29
   40: !ruby/object:RPG::Event
     id: 40
     name: Starter3 Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 2
     y: 1
   41: !ruby/object:RPG::Event
     id: 41
     name: Photo Event
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "(31..40).each { |id| set_self_switch(true, 'A', id) }"
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 3
-              - 28
-              - 43
-              - 4
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 31
-              - 0
-              - 27
-              - 43
-              - 6
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 32
-              - 0
-              - 29
-              - 43
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 33
-              - 0
-              - 28
-              - 42
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 34
-              - 0
-              - 27
-              - 42
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 35
-              - 0
-              - 29
-              - 42
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 36
-              - 0
-              - 26
-              - 42
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 37
-              - 0
-              - 30
-              - 42
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - ge(38).set_appearance($user_data[:player_team][0].character_name)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - ge(39).set_appearance($user_data[:player_team][1].character_name)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - ge(40).set_appearance($user_data[:player_team][2].character_name)
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 38
-              - 0
-              - 27
-              - 44
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 39
-              - 0
-              - 28
-              - 44
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 40
-              - 0
-              - 29
-              - 44
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 0
-            parameters:
-              - 1
-              - 30
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 235
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 125 :[name=SirMalo]:Here we are, with the whole team and your very first
-                Pokémon!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 126 :[name=SirMalo]:What we're going to do?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 127 :[name=SirMalo]:We're going to take a commemorative photo!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 128 :[name=SirMalo]:Look down...
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &139
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *139
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 31
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &140
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *140
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 32
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &141
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *141
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 129 :[name=SirMalo]:Say "Chespin"!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 130 :[name=Everyone]::[align=center]:CHESPIN!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - take_screenshot("technical_demo.png", scale = 2)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 224
-            indent: 0
-            parameters:
-              - !ruby/object:Color
-                red: 255
-                green: 255
-                blue: 255
-                alpha: 255
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &142
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *142
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 31
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &143
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *143
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 32
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &144
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *144
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 131 :[name=SirMalo]:There, the photo is taken... Or should I say the
-                screenshot!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 132 :[name=SirMalo]:You can find it in the folder of the demo, named
-                "technical_demo.png".
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "3, 133 :[name=SirMalo]:We would love if you could share this screen and
-                your reactions about the demo on the Pokémon Workshop Discord server, in
-                the channel #psdk-talk!"
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - !binary |-
-                cmVtYXJxdWVzIGV0IHRlcyBjb21tZW50YWlyZXMgc3VyIGNldHRlIGTDqW1vICE=
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 134 :[name=SirMalo]:Thanks again for playing until the end, we hope you
-                had as much fun when journeying through this demo as us creating it!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 135 :[name=SirMalo]:We hope to see you soon on the Discord!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 136 :[name=SirMalo]:And now, roll the credits!
-          - !ruby/object:RPG::EventCommand
-            code: 231
-            indent: 0
-            parameters:
-              - 1
-              - black
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 0
-            parameters:
-              - 1
-              - 10
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 3
-              - 25
-              - 33
-              - 2
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "(31..40).each { |id| delete_event_forever(id) }"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$scene.call_scene(GamePlay::CreditScene)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - force_save
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@wait = 1"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 0
-            parameters:
-              - 1
-              - 30
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 235
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "(31..40).each { |id| set_self_switch(true, 'A', id) }"
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 3
+        - 28
+        - 43
+        - 4
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 31
+        - 0
+        - 27
+        - 43
+        - 6
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 32
+        - 0
+        - 29
+        - 43
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 33
+        - 0
+        - 28
+        - 42
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 34
+        - 0
+        - 27
+        - 42
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 35
+        - 0
+        - 29
+        - 42
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 36
+        - 0
+        - 26
+        - 42
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 37
+        - 0
+        - 30
+        - 42
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - ge(38).set_appearance($user_data[:player_team][0].character_name)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - ge(39).set_appearance($user_data[:player_team][1].character_name)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - ge(40).set_appearance($user_data[:player_team][2].character_name)
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 38
+        - 0
+        - 27
+        - 44
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 39
+        - 0
+        - 28
+        - 44
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 40
+        - 0
+        - 29
+        - 44
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 0
+        parameters:
+        - 1
+        - 30
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 235
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 125 :[name=SirMalo]:Here we are, with the whole team and your very first
+          Pokémon!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 126 :[name=SirMalo]:What we're going to do?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 127 :[name=SirMalo]:We're going to take a commemorative photo!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 128 :[name=SirMalo]:Look down...
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &137 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *137
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 31
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &138 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *138
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 32
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &139 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *139
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 129 :[name=SirMalo]:Say "Chespin"!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 130 :[name=Everyone]::[align=center]:CHESPIN!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - take_screenshot("technical_demo.png", scale = 2)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 224
+        indent: 0
+        parameters:
+        - !ruby/object:Color
+          red: 255
+          green: 255
+          blue: 255
+          alpha: 255
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &140 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *140
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 31
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &141 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *141
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 32
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &142 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *142
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 131 :[name=SirMalo]:There, the photo is taken... Or should I say the
+          screenshot!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 132 :[name=SirMalo]:You can find it in the folder of the demo, named
+          "technical_demo.png".
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '3, 133 :[name=SirMalo]:We would love if you could share this screen and
+          your reactions about the demo on the Pokémon Workshop Discord server, in
+          the channel #psdk-talk!'
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - !binary |-
+          cmVtYXJxdWVzIGV0IHRlcyBjb21tZW50YWlyZXMgc3VyIGNldHRlIGTDqW1vICE=
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 134 :[name=SirMalo]:Thanks again for playing until the end, we hope you
+          had as much fun when journeying through this demo as us creating it!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 135 :[name=SirMalo]:We hope to see you soon on the Discord!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 136 :[name=SirMalo]:And now, roll the credits!
+      - !ruby/object:RPG::EventCommand
+        code: 231
+        indent: 0
+        parameters:
+        - 1
+        - black
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 0
+        parameters:
+        - 1
+        - 10
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 3
+        - 25
+        - 33
+        - 2
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "(31..40).each { |id| delete_event_forever(id) }"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$scene.call_scene(GamePlay::CreditScene)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - force_save
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@wait = 1"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 0
+        parameters:
+        - 1
+        - 30
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 235
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 0
     y: 2
   42: !ruby/object:RPG::Event
@@ -9167,664 +9142,664 @@ events:
     name: !binary |-
       wqcgZXNjYWxhdG9yIHJhaWxpbmc=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Escalator-railings
-          direction: 4
-          opacity: 0
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Escalator-railings
+        direction: 4
+        opacity: 0
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 17
     y: 47
   43: !ruby/object:RPG::Event
     id: 43
     name: Give item
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Aroma-Lady
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Aroma-Lady
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 137 Here, we encourage young Trainers to catch lots and lots of Pokémon!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 138 I'm going to use the \c[5]"give_item"\c[0] command to give you 10
+          Poké Balls.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - give_item(:poke_ball, 10)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 139 The Tower brims with a great variety of Pokémon to catch.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 140 So don't hesitate to launch a lot of these in all directions!
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 137 Here, we encourage young Trainers to catch lots and lots of Pokémon!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 138 I'm going to use the \c[5]"give_item"\c[0] command to give you 10
-                Poké Balls.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - give_item(:poke_ball, 10)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 139 The Tower brims with a great variety of Pokémon to catch.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 140 So don't hesitate to launch a lot of these in all directions!
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Aroma-Lady
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Aroma-Lady
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 141 The Tower brims with a great variety of Pokémon to catch.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 142 So don't hesitate to launch a lot of these in all directions!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 141 The Tower brims with a great variety of Pokémon to catch.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 142 So don't hesitate to launch a lot of these in all directions!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 1
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 1
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 34
     y: 43
   44: !ruby/object:RPG::Event
     id: 44
     name: Silently give an item
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Burglar
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 143 Hey, psst...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 144 I'm gonna slip you something on the down low...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 145 I put it directly in your bag using the \c[5]"$bag.add_item"\c[0]
-                command.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$bag.add_item(:rare_candy)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 146 .[WAIT 20].[WAIT 20].[WAIT 20]
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Now scram.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking the position of the player
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 26
-              - 26
-              - 0
-              - 6
-              - -1
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 34
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &145
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &146
-                    code: 13
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *145
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *146
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "get_character(44).find_path(to: [28, 47])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - wait_event(44)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &147
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &148
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand &149
-                    code: 41
-                    parameters:
-                      - npc_Burglar
-                      - 0
-                      - 2
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &150
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *147
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *148
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *149
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *150
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 2
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Burglar
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 143 Hey, psst...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 144 I'm gonna slip you something on the down low...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 145 I put it directly in your bag using the \c[5]"$bag.add_item"\c[0]
+          command.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$bag.add_item(:rare_candy)"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 146 .[WAIT 20].[WAIT 20].[WAIT 20]
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Now scram.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking the position of the player
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 26
+        - 26
+        - 0
+        - 6
+        - -1
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 34
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &143 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - &144 !ruby/object:RPG::MoveCommand
+            code: 13
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *143
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *144
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'get_character(44).find_path(to: [28, 47])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - wait_event(44)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &145 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - &146 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - &147 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - npc_Burglar
+            - 0
+            - 2
+            - 1
+          - &148 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *145
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *146
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *147
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *148
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 2
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 35
     y: 47
   5: !ruby/object:RPG::Event
     id: 5
     name: Nurse
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Nurse-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Nurse-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We set the Map Return depending on the Nurse's position,
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - with a +2 to her Y position so that when we black out, we
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - appear directly on the right position.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 47
+        - 47
+        - 0
+        - 7
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 48
+        - 48
+        - 0
+        - 6
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 49
+        - 49
+        - 0
+        - 6
+        - 5
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 49
+        - 49
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We set the Map Return depending on the Nurse's position,
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - with a +2 to her Y position so that when we black out, we
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - appear directly on the right position.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 47
-              - 47
-              - 0
-              - 7
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 48
-              - 48
-              - 0
-              - 6
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 49
-              - 49
-              - 0
-              - 6
-              - 5
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 49
-              - 49
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 18
     y: 40
   6: !ruby/object:RPG::Event
     id: 6
     name: "[sprite=off] Exiting arrow"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This event displays an arrow under the exit when the player stands in front
-                of it and faces down.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gp.x == 28 && gp.y == 47
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 6
-              - -1
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - 1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &151
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *151
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - 1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &152
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *152
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &153
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *153
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This event displays an arrow under the exit when the player stands in front
+          of it and faces down.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gp.x == 28 && gp.y == 47
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 6
+        - -1
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - 1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &149 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *149
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - 1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &150 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *150
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &151 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *151
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 28
     y: 49
   7: !ruby/object:RPG::Event
@@ -9832,51 +9807,51 @@ events:
     name: !binary |-
       wqcgRXNjYWxhdG9yIGdyYXBoaWNz
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Escalator-up
-          direction: 6
-          opacity: 0
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Escalator-up
+        direction: 6
+        opacity: 0
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - ge(7).z = 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - ge(7).z = 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 16
     y: 47
   8: !ruby/object:RPG::Event
@@ -9884,249 +9859,249 @@ events:
     name: !binary |-
       wqcgYmFzZW1lbnQgd2FycCBsZWZ0
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: door_exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &154
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &155
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &156
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &157
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &158
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *154
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *155
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *156
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *157
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *158
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This command turns on the self switch on the basement to settle the tone
-                and the followers.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",1,map_id = 17)
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 17
-              - 17
-              - 29
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: door_exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 31
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 35
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 39
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 2
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 2
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
+          - &152 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+            - 2
+          - &153 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &154 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &155 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &156 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *152
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *153
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *154
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *155
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *156
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This command turns on the self switch on the basement to settle the tone
+          and the followers.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",1,map_id = 17)
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 17
+        - 17
+        - 29
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 31
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 35
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 39
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 2
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 2
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 27
     y: 39
   9: !ruby/object:RPG::Event
@@ -10134,249 +10109,249 @@ events:
     name: !binary |-
       wqcgYmFzZW1lbnQgd2FycCBtaWRkbGU=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: door_exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &159
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &160
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &161
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &162
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &163
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *159
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *160
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *161
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *162
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *163
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This command turns on the self switch on the basement to settle the tone
-                and the followers.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",2,map_id = 17)
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 17
-              - 18
-              - 29
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: door_exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 31
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 35
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 39
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 2
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 2
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
+          - &157 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+            - 2
+          - &158 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &159 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &160 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &161 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *157
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *158
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *159
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *160
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *161
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This command turns on the self switch on the basement to settle the tone
+          and the followers.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",2,map_id = 17)
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 17
+        - 18
+        - 29
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 31
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 35
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 39
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 2
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 2
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 28
     y: 39
 height: 64

--- a/Data/Map005.rxdata.yml
+++ b/Data/Map005.rxdata.yml
@@ -1,5 +1,4 @@
----
-!ruby/object:RPG::Map
+--- !ruby/object:RPG::Map
 autoplay_bgm: true
 autoplay_bgs: false
 bgm: !ruby/object:RPG::AudioFile
@@ -7,7 +6,7 @@ bgm: !ruby/object:RPG::AudioFile
   pitch: 100
   volume: 100
 bgs: !ruby/object:RPG::AudioFile
-  name: ""
+  name: ''
   pitch: 100
   volume: 100
 data: !ruby/object:Table
@@ -216,560 +215,560 @@ events:
     name: !binary |-
       wqcgd2FycA==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Warp-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Warp-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 44
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Activating this self switch will play the descending
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - animation on the destination map.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",15,map_id = 3)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 3
+        - 28
+        - 43
+        - 6
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 222
+        indent: 0
+        parameters:
+        - ''
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 44
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Activating this self switch will play the descending
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - animation on the destination map.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",15,map_id = 3)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 3
-              - 28
-              - 43
-              - 6
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 222
-            indent: 0
-            parameters:
-              - ""
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
-            - !ruby/object:RPG::MoveCommand
-              code: 15
-              parameters:
-                - 960
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 3
-        step_anime: false
-        through: true
-        trigger: 2
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
+        - !ruby/object:RPG::MoveCommand
+          code: 15
+          parameters:
+          - 960
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 3
+      step_anime: false
+      through: true
+      trigger: 2
+      walk_anime: false
     x: 29
     y: 18
   10: !ruby/object:RPG::Event
     id: 10
     name: Scientist
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Scientist-F
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Scientist-F
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 0 I study the diversity of the wildlife in each floor.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 1 By the way, this patch of grass is particular as the Pokémon in it
+          always attack in groups of two!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 2 Apparently it's due to a \c[5]specific setup of the encounter group\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 0 I study the diversity of the wildlife in each floor.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 1 By the way, this patch of grass is particular as the Pokémon in it
-                always attack in groups of two!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 2 Apparently it's due to a \c[5]specific setup of the encounter group\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 33
     y: 40
   11: !ruby/object:RPG::Event
     id: 11
     name: Fisherman
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Fisherman
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Fisherman
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 3 I don't know if you already know, but it's possible to fish from a
+          bridge!
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 2
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 5, 18 I see you don't have any fishing rod! Here, take these!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - give_item(:old_rod)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - give_item(:good_rod)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - give_item(:super_rod)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 4 Moreover, as I'm considered on the bridge, you'll be able to pass under
+          me.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 5 And if you try to talk to me while surfing, I won't answer you!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 3 I don't know if you already know, but it's possible to fish from a
-                bridge!
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 2
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 5, 18 I see you don't have any fishing rod! Here, take these!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - give_item(:old_rod)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - give_item(:good_rod)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - give_item(:super_rod)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 4 Moreover, as I'm considered on the bridge, you'll be able to pass under
-                me.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 5 And if you try to talk to me while surfing, I won't answer you!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 29
     y: 39
   12: !ruby/object:RPG::Event
     id: 12
     name: Chansey
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0113"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 6 Chan-chansey!
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &1
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &2
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &3
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &4
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &5
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &6
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &7
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &8
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &9
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &10
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &11
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &12
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &13
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &14
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &15
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &16
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &17
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &18
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &19
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &20
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *1
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *2
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *3
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *4
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *5
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *6
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *7
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *8
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *9
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *10
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *11
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *12
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *13
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *14
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *15
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *16
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *17
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *18
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *19
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *20
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: rosa_healpokemon
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 7 Chansey heals your team.[WAIT 90]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM.game_state.heal_party
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:music, 0, 0, oy_offset: 10)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0113'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 6 Chan-chansey!
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &2 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &3 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &4 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &5 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &6 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &7 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &8 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &9 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &10 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &11 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &12 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &13 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &14 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &15 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &16 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &17 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &20 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *1
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *2
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *3
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *4
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *5
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *6
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *7
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *8
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *9
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *10
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *11
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *12
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *13
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *14
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *15
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *16
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *17
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *18
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *19
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *20
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: rosa_healpokemon
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 7 Chansey heals your team.[WAIT 90]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM.game_state.heal_party
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:music, 0, 0, oy_offset: 10)'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 16
   2: !ruby/object:RPG::Event
@@ -777,397 +776,397 @@ events:
     name: !binary |-
       wqcgZWxldmF0b3IgZG9vcg==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 242
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &21
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &22
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &23
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &24
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &25
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *21
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *22
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *23
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *24
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *25
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable tells the game from which floor the playe came inside the
-                elevator.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 4
-              - 12
-              - 16
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 242
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &26
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &27
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &28
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &29
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &30
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *26
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *27
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *28
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *29
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *30
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &21 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &22 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &23 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &24 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The animation will play in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &25 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *21
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *22
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *25
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable tells the game from which floor the playe came inside the
+          elevator.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 4
+        - 12
+        - 16
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &26 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &27 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &28 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &29 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *26
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *27
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *30
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The animation will play in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 33
     y: 15
   3: !ruby/object:RPG::Event
@@ -1175,221 +1174,197 @@ events:
     name: !binary |-
       wqcgQ29tcHV0ZXI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Computer-screen
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &31
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_on
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &32
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &33
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand &34
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &35
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &36
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &37
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *31
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *32
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *33
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *34
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *35
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *36
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *37
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_pc
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &38
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_off
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &39
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &40
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &41
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &42
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &43
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &44
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *38
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *39
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *40
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *41
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *42
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *43
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *44
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Computer-screen
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 3
+          - &32 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - &33 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &34 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &35 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &36 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *31
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *34
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *35
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *36
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_pc
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &37 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &38 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &39 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &40 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &41 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 0
+          - &42 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *37
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *38
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *39
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *40
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *41
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *42
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 30
     y: 16
   4: !ruby/object:RPG::Event
@@ -1397,594 +1372,594 @@ events:
     name: !binary |-
       wqdbb2Zmc2V0X3k9MzJdQ3V0IFRyZWU=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-cut-tree
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-cut-tree
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 21
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 21
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 32
     y: 44
   5: !ruby/object:RPG::Event
     id: 5
     name: EV005
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-Pokeball
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-Pokeball
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This event gives the HM Surf then gets deleted forever
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - thanks to the pick_item method
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:hm03)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This event gives the HM Surf then gets deleted forever
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - thanks to the pick_item method
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:hm03)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 33
     y: 46
   6: !ruby/object:RPG::Event
     id: 6
     name: EV006
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-Pokeball
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-Pokeball
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:intriguing_stone)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:intriguing_stone)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 19
     y: 22
   7: !ruby/object:RPG::Event
     id: 7
     name: "$The Legend Guy"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Collector
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Collector
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 8 A legend says that the one who succeed in ascending the waterfall will
+          be granted a stone of inestimable value.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 9 For that, Waterfall is needed.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 10 I think I saw a dropped HM Surf at the other side of the bridge, but
+          to reach it, you need the HM Cut... which I'll generously give you!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We give the HM Cut.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - give_item(:hm01)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 11 Can you believe if it's actually real?
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 8 A legend says that the one who succeed in ascending the waterfall will
-                be granted a stone of inestimable value.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 9 For that, Waterfall is needed.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 10 I think I saw a dropped HM Surf at the other side of the bridge, but
-                to reach it, you need the HM Cut... which I'll generously give you!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We give the HM Cut.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - give_item(:hm01)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 11 Can you believe if it's actually real?
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 12 Can you believe if it's actually real?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 12 Can you believe if it's actually real?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: C
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: C
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 13 So the legend was true...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 13 So the legend was true...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 24
   8: !ruby/object:RPG::Event
     id: 8
     name: "$surf_swimmer"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Swimmer-F-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Swimmer-F-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 14 I definitely prefer to swim in this water than in the floor just above...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 15 To add to that, there's the waterfall here!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 16 Talking about that, are you interested in the HM Waterfall?
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We give the HM Waterfall.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - give_item(:hm05)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 14 I definitely prefer to swim in this water than in the floor just above...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 15 To add to that, there's the waterfall here!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 16 Talking about that, are you interested in the HM Waterfall?
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We give the HM Waterfall.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - give_item(:hm05)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 5, 17 So? How is it to climb a waterfall?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 5, 17 So? How is it to climb a waterfall?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 23
     y: 39
   9: !ruby/object:RPG::Event
     id: 9
     name: EV009
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We constantly check if the player passes the four tiles
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - of the waterfall and is facing north (direction == 8).
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - detect_player(4, :right) && gp.direction == 8
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - We're switching a few self switches then delete the event
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - forever so that it works only one time.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, "A", 6)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - set_self_switch(true, "C", 7)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We constantly check if the player passes the four tiles
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - of the waterfall and is facing north (direction == 8).
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - detect_player(4, :right) && gp.direction == 8
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - We're switching a few self switches then delete the event
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - forever so that it works only one time.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, "A", 6)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - set_self_switch(true, "C", 7)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 20
     y: 30
 height: 64

--- a/Data/Map006.rxdata.yml
+++ b/Data/Map006.rxdata.yml
@@ -1,5 +1,4 @@
----
-!ruby/object:RPG::Map
+--- !ruby/object:RPG::Map
 autoplay_bgm: true
 autoplay_bgs: false
 bgm: !ruby/object:RPG::AudioFile
@@ -7,7 +6,7 @@ bgm: !ruby/object:RPG::AudioFile
   pitch: 100
   volume: 100
 bgs: !ruby/object:RPG::AudioFile
-  name: ""
+  name: ''
   pitch: 100
   volume: 100
 data: !ruby/object:Table
@@ -216,102 +215,102 @@ events:
     name: !binary |-
       wqcgd2FycA==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Warp-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Warp-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 44
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Activating this self switch will play the descending
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - animation on the destination map.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",15,map_id = 3)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 3
+        - 28
+        - 43
+        - 6
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 222
+        indent: 0
+        parameters:
+        - ''
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 44
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Activating this self switch will play the descending
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - animation on the destination map.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",15,map_id = 3)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 3
-              - 28
-              - 43
-              - 6
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 222
-            indent: 0
-            parameters:
-              - ""
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
-            - !ruby/object:RPG::MoveCommand
-              code: 15
-              parameters:
-                - 960
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 3
-        step_anime: false
-        through: true
-        trigger: 2
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
+        - !ruby/object:RPG::MoveCommand
+          code: 15
+          parameters:
+          - 960
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 3
+      step_anime: false
+      through: true
+      trigger: 2
+      walk_anime: false
     x: 29
     y: 18
   10: !ruby/object:RPG::Event
@@ -319,131 +318,131 @@ events:
     name: !binary |-
       wqdKdW1wMQ==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: FX_water-jump
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player is surfing and facing right
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gp.direction == 6
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &1
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &2
-                    code: 3
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *1
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *2
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &3
-                    code: 14
-                    parameters:
-                      - 2
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &4
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *3
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *4
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: FX_water-jump
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player is surfing and facing right
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gp.direction == 6
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &2 !ruby/object:RPG::MoveCommand
+            code: 3
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 1
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *1
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *2
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &3 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 2
+            - 0
+          - &4 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *3
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *4
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 20
     y: 44
   11: !ruby/object:RPG::Event
@@ -451,78 +450,78 @@ events:
     name: !binary |-
       W3JlZmxlY3Rpb249b25dwqdCZWF1dHk=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Beauty-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Beauty-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 0 My reflection in this puddle is absolutely gorgeous...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 2 Don't distort it by stepping on it!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 1 It appears thanks to the \c[5]"[reflection=on]" tag\c[0] present in
+          my name.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 30 But it's not all there is to it...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 31 The tiles must be transparent to see the reflection.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 32 As for the background color, you can just use a panorama with the
+          wanted color!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 0 My reflection in this puddle is absolutely gorgeous...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 2 Don't distort it by stepping on it!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 1 It appears thanks to the \c[5]"[reflection=on]" tag\c[0] present in
-                my name.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 30 But it's not all there is to it...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 31 The tiles must be transparent to see the reflection.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 32 As for the background color, you can just use a panorama with the
-                wanted color!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 43
     y: 19
   12: !ruby/object:RPG::Event
@@ -530,131 +529,131 @@ events:
     name: !binary |-
       wqdKdW1wMQ==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: FX_water-jump
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player is surfing and facing right
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gp.direction == 6
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &5
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &6
-                    code: 3
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *5
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *6
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &7
-                    code: 14
-                    parameters:
-                      - 2
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &8
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *7
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *8
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: FX_water-jump
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player is surfing and facing right
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gp.direction == 6
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &5 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &6 !ruby/object:RPG::MoveCommand
+            code: 3
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 1
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *5
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *6
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &7 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 2
+            - 0
+          - &8 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *7
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *8
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 20
     y: 45
   13: !ruby/object:RPG::Event
@@ -662,131 +661,131 @@ events:
     name: !binary |-
       wqdKdW1wMQ==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: FX_water-jump
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player is surfing and facing right
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gp.direction == 6
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &9
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &10
-                    code: 3
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *9
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *10
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &11
-                    code: 14
-                    parameters:
-                      - 2
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &12
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *11
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *12
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: FX_water-jump
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player is surfing and facing right
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gp.direction == 6
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &9 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &10 !ruby/object:RPG::MoveCommand
+            code: 3
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 1
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *9
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *10
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &11 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 2
+            - 0
+          - &12 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *11
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *12
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 26
     y: 45
   14: !ruby/object:RPG::Event
@@ -794,131 +793,131 @@ events:
     name: !binary |-
       wqdKdW1wMQ==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: FX_water-jump
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player is surfing and facing right
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gp.direction == 6
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &13
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &14
-                    code: 3
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *13
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *14
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &15
-                    code: 14
-                    parameters:
-                      - 2
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &16
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *15
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *16
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: FX_water-jump
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player is surfing and facing right
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gp.direction == 6
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &13 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &14 !ruby/object:RPG::MoveCommand
+            code: 3
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 1
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *13
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *14
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &15 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 2
+            - 0
+          - &16 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *15
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *16
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 26
     y: 44
   15: !ruby/object:RPG::Event
@@ -926,506 +925,506 @@ events:
     name: !binary |-
       wqdKdW1wMQ==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: FX_water-jump
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player is surfing and facing right
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gp.direction == 6
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &17
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &18
-                    code: 3
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *17
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *18
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &19
-                    code: 14
-                    parameters:
-                      - 2
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &20
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *19
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *20
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: FX_water-jump
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player is surfing and facing right
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gp.direction == 6
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &17 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 3
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 1
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *17
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *18
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 2
+            - 0
+          - &20 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *19
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *20
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 32
     y: 45
   16: !ruby/object:RPG::Event
     id: 16
     name: "[offset_y=-24][reflection=on][particle=off] Wingull"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0278"
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0278'
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:wingull)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 3 :[name=Wingull]:Wiiii! Wiiii! Wiiiin![WAIT 60]
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:wingull)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 3 :[name=Wingull]:Wiiii! Wiiii! Wiiiin![WAIT 60]
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 1
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 1
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 4
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 4
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 1
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 1
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 4
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 4
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 20
     y: 20
   17: !ruby/object:RPG::Event
     id: 17
     name: Chansey
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0113"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 4 Chan-chansey!
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &21
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &22
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &23
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &24
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &25
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &26
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &27
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &28
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &29
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &30
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &31
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &32
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &33
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &34
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &35
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &36
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &37
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &38
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &39
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &40
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *21
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *22
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *23
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *24
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *25
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *26
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *27
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *28
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *29
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *30
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *31
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *32
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *33
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *34
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *35
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *36
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *37
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *38
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *39
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *40
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: rosa_healpokemon
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 5 Chansey heals your team.[WAIT 90]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM.game_state.heal_party
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:music, 0, 0, oy_offset: 10)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0113'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 4 Chan-chansey!
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &21 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &22 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &23 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &24 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &25 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &26 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &27 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &28 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &29 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &32 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &33 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &34 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &35 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &36 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &37 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &38 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &39 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &40 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *21
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *22
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *25
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *26
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *27
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *30
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *31
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *34
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *35
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *36
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *37
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *38
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *39
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *40
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: rosa_healpokemon
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 5 Chansey heals your team.[WAIT 90]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM.game_state.heal_party
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:music, 0, 0, oy_offset: 10)'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 16
   2: !ruby/object:RPG::Event
@@ -1433,404 +1432,404 @@ events:
     name: !binary |-
       wqcgZWxldmF0b3IgZG9vcg==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 242
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &41
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &42
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &43
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &44
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &45
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *41
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *42
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *43
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *44
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *45
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable tells the game from which floor the playe came inside the
-                elevator.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 4
-              - 12
-              - 16
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 242
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &46
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &47
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &48
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &49
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &50
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *46
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *47
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *48
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *49
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *50
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &41 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &42 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &43 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &44 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The animation will play in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 54
-              - 54
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &45 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *41
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *42
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *43
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *44
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *45
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable tells the game from which floor the playe came inside the
+          elevator.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 4
+        - 12
+        - 16
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &46 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &47 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &48 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &49 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &50 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *46
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *47
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *48
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *49
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *50
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The animation will play in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 54
+        - 54
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 33
     y: 15
   3: !ruby/object:RPG::Event
@@ -1838,954 +1837,930 @@ events:
     name: !binary |-
       wqcgQ29tcHV0ZXI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Computer-screen
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &51
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_on
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &52
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &53
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand &54
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &55
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &56
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &57
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *51
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *52
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *53
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *54
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *55
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *56
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *57
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_pc
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &58
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_off
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &59
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &60
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &61
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &62
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &63
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &64
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *58
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *59
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *60
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *61
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *62
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *63
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *64
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Computer-screen
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &51 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 3
+          - &52 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - &53 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &54 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &55 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &56 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *51
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *52
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *53
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *54
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *55
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *56
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_pc
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &57 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &58 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &59 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &60 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &61 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 0
+          - &62 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *57
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *58
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *59
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *60
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *61
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *62
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 30
     y: 16
   4: !ruby/object:RPG::Event
     id: 4
     name: Intriguing Stone
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-Pokeball
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-Pokeball
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We give the Intriguing Stone, then this event gets deleted
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - thanks to the pick_item method
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:intriguing_stone)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We give the Intriguing Stone, then this event gets deleted
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - thanks to the pick_item method
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:intriguing_stone)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 41
     y: 44
   5: !ruby/object:RPG::Event
     id: 5
     name: EV005
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Tuber-M
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "This event's movement are set using "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - move_random_within_systemtag. This means this event
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - won't leave the puddle Systemtags.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 33 I like to play in puddles!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 34 When you walk in a \c[5]Puddle\c[0] Systemtag, a little ripple appears!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 35 Maybe you saw that, but the ripple doesn't leave the water. It's because
-                the animation is made to be displayed under this puddle!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "6, 36 So the puddle must be transparent! The nice lady who admires herself
-                will explain this to you! "
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &65
-                    code: 45
-                    parameters:
-                      - move_random_within_systemtag(::GameData::SystemTags::Puddle)
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *65
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 37 Plop... Plop. Hehe!
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Tuber-M
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'This event''s movement are set using '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - move_random_within_systemtag. This means this event
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - won't leave the puddle Systemtags.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 33 I like to play in puddles!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 34 When you walk in a \c[5]Puddle\c[0] Systemtag, a little ripple appears!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 35 Maybe you saw that, but the ripple doesn't leave the water. It's because
+          the animation is made to be displayed under this puddle!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '6, 36 So the puddle must be transparent! The nice lady who admires herself
+          will explain this to you! '
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - move_random_within_systemtag(::GameData::SystemTags::Puddle)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &63 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - move_random_within_systemtag(::GameData::SystemTags::Puddle)
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *63
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 37 Plop... Plop. Hehe!
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - move_random_within_systemtag(::GameData::SystemTags::Puddle)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 23
     y: 23
   6: !ruby/object:RPG::Event
     id: 6
     name: Fisherman
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Fisherman
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Fisherman
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 6 The sea is quite choppy here.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 7 The Tower's engineers equiped this room with a mechanism that generates
+          powerful rapids.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 8 It's quite impressive, they even succeeded in creating a whirlpool!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player already has received HM Surf
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - "$bag.has_item?(:hm03)"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 6, 9 I see you have the HM Surf...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 6, 10 You can sail freely!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 6, 11 Oh!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - It seems like you don't have the HM Surf!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 6, 12 Let me fix that...
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - give_item(:hm03)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 6, 13 You can now sail freely!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 6 The sea is quite choppy here.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 7 The Tower's engineers equiped this room with a mechanism that generates
-                powerful rapids.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 8 It's quite impressive, they even succeeded in creating a whirlpool!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player already has received HM Surf
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - "$bag.has_item?(:hm03)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 6, 9 I see you have the HM Surf...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 6, 10 You can sail freely!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 6, 11 Oh!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - It seems like you don't have the HM Surf!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 6, 12 Let me fix that...
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - give_item(:hm03)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 6, 13 You can now sail freely!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 26
     y: 26
   7: !ruby/object:RPG::Event
     id: 7
     name: EV007
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Tuber-F
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Tuber-F
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 14 I love to walk on the sand!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 15 It leaves footprints everywhere!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 16 But this sand is infested with wild Pokémon hiding in it...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 14 I love to walk on the sand!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 15 It leaves footprints everywhere!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 16 But this sand is infested with wild Pokémon hiding in it...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 34
     y: 23
   8: !ruby/object:RPG::Event
     id: 8
     name: NPC_whirlpool
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Parasol-Lady
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Parasol-Lady
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 17 I really enjoy this small isolated islet.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 18 Rare are those who visit me, so I always make sure to reward them!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 19 Do you want me to teach the move Whirlpool to one of your Pokémon?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 6, 20 To which Pokémon should I teach it?
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - !binary |-
+          Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - !binary |-
+          VGhlIGNob3NlbiBQb2vDqW1vbiBpcyBzdG9yZWQgaW4gdmFyaWFibGUgNDMu
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - call_party_menu
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 1
+        - 43
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - Creating a dynamic text that will display the name
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - !binary |-
+          b2YgdGhlIGNob3NlbiBQb2vDqW1vbiAodmFyaWFibGUgNDMpIHRvIHdyaXRlIGl0IGluc2lkZQ==
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - a message instead of "[POKE]".
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - PFM::Text.set_variable("[POKE]", $actors[gv[43]].name)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - 'Then, we check if:'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - !binary |-
+          LSB0aGUgUG9rw6ltb24gY2FuIGxlYXJuIGl0LA==
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - "- else, if the player exited the party menu"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 2
+        parameters:
+        - 12
+        - gv[43] >= 0 && $actors[gv[43]].can_learn?(:whirlpool)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 3
+        parameters:
+        - !binary |-
+          SWYgdGhlIGNob3NlbiBQb2vDqW1vbiBjYW4gbGVhcm4gdGhlIG1vdmUsIHdl
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 3
+        parameters:
+        - check if it already has learnt it.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 3
+        parameters:
+        - 12
+        - "$actors[gv[43]].skills_set.any? { |skill| skill.db_symbol == :whirlpool
+          }"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 4
+        parameters:
+        - 6, 21 It seems like your [POKE] already knows Whirlpool...
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 4
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 4
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 4
+        parameters:
+        - 6, 22 Alright, let's teach Whirlpool to your [POKE].
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 4
+        parameters:
+        - Learning the move
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 4
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 4
+        parameters:
+        - skill_learn(gv[43], :whirlpool)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 4
+        parameters:
+        - 6, 23 Your [POKE] will now be able to across the marine swirls!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 4
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 4
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 3
+        parameters:
+        - If the player exited the menu or if the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 3
+        parameters:
+        - !binary |-
+          Y2hvc2VuIFBva8OpbW9uIGNhbid0IGxlYXJuIHRoZSBtb3ZlLg==
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 6, 24 I'm afraid your [POKE] isn't able to learn this move...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 6, 25 You can find certain Pokémon species that can learn Whirlpool in the
+          sea around us, or in the river in the floor below.
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 3
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 6, 26 Don't you want to explore the high sea?
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - Event end
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 6, 27 Don't you want to explore the high sea?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'Warning: you must ALWAYS reset the variables at the'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'end of the event with: PFM::Text.reset_variables'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM::Text.reset_variables
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 17 I really enjoy this small isolated islet.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 18 Rare are those who visit me, so I always make sure to reward them!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 19 Do you want me to teach the move Whirlpool to one of your Pokémon?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 6, 20 To which Pokémon should I teach it?
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - !binary |-
-                Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - !binary |-
-                VGhlIGNob3NlbiBQb2vDqW1vbiBpcyBzdG9yZWQgaW4gdmFyaWFibGUgNDMu
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - call_party_menu
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 1
-              - 43
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - Creating a dynamic text that will display the name
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - !binary |-
-                b2YgdGhlIGNob3NlbiBQb2vDqW1vbiAodmFyaWFibGUgNDMpIHRvIHdyaXRlIGl0IGluc2lkZQ==
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - a message instead of "[POKE]".
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - PFM::Text.set_variable("[POKE]", $actors[gv[43]].name)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - "Then, we check if:"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - !binary |-
-                LSB0aGUgUG9rw6ltb24gY2FuIGxlYXJuIGl0LA==
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - "- else, if the player exited the party menu"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 2
-            parameters:
-              - 12
-              - gv[43] >= 0 && $actors[gv[43]].can_learn?(:whirlpool)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 3
-            parameters:
-              - !binary |-
-                SWYgdGhlIGNob3NlbiBQb2vDqW1vbiBjYW4gbGVhcm4gdGhlIG1vdmUsIHdl
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 3
-            parameters:
-              - check if it already has learnt it.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 3
-            parameters:
-              - 12
-              - "$actors[gv[43]].skills_set.any? { |skill| skill.db_symbol == :whirlpool
-                }"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 4
-            parameters:
-              - 6, 21 It seems like your [POKE] already knows Whirlpool...
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 4
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 4
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 4
-            parameters:
-              - 6, 22 Alright, let's teach Whirlpool to your [POKE].
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 4
-            parameters:
-              - Learning the move
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 4
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 4
-            parameters:
-              - skill_learn(gv[43], :whirlpool)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 4
-            parameters:
-              - 6, 23 Your [POKE] will now be able to across the marine swirls!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 4
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 4
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 3
-            parameters:
-              - If the player exited the menu or if the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 3
-            parameters:
-              - !binary |-
-                Y2hvc2VuIFBva8OpbW9uIGNhbid0IGxlYXJuIHRoZSBtb3ZlLg==
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 6, 24 I'm afraid your [POKE] isn't able to learn this move...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 6, 25 You can find certain Pokémon species that can learn Whirlpool in the
-                sea around us, or in the river in the floor below.
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 3
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 6, 26 Don't you want to explore the high sea?
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - Event end
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 6, 27 Don't you want to explore the high sea?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "Warning: you must ALWAYS reset the variables at the"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "end of the event with: PFM::Text.reset_variables"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM::Text.reset_variables
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 38
     y: 33
   9: !ruby/object:RPG::Event
@@ -2793,75 +2768,75 @@ events:
     name: !binary |-
       wqdzdXJmX1N3aW1tZXI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Swimmer-M-01
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Swimmer-M-01
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 28 I'm warming up before challenging the rapids!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 6, 29 As I have the \c[5]"surf_" tag\c[0] in my name, I can't leave the
+          water and I correctly interact with it.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 28 I'm warming up before challenging the rapids!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 6, 29 As I have the \c[5]"surf_" tag\c[0] in my name, I can't leave the
-                water and I correctly interact with it.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 27
     y: 28
 height: 64

--- a/Data/Map007.rxdata.yml
+++ b/Data/Map007.rxdata.yml
@@ -1,5 +1,4 @@
----
-!ruby/object:RPG::Map
+--- !ruby/object:RPG::Map
 autoplay_bgm: true
 autoplay_bgs: false
 bgm: !ruby/object:RPG::AudioFile
@@ -7,7 +6,7 @@ bgm: !ruby/object:RPG::AudioFile
   pitch: 100
   volume: 100
 bgs: !ruby/object:RPG::AudioFile
-  name: ""
+  name: ''
   pitch: 100
   volume: 100
 data: !ruby/object:Table
@@ -264,1424 +263,1424 @@ events:
     name: !binary |-
       wqcgd2FycA==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Warp-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Warp-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 44
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Activating this self switch will play the descending
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - animation on the destination map.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",15,map_id = 3)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 3
+        - 28
+        - 43
+        - 6
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 222
+        indent: 0
+        parameters:
+        - ''
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 44
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Activating this self switch will play the descending
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - animation on the destination map.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",15,map_id = 3)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 3
-              - 28
-              - 43
-              - 6
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 222
-            indent: 0
-            parameters:
-              - ""
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
-            - !ruby/object:RPG::MoveCommand
-              code: 15
-              parameters:
-                - 960
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 3
-        step_anime: false
-        through: true
-        trigger: 2
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
+        - !ruby/object:RPG::MoveCommand
+          code: 15
+          parameters:
+          - 960
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 3
+      step_anime: false
+      through: true
+      trigger: 2
+      walk_anime: false
     x: 29
     y: 18
   10: !ruby/object:RPG::Event
     id: 10
     name: "$Aerun the Bear-ded man"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Hiker-03
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Hiker-03
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'find_path(to: [31, 26])'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 0 :[name=???]:Another great day of work done!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '7, 1 :[name=???]:The floor on the east part of the room is still very fragile,
+          but that''ll wait: priority to the flooding in the basement...'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - wait_event
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:exclamation, 0, 50, oy_offset: 8)'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'find_path(to: [gp.x, gp.y + 1])'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - wait_event
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 2 :[name=???]:Sorry, I was thinking out loud, I didn't even see you...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 3 :[name=Aerun]:My name's Aerun, but some call me the Ursaring, because
+          of my pretty beard.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 4 :[name=Aerun]:SirMalo told you about me I presume.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 5 :[name=Aerun]:I hid it just a moment ago.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 6 :[name=Aerun]:And to unveil its position, you'll have to pass the test
+          of this floor!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 7 :[name=Aerun]:In this floor, you'll find 5 boulders and 5 switches.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 8 :[name=Aerun]:Your mission is to push these boulders on their respective
+          switches.
+      - !ruby/object:RPG::EventCommand
+        code: 203
+        indent: 0
+        parameters:
+        - 4
+        - 8
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 9 :[name=Aerun]:You'll find 3 of these here, to push into the holes and
+          then bring to the switches...[WAIT 60]
+      - !ruby/object:RPG::EventCommand
+        code: 203
+        indent: 0
+        parameters:
+        - 2
+        - 8
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 10 :[name=Aerun]:One here, but you'll need Rock Climb to reach it...[WAIT
+          30]
+      - !ruby/object:RPG::EventCommand
+        code: 203
+        indent: 0
+        parameters:
+        - 6
+        - 16
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 203
+        indent: 0
+        parameters:
+        - 8
+        - 8
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 11 :[name=Aerun]:And finally, one to the right, but you need to cross
+          the cracked floor.[WAIT 90]
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 12 :[name=Aerun]:I'd advise you to get a Mach Bike for that.[WAIT 90]
+      - !ruby/object:RPG::EventCommand
+        code: 203
+        indent: 0
+        parameters:
+        - 4
+        - 8
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 13 :[name=Aerun]:I'll give you the HM Strength.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - give_item(:hm04)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 14 :[name=Aerun]:As for Rock Climb, just ask the monk downstairs.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 15 :[name=Aerun]:And if you were to stuck one of the boulders, come see
+          me, I will reset the position of the boulders that didn't make it to their
+          switches!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'find_path(to: [35, 33])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - wait_event
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true, "A", 11)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "find_path(to: [31, 26])"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 0 :[name=???]:Another great day of work done!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "7, 1 :[name=???]:The floor on the east part of the room is still very fragile,
-                but that'll wait: priority to the flooding in the basement..."
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - wait_event
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:exclamation, 0, 50, oy_offset: 8)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "find_path(to: [gp.x, gp.y + 1])"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - wait_event
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &1
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 2 :[name=???]:Sorry, I was thinking out loud, I didn't even see you...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 3 :[name=Aerun]:My name's Aerun, but some call me the Ursaring, because
-                of my pretty beard.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 4 :[name=Aerun]:SirMalo told you about me I presume.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 5 :[name=Aerun]:I hid it just a moment ago.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 6 :[name=Aerun]:And to unveil its position, you'll have to pass the test
-                of this floor!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 7 :[name=Aerun]:In this floor, you'll find 5 boulders and 5 switches.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 8 :[name=Aerun]:Your mission is to push these boulders on their respective
-                switches.
-          - !ruby/object:RPG::EventCommand
-            code: 203
-            indent: 0
-            parameters:
-              - 4
-              - 8
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 9 :[name=Aerun]:You'll find 3 of these here, to push into the holes and
-                then bring to the switches...[WAIT 60]
-          - !ruby/object:RPG::EventCommand
-            code: 203
-            indent: 0
-            parameters:
-              - 2
-              - 8
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 10 :[name=Aerun]:One here, but you'll need Rock Climb to reach it...[WAIT
-                30]
-          - !ruby/object:RPG::EventCommand
-            code: 203
-            indent: 0
-            parameters:
-              - 6
-              - 16
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 203
-            indent: 0
-            parameters:
-              - 8
-              - 8
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 11 :[name=Aerun]:And finally, one to the right, but you need to cross
-                the cracked floor.[WAIT 90]
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 12 :[name=Aerun]:I'd advise you to get a Mach Bike for that.[WAIT 90]
-          - !ruby/object:RPG::EventCommand
-            code: 203
-            indent: 0
-            parameters:
-              - 4
-              - 8
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 13 :[name=Aerun]:I'll give you the HM Strength.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - give_item(:hm04)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 14 :[name=Aerun]:As for Rock Climb, just ask the monk downstairs.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 15 :[name=Aerun]:And if you were to stuck one of the boulders, come see
-                me, I will reset the position of the boulders that didn't make it to their
-                switches!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "find_path(to: [35, 33])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - wait_event
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true, "A", 11)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 31
     y: 33
   11: !ruby/object:RPG::Event
     id: 11
     name: "$Aerun the Bear-ded man"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Hiker-03
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Hiker-03
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 16 :[name=Aerun]:Do you need me to reset the position of the unplaced
+          boulders?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - 7, 17 Yes
+          - 7, 18 No
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - 7, 17 Yes
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 7, 19 :[name=Aerun]:Alrighty, lessgo!
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: HM_Strength
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: HM_Strength
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: HM_Strength
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - We teleport each boulder to its initial position. If the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - boulder is already at its designated place, it's deleted
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - forever and won't be affected
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 4
+        - 0
+        - 19
+        - 21
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 6
+        - 0
+        - 25
+        - 21
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 12
+        - 0
+        - 21
+        - 28
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 5
+        - 0
+        - 24
+        - 29
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 13
+        - 0
+        - 23
+        - 33
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 7
+        - 0
+        - 38
+        - 20
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - 7, 18 No
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 7, 20 :[name=Aerun]:No problem, come back if you're stuck!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 7, 21 :[name=Aerun]:Else, you can exit this floor and come back, it'll do
+          the same thing.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - '7, 22 :[name=Aerun]:Just a quick reminder: a boulder placed is a boulder
+          that won''t reset!'
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 16 :[name=Aerun]:Do you need me to reset the position of the unplaced
-                boulders?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - 7, 17 Yes
-                - 7, 18 No
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - 7, 17 Yes
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 7, 19 :[name=Aerun]:Alrighty, lessgo!
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: HM_Strength
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: HM_Strength
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: HM_Strength
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - We teleport each boulder to its initial position. If the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - boulder is already at its designated place, it's deleted
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - forever and won't be affected
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 4
-              - 0
-              - 19
-              - 21
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 6
-              - 0
-              - 25
-              - 21
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 12
-              - 0
-              - 21
-              - 28
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 5
-              - 0
-              - 24
-              - 29
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 13
-              - 0
-              - 23
-              - 33
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 7
-              - 0
-              - 38
-              - 20
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - 7, 18 No
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 7, 20 :[name=Aerun]:No problem, come back if you're stuck!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 7, 21 :[name=Aerun]:Else, you can exit this floor and come back, it'll do
-                the same thing.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - "7, 22 :[name=Aerun]:Just a quick reminder: a boulder placed is a boulder
-                that won't reset!"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 35
     y: 33
   12: !ruby/object:RPG::Event
     id: 12
     name: "$Rock4"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - ge.x == 24 && ge.y == 64
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, "A", 18)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - get_local_variable(21, :boulders, :add, 1)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - delete_event_forever(15)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - ge.x == 24 && ge.y == 64
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, "A", 18)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - get_local_variable(21, :boulders, :add, 1)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - delete_event_forever(15)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 21
     y: 28
   13: !ruby/object:RPG::Event
     id: 13
     name: "$Rock6"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - ge.x == 22 && ge.y == 33
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, "A", 19)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - get_local_variable(21, :boulders, :add, 1)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - ge.x == 22 && ge.y == 33
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, "A", 19)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - get_local_variable(21, :boulders, :add, 1)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 23
     y: 33
   14: !ruby/object:RPG::Event
     id: 14
     name: Rock fall manager 2
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - "$game_map.events[6].x == 24 && $game_map.events[6].y == 23"
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &2
-                    code: 15
-                    parameters:
-                      - 55
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *2
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 25
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 6
-              - 0
-              - 25
-              - 58
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: fall
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - "TODO: Bruit impact au sol"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - "$game_map.events[6].x == 24 && $game_map.events[6].y == 23"
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &2 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 55
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *2
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 25
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 6
+        - 0
+        - 25
+        - 58
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: fall
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - 'TODO: Bruit impact au sol'
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 23
     y: 26
   15: !ruby/object:RPG::Event
     id: 15
     name: Rock fall manager 3
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - "$game_map.events[12].x == 24 && $game_map.events[12].y == 27"
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &3
-                    code: 15
-                    parameters:
-                      - 55
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *3
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 25
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 12
-              - 0
-              - 25
-              - 62
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: fall
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - "TODO: Bruit impact au sol"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - "$game_map.events[12].x == 24 && $game_map.events[12].y == 27"
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &3 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 55
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *3
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 25
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 12
+        - 0
+        - 25
+        - 62
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: fall
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - 'TODO: Bruit impact au sol'
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 22
     y: 27
   16: !ruby/object:RPG::Event
     id: 16
     name: Placed Rock 1
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 19
     y: 64
   17: !ruby/object:RPG::Event
     id: 17
     name: Placed Rock 2
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 21
     y: 55
   18: !ruby/object:RPG::Event
     id: 18
     name: Placed Rock 3
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 24
     y: 64
   19: !ruby/object:RPG::Event
     id: 19
     name: Placed Rock 4
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 22
     y: 33
   2: !ruby/object:RPG::Event
@@ -1689,824 +1688,824 @@ events:
     name: !binary |-
       wqcgZWxldmF0b3IgZG9vcg==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 242
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &4
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &5
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &6
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &7
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &8
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *4
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *5
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *6
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *7
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *8
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable tells the game from which floor the playe came inside the
-                elevator.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 4
-              - 12
-              - 16
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 242
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &9
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &10
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &11
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &12
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &13
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *9
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *10
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *11
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *12
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *13
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &4 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &5 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &6 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &7 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The animation will play in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &8 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *4
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *5
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *6
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *7
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *8
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable tells the game from which floor the playe came inside the
+          elevator.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 4
+        - 12
+        - 16
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &9 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &10 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &11 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &12 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &13 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *9
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *10
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *11
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *12
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *13
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The animation will play in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 33
     y: 15
   20: !ruby/object:RPG::Event
     id: 20
     name: Placed Rock 5
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 37
     y: 20
   21: !ruby/object:RPG::Event
     id: 21
     name: Cinematic Item appearing
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - get_local_variable(:boulders) == 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, "A", 22)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - get_local_variable(:boulders) == 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, "A", 22)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 26
+        - 26
+        - 0
+        - 7
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 27
+        - 27
+        - 0
+        - 6
+        - -1
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 28
+        - 28
+        - 0
+        - 6
+        - -1
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &14 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *14
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 7
+        - 39
+        - 54
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: menu_get
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &15 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *15
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 27
+        - 28
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 26
-              - 26
-              - 0
-              - 7
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 27
-              - 27
-              - 0
-              - 6
-              - -1
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 28
-              - 28
-              - 0
-              - 6
-              - -1
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &14
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *14
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 7
-              - 39
-              - 54
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: menu_get
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &15
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *15
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 27
-              - 28
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 39
     y: 53
   22: !ruby/object:RPG::Event
     id: 22
     name: Intriguous Stone
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-Pokeball
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-Pokeball
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:intriguing_stone)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:intriguing_stone)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 39
     y: 54
   23: !ruby/object:RPG::Event
@@ -2514,100 +2513,100 @@ events:
     name: !binary |-
       wqdbbm9zbGlkZT1vbl0gTXVkIDEgYm90dG9t
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Mud-slope
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &16
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: step_Mud-slope
-                        pitch: 100
-                        volume: 100
-                  - !ruby/object:RPG::MoveCommand &17
-                    code: 45
-                    parameters:
-                      - animate_from_charset([2,3],30)
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *16
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *17
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 24
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &18
-                    code: 45
-                    parameters:
-                      - animate_from_charset([0,1],30)
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *18
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Mud-slope
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &16 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: step_Mud-slope
+              pitch: 100
+              volume: 100
+          - &17 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([2,3],30)
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 2
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *16
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *17
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 24
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([0,1],30)
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *18
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 2
+      walk_anime: true
     x: 38
     y: 59
   24: !ruby/object:RPG::Event
@@ -2615,100 +2614,100 @@ events:
     name: !binary |-
       wqdbbm9zbGlkZT1vbl0gTXVkIDEgdG9w
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Mud-slope
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &19
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: step_Mud-slope
-                        pitch: 100
-                        volume: 100
-                  - !ruby/object:RPG::MoveCommand &20
-                    code: 45
-                    parameters:
-                      - animate_from_charset([0,1],30)
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *19
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *20
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 23
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &21
-                    code: 45
-                    parameters:
-                      - animate_from_charset([2,3],30)
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *21
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Mud-slope
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: step_Mud-slope
+              pitch: 100
+              volume: 100
+          - &20 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([0,1],30)
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 2
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *19
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *20
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 23
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &21 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([2,3],30)
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *21
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 2
+      walk_anime: true
     x: 38
     y: 58
   25: !ruby/object:RPG::Event
@@ -2716,100 +2715,100 @@ events:
     name: !binary |-
       wqdbbm9zbGlkZT1vbl0gTXVkIDIgYm90dG9t
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Mud-slope
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &22
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: step_Mud-slope
-                        pitch: 100
-                        volume: 100
-                  - !ruby/object:RPG::MoveCommand &23
-                    code: 45
-                    parameters:
-                      - animate_from_charset([0,1],30)
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *22
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *23
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 26
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &24
-                    code: 45
-                    parameters:
-                      - animate_from_charset([0,1],30)
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *24
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Mud-slope
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &22 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: step_Mud-slope
+              pitch: 100
+              volume: 100
+          - &23 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([0,1],30)
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 2
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *22
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 26
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &24 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([0,1],30)
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 2
+      walk_anime: true
     x: 38
     y: 57
   26: !ruby/object:RPG::Event
@@ -2817,100 +2816,100 @@ events:
     name: !binary |-
       wqdbbm9zbGlkZT1vbl0gTXVkIDIgdG9w
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Mud-slope
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &25
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: step_Mud-slope
-                        pitch: 100
-                        volume: 100
-                  - !ruby/object:RPG::MoveCommand &26
-                    code: 45
-                    parameters:
-                      - animate_from_charset([0,1],30)
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *25
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *26
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 25
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &27
-                    code: 45
-                    parameters:
-                      - animate_from_charset([0,1],30)
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *27
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Mud-slope
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &25 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: step_Mud-slope
+              pitch: 100
+              volume: 100
+          - &26 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([0,1],30)
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 2
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *25
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *26
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 25
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &27 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([0,1],30)
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *27
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 2
+      walk_anime: true
     x: 38
     y: 56
   27: !ruby/object:RPG::Event
@@ -2918,827 +2917,827 @@ events:
     name: !binary |-
       wqcgTGFkZGVy
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - "$game_player.direction == 2 || 8"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 231
-            indent: 1
-            parameters:
-              - 50
-              - black_gradient
-              - 0
-              - 0
-              - 0
-              - -304
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 1
-            parameters:
-              - 50
-              - 10
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Door exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &28
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *28
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 1
-            parameters:
-              - 0
-              - 7
-              - 33
-              - 35
-              - 8
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, "A", 29)
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 0
-              - 1
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &29
-                    code: 41
-                    parameters:
-                      - player_f_ladder
-                      - 0
-                      - 8
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &30
-                    code: 29
-                    parameters:
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &31
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &32
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &33
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &34
-                    code: 41
-                    parameters:
-                      - player_f_walk
-                      - 0
-                      - 8
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &35
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &36
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *29
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *30
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *31
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *32
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *33
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *34
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *35
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *36
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 2
-            parameters:
-              - 50
-              - 10
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &37
-                    code: 41
-                    parameters:
-                      - player_m_ladder
-                      - 0
-                      - 8
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &38
-                    code: 29
-                    parameters:
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &39
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &40
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &41
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &42
-                    code: 41
-                    parameters:
-                      - player_m_walk
-                      - 0
-                      - 8
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &43
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &44
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *37
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *38
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *39
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *40
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *41
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *42
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *43
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *44
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 2
-            parameters:
-              - 50
-              - 10
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(false, "A", 29)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - "$game_player.direction == 2 || 8"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 231
+        indent: 1
+        parameters:
+        - 50
+        - black_gradient
+        - 0
+        - 0
+        - 0
+        - -304
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 1
+        parameters:
+        - 50
+        - 10
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Door exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &28 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 1
+        parameters:
+        - 0
+        - 7
+        - 33
+        - 35
+        - 8
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, "A", 29)
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 0
+        - 1
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &29 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - player_f_ladder
+            - 0
+            - 8
+            - 0
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 1
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &32 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &33 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &34 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - player_f_walk
+            - 0
+            - 8
+            - 0
+          - &35 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &36 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *30
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *31
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *34
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *35
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *36
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 2
+        parameters:
+        - 50
+        - 10
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &37 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - player_m_ladder
+            - 0
+            - 8
+            - 0
+          - &38 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 1
+          - &39 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &40 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &41 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &42 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - player_m_walk
+            - 0
+            - 8
+            - 0
+          - &43 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &44 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *37
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *38
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *39
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *40
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *41
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *42
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *43
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *44
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 2
+        parameters:
+        - 50
+        - 10
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(false, "A", 29)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: false
     x: 33
     y: 65
   28: !ruby/object:RPG::Event
     id: 28
     name: Ladder up
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true, "A", 29)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 1
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &45
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &46
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand &47
-                    code: 41
-                    parameters:
-                      - player_f_ladder
-                      - 0
-                      - 8
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &48
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &49
-                    code: 29
-                    parameters:
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &50
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &51
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &52
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &53
-                    code: 41
-                    parameters:
-                      - player_f_walk
-                      - 0
-                      - 2
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &54
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *45
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *46
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *47
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *48
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *49
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *50
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *51
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *52
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *53
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *54
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 231
-            indent: 1
-            parameters:
-              - 50
-              - black_gradient
-              - 0
-              - 0
-              - 0
-              - -304
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 1
-            parameters:
-              - 50
-              - 10
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &55
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &56
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand &57
-                    code: 41
-                    parameters:
-                      - player_m_ladder
-                      - 0
-                      - 8
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &58
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &59
-                    code: 29
-                    parameters:
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &60
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &61
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &62
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &63
-                    code: 41
-                    parameters:
-                      - player_m_walk
-                      - 0
-                      - 2
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &64
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *55
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *56
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *57
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *58
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *59
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *60
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *61
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *62
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *63
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *64
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 231
-            indent: 1
-            parameters:
-              - 50
-              - black_gradient
-              - 0
-              - 0
-              - 0
-              - -304
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 1
-            parameters:
-              - 50
-              - 10
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Door exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 7
-              - 33
-              - 66
-              - 2
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 0
-            parameters:
-              - 50
-              - 10
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(false, "A", 29)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true, "A", 29)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 1
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &45 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - &46 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - &47 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - player_f_ladder
+            - 0
+            - 8
+            - 0
+          - &48 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - &49 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 1
+          - &50 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &51 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &52 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - &53 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - player_f_walk
+            - 0
+            - 2
+            - 0
+          - &54 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *45
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *46
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *47
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *48
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *49
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *50
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *51
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *52
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *53
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *54
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 231
+        indent: 1
+        parameters:
+        - 50
+        - black_gradient
+        - 0
+        - 0
+        - 0
+        - -304
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 1
+        parameters:
+        - 50
+        - 10
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &55 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - &56 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - &57 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - player_m_ladder
+            - 0
+            - 8
+            - 0
+          - &58 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - &59 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 1
+          - &60 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &61 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &62 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - &63 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - player_m_walk
+            - 0
+            - 2
+            - 0
+          - &64 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *55
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *56
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *57
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *58
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *59
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *60
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *61
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *62
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *63
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *64
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 231
+        indent: 1
+        parameters:
+        - 50
+        - black_gradient
+        - 0
+        - 0
+        - 0
+        - -304
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 1
+        parameters:
+        - 50
+        - 10
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Door exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 7
+        - 33
+        - 66
+        - 2
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 0
+        parameters:
+        - 50
+        - 10
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(false, "A", 29)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 33
     y: 34
   29: !ruby/object:RPG::Event
@@ -3746,86 +3745,86 @@ events:
     name: !binary |-
       wqcgTGFkZGVyIG1hc2s=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: misc-ladder-floor
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: misc-ladder-floor
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 0
+      walk_anime: false
     x: 33
     y: 35
   3: !ruby/object:RPG::Event
@@ -3833,509 +3832,485 @@ events:
     name: !binary |-
       wqcgQ29tcHV0ZXI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Computer-screen
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &65
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_on
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &66
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &67
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand &68
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &69
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &70
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &71
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *65
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *66
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *67
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *68
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *69
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *70
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *71
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_pc
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &72
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_off
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &73
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &74
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &75
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &76
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &77
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &78
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *72
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *73
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *74
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *75
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *76
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *77
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *78
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Computer-screen
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &65 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 3
+          - &66 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - &67 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &68 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &69 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &70 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *65
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *66
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *67
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *68
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *69
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *70
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_pc
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &71 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &72 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &73 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &74 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &75 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 0
+          - &76 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *71
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *72
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *73
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *74
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *75
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *76
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 30
     y: 16
   30: !ruby/object:RPG::Event
     id: 30
     name: EV030
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Elder
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Elder
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 23 Hello, young Maker.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 24 Now, I can teach this to anyone or anything interested, whatever their
+          morphology.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 25 I wish to share my wisdom with you, or at the very least, to one of
+          your Pokémon.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 26 Would you be interested in having me teach Rock Climb to one of your
+          Pokémon?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 7, 27 To which Pokémon should I teach it?
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - !binary |-
+          Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - !binary |-
+          VGhlIGNob3NlbiBQb2vDqW1vbiBpcyBzdG9yZWQgaW4gdmFyaWFibGUgNDMu
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - call_party_menu
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 1
+        - 43
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - Creating a dynamic text that will display the name
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - !binary |-
+          b2YgdGhlIGNob3NlbiBQb2vDqW1vbiAodmFyaWFibGUgNDMpIHRvIHdyaXRlIGl0IGluc2lkZQ==
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - a message instead of "[POKE]".
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - PFM::Text.set_variable("[POKE]", $actors[gv[43]].name)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - We're bypassing the learn check but we still
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - check if it already has learnt it.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 2
+        parameters:
+        - 12
+        - "$actors[gv[43]].skills_set.any? { |skill| skill.db_symbol == :rock_climb
+          }"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 7, 28 It seems like your [POKE] already knows Rock Climb...
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 3
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 7, 29 Alright, I'll teach Rock Climb to your [POKE].
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 3
+        parameters:
+        - Learning the move
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 3
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - skill_learn(gv[43], :rock_climb)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 7, 30 Your [POKE] can now climb the rocky slopes!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 3
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 7, 31 I understand... Rock climbing without any protective gear might be
+          too scary.
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - Event end
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 7, 32 I understand... Rock climbing without any protective gear might be
+          too scary.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 23 Hello, young Maker.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 24 Now, I can teach this to anyone or anything interested, whatever their
-                morphology.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 25 I wish to share my wisdom with you, or at the very least, to one of
-                your Pokémon.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 26 Would you be interested in having me teach Rock Climb to one of your
-                Pokémon?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 7, 27 To which Pokémon should I teach it?
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - !binary |-
-                Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - !binary |-
-                VGhlIGNob3NlbiBQb2vDqW1vbiBpcyBzdG9yZWQgaW4gdmFyaWFibGUgNDMu
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - call_party_menu
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 1
-              - 43
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - Creating a dynamic text that will display the name
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - !binary |-
-                b2YgdGhlIGNob3NlbiBQb2vDqW1vbiAodmFyaWFibGUgNDMpIHRvIHdyaXRlIGl0IGluc2lkZQ==
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - a message instead of "[POKE]".
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - PFM::Text.set_variable("[POKE]", $actors[gv[43]].name)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - We're bypassing the learn check but we still
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - check if it already has learnt it.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 2
-            parameters:
-              - 12
-              - "$actors[gv[43]].skills_set.any? { |skill| skill.db_symbol == :rock_climb
-                }"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 7, 28 It seems like your [POKE] already knows Rock Climb...
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 3
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 7, 29 Alright, I'll teach Rock Climb to your [POKE].
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 3
-            parameters:
-              - Learning the move
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 3
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - skill_learn(gv[43], :rock_climb)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 7, 30 Your [POKE] can now climb the rocky slopes!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 3
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 7, 31 I understand... Rock climbing without any protective gear might be
-                too scary.
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - Event end
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 7, 32 I understand... Rock climbing without any protective gear might be
-                too scary.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 28
     y: 32
   31: !ruby/object:RPG::Event
@@ -4343,264 +4318,264 @@ events:
     name: !binary |-
       wqdSb2NrIENsaW1iIDE=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.shadow_disabled = true
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.enter_in_climbing_up_state
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &79
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &80
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &81
-                    code: 14
-                    parameters:
-                      - -1
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *79
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *80
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *81
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 112
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 2
-            parameters:
-              - 12
-              - gm.system_tag_here?(gp.x - 1, gp.y - 1, ::GameData::SystemTags::RClimb)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::Particles.add_particle($game_player, :rock_climb)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 3
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &82
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: hm_climb
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &83
-                    code: 7
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *82
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *83
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - gp.shadow_disabled = false
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 3
-            parameters:
-              - gp.leave_climbing_state
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::Particles.add_particle($game_player, :rock_climb)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 3
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &84
-                    code: 14
-                    parameters:
-                      - -1
-                      - -1
-                  - !ruby/object:RPG::MoveCommand &85
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &86
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *84
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *85
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *86
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 113
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 413
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.shadow_disabled = true
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.enter_in_climbing_up_state
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &77 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - &78 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &79 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - -1
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *77
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *78
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *79
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 112
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 2
+        parameters:
+        - 12
+        - gm.system_tag_here?(gp.x - 1, gp.y - 1, ::GameData::SystemTags::RClimb)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::Particles.add_particle($game_player, :rock_climb)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 3
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &80 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: hm_climb
+              pitch: 100
+              volume: 80
+          - &81 !ruby/object:RPG::MoveCommand
+            code: 7
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *80
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *81
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - gp.shadow_disabled = false
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 3
+        parameters:
+        - gp.leave_climbing_state
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::Particles.add_particle($game_player, :rock_climb)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 3
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &82 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - -1
+            - -1
+          - &83 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &84 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *82
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *83
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *84
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 113
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 413
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 27
     y: 33
   32: !ruby/object:RPG::Event
@@ -4608,553 +4583,553 @@ events:
     name: !binary |-
       wqdSb2NrIENsaW1iIDI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.shadow_disabled = true
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.enter_in_climbing_up_state
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &87
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &88
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &89
-                    code: 14
-                    parameters:
-                      - 1
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *87
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *88
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *89
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 112
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 2
-            parameters:
-              - 12
-              - gm.system_tag_here?(gp.x + 1, gp.y + 1, ::GameData::SystemTags::RClimb)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::Particles.add_particle($game_player, :rock_climb)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 3
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &90
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: hm_climb
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &91
-                    code: 6
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *90
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *91
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - gp.shadow_disabled = false
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 3
-            parameters:
-              - gp.leave_climbing_state
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::Particles.add_particle($game_player, :rock_climb)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 3
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &92
-                    code: 14
-                    parameters:
-                      - 1
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &93
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &94
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *92
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *93
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *94
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 113
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 413
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.shadow_disabled = true
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.enter_in_climbing_up_state
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &85 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - &86 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &87 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 1
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *85
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *86
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *87
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 112
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 2
+        parameters:
+        - 12
+        - gm.system_tag_here?(gp.x + 1, gp.y + 1, ::GameData::SystemTags::RClimb)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::Particles.add_particle($game_player, :rock_climb)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 3
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &88 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: hm_climb
+              pitch: 100
+              volume: 80
+          - &89 !ruby/object:RPG::MoveCommand
+            code: 6
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *88
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *89
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - gp.shadow_disabled = false
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 3
+        parameters:
+        - gp.leave_climbing_state
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::Particles.add_particle($game_player, :rock_climb)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 3
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &90 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 1
+            - 1
+          - &91 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &92 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *90
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *91
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *92
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 113
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 413
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 26
     y: 31
   33: !ruby/object:RPG::Event
     id: 33
     name: Chansey
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0113"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 33 Chan-chansey!
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &95
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &96
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &97
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &98
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &99
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &100
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &101
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &102
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &103
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &104
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &105
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &106
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &107
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &108
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &109
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &110
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &111
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &112
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &113
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &114
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *95
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *96
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *97
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *98
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *99
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *100
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *101
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *102
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *103
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *104
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *105
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *106
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *107
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *108
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *109
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *110
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *111
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *112
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *113
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *114
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: rosa_healpokemon
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 7, 34 Chansey heals your team.[WAIT 90]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM.game_state.heal_party
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:music, 0, 0, oy_offset: 10)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0113'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 33 Chan-chansey!
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &93 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &94 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &95 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &96 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &97 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &98 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &99 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &100 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &101 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &102 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &103 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &104 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &105 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &106 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &107 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &108 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &109 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &110 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &111 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &112 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *93
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *94
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *95
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *96
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *97
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *98
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *99
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *100
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *101
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *102
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *103
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *104
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *105
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *106
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *107
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *108
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *109
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *110
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *111
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *112
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: rosa_healpokemon
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 7, 34 Chansey heals your team.[WAIT 90]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM.game_state.heal_party
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:music, 0, 0, oy_offset: 10)'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 16
   34: !ruby/object:RPG::Event
@@ -5162,264 +5137,264 @@ events:
     name: !binary |-
       wqdSb2NrIENsaW1iIDM=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.shadow_disabled = true
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.enter_in_climbing_up_state
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &115
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &116
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &117
-                    code: 14
-                    parameters:
-                      - 0
-                      - -1
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *115
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *116
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *117
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 112
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 2
-            parameters:
-              - 12
-              - gm.system_tag_here?(gp.x, gp.y - 1, ::GameData::SystemTags::RClimb)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::Particles.add_particle($game_player, :rock_climb)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 3
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &118
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: hm_climb
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &119
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *118
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *119
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - gp.shadow_disabled = false
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 3
-            parameters:
-              - gp.leave_climbing_state
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::Particles.add_particle($game_player, :rock_climb)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 3
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &120
-                    code: 14
-                    parameters:
-                      - 0
-                      - -1
-                  - !ruby/object:RPG::MoveCommand &121
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &122
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *120
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *121
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *122
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 113
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 413
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.shadow_disabled = true
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.enter_in_climbing_up_state
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &113 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - &114 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &115 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - -1
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *113
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *114
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *115
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 112
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 2
+        parameters:
+        - 12
+        - gm.system_tag_here?(gp.x, gp.y - 1, ::GameData::SystemTags::RClimb)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::Particles.add_particle($game_player, :rock_climb)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 3
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &116 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: hm_climb
+              pitch: 100
+              volume: 80
+          - &117 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *116
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *117
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - gp.shadow_disabled = false
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 3
+        parameters:
+        - gp.leave_climbing_state
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::Particles.add_particle($game_player, :rock_climb)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 3
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &118 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - -1
+          - &119 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &120 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *118
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *119
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *120
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 113
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 413
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 29
     y: 30
   35: !ruby/object:RPG::Event
@@ -5427,820 +5402,820 @@ events:
     name: !binary |-
       wqdSb2NrIENsaW1iIDQ=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.shadow_disabled = true
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.enter_in_climbing_up_state
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &123
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &124
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &125
-                    code: 14
-                    parameters:
-                      - 0
-                      - 1
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *123
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *124
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *125
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 112
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 2
-            parameters:
-              - 12
-              - gm.system_tag_here?(gp.x, gp.y + 1, ::GameData::SystemTags::RClimb)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::Particles.add_particle($game_player, :rock_climb)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 3
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &126
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: hm_climb
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &127
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *126
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *127
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - gp.shadow_disabled = false
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 3
-            parameters:
-              - gp.leave_climbing_state
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::Particles.add_particle($game_player, :rock_climb)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 3
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &128
-                    code: 14
-                    parameters:
-                      - 0
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &129
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &130
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *128
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *129
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 3
-            parameters:
-              - *130
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 113
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 413
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.shadow_disabled = true
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.enter_in_climbing_up_state
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &121 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - &122 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &123 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 1
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *121
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *122
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *123
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 112
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 2
+        parameters:
+        - 12
+        - gm.system_tag_here?(gp.x, gp.y + 1, ::GameData::SystemTags::RClimb)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::Particles.add_particle($game_player, :rock_climb)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 3
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &124 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: hm_climb
+              pitch: 100
+              volume: 80
+          - &125 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *124
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *125
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - gp.shadow_disabled = false
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 3
+        parameters:
+        - gp.leave_climbing_state
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::Particles.add_particle($game_player, :rock_climb)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 3
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &126 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 1
+          - &127 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &128 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *126
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *127
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 3
+        parameters:
+        - *128
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 113
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 413
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 29
     y: 27
   4: !ruby/object:RPG::Event
     id: 4
     name: "$Rock1"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - ge.x == 19 && ge.y == 64
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, "A", 16)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - get_local_variable(21, :boulders, :add, 1)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - delete_event_forever(8)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - ge.x == 19 && ge.y == 64
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, "A", 16)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - get_local_variable(21, :boulders, :add, 1)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - delete_event_forever(8)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 19
     y: 21
   5: !ruby/object:RPG::Event
     id: 5
     name: "$Rock2"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - "$game_player.direction != 8"
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 1
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - "$game_player.direction != 8"
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 1
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 24
     y: 29
   6: !ruby/object:RPG::Event
     id: 6
     name: "$Rock3"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - ge.x == 21 && ge.y == 55
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, "A", 17)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - get_local_variable(21, :boulders, :add, 1)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - delete_event_forever(14)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - ge.x == 21 && ge.y == 55
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, "A", 17)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - get_local_variable(21, :boulders, :add, 1)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - delete_event_forever(14)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 25
     y: 21
   7: !ruby/object:RPG::Event
     id: 7
     name: "$Rock5"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-HM
-          direction: 2
-          opacity: 255
-          pattern: 2
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-HM
+        direction: 2
+        opacity: 255
+        pattern: 2
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - ge.x == 37 && ge.y == 20
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, "A", 20)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - get_local_variable(21, :boulders, :add, 1)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - ge.x == 37 && ge.y == 20
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, "A", 20)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - get_local_variable(21, :boulders, :add, 1)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: false
     x: 38
     y: 20
   8: !ruby/object:RPG::Event
     id: 8
     name: Rock fall manager 1
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - "$game_map.events[4].x == 19 && $game_map.events[4].y == 25"
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &131
-                    code: 15
-                    parameters:
-                      - 55
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *131
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 25
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 4
-              - 0
-              - 20
-              - 60
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: fall
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - "TODO: Bruit impact au sol"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - "$game_map.events[4].x == 19 && $game_map.events[4].y == 25"
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &129 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 55
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *129
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 25
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 4
+        - 0
+        - 20
+        - 60
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: fall
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - 'TODO: Bruit impact au sol'
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 22
     y: 26
   9: !ruby/object:RPG::Event
     id: 9
     name: Aerun Event Begin Check
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - detect_player(2, :left)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, "A", 10)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - detect_player(2, :left)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, "A", 10)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 33
     y: 22
 height: 80

--- a/Data/Map008.rxdata.yml
+++ b/Data/Map008.rxdata.yml
@@ -1,5 +1,4 @@
----
-!ruby/object:RPG::Map
+--- !ruby/object:RPG::Map
 autoplay_bgm: true
 autoplay_bgs: false
 bgm: !ruby/object:RPG::AudioFile
@@ -7,7 +6,7 @@ bgm: !ruby/object:RPG::AudioFile
   pitch: 100
   volume: 100
 bgs: !ruby/object:RPG::AudioFile
-  name: ""
+  name: ''
   pitch: 100
   volume: 100
 data: !ruby/object:Table
@@ -216,642 +215,642 @@ events:
     name: !binary |-
       wqcgd2FycA==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Warp-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Warp-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 44
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Activating this self switch will play the descending
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - animation on the destination map.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",15,map_id = 3)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 3
+        - 28
+        - 43
+        - 6
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 222
+        indent: 0
+        parameters:
+        - ''
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 44
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Activating this self switch will play the descending
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - animation on the destination map.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",15,map_id = 3)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 3
-              - 28
-              - 43
-              - 6
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 222
-            indent: 0
-            parameters:
-              - ""
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
-            - !ruby/object:RPG::MoveCommand
-              code: 15
-              parameters:
-                - 960
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 3
-        step_anime: false
-        through: true
-        trigger: 2
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
+        - !ruby/object:RPG::MoveCommand
+          code: 15
+          parameters:
+          - 960
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 3
+      step_anime: false
+      through: true
+      trigger: 2
+      walk_anime: false
     x: 29
     y: 18
   10: !ruby/object:RPG::Event
     id: 10
     name: "$ Worker"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Worker
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Worker
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 0 I saw a colorful stone not long ago...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 1 But I can't find it anymore!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 2 Maybe somebody picked it before I could...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 0 I saw a colorful stone not long ago...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 1 But I can't find it anymore!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 2 Maybe somebody picked it before I could...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - move_random_within_zone(23, 28 ,40, 44)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - move_random_within_zone(23, 28 ,40, 44)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - emotion(:exclamation)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 3 This light in your bag...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 4 That's the light I saw the other day!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 5 So, you're the one who picked the stone I was looking for everywhere!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 6 Eh... You won't give it to me, right?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - 8, 7 No chance
+          - 8, 8 You can dream on it
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - 8, 7 No chance
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 8, 9 Huh! No need to be this rude...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - 8, 8 You can dream on it
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 8, 10 You're mocking me too?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 11 If you were able to find it...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 12 Then maybe there is more to find!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 13 I'm going to intensify my research.
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - emotion(:exclamation)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 3 This light in your bag...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 4 That's the light I saw the other day!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 5 So, you're the one who picked the stone I was looking for everywhere!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 6 Eh... You won't give it to me, right?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - 8, 7 No chance
-                - 8, 8 You can dream on it
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - 8, 7 No chance
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 8, 9 Huh! No need to be this rude...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - 8, 8 You can dream on it
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 8, 10 You're mocking me too?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 11 If you were able to find it...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 12 Then maybe there is more to find!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 13 I'm going to intensify my research.
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - move_random_within_zone(23, 28 ,40, 44)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - move_random_within_zone(23, 28 ,40, 44)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 14 If you were able to find it...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 15 Then maybe there is more to find!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 16 I'm going to intensify my research.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 14 If you were able to find it...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 15 Then maybe there is more to find!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 16 I'm going to intensify my research.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 26
     y: 42
   11: !ruby/object:RPG::Event
     id: 11
     name: Chansey
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0113"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 17 Chan-chansey!
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &1
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &2
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &3
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &4
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &5
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &6
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &7
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &8
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &9
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &10
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &11
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &12
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &13
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &14
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &15
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &16
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &17
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &18
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &19
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &20
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *1
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *2
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *3
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *4
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *5
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *6
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *7
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *8
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *9
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *10
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *11
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *12
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *13
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *14
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *15
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *16
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *17
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *18
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *19
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *20
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: rosa_healpokemon
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 18 Chansey heals your team.[WAIT 90]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM.game_state.heal_party
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:music, 0, 0, oy_offset: 10)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0113'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 17 Chan-chansey!
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &2 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &3 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &4 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &5 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &6 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &7 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &8 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &9 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &10 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &11 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &12 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &13 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &14 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &15 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &16 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &17 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &20 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *1
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *2
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *3
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *4
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *5
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *6
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *7
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *8
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *9
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *10
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *11
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *12
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *13
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *14
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *15
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *16
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *17
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *18
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *19
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *20
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: rosa_healpokemon
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 18 Chansey heals your team.[WAIT 90]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM.game_state.heal_party
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:music, 0, 0, oy_offset: 10)'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 16
   2: !ruby/object:RPG::Event
@@ -859,397 +858,397 @@ events:
     name: !binary |-
       wqcgZWxldmF0b3IgZG9vcg==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 242
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &21
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &22
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &23
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &24
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &25
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *21
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *22
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *23
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *24
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *25
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable tells the game from which floor the playe came inside the
-                elevator.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 4
-              - 12
-              - 16
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 242
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &26
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &27
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &28
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &29
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &30
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *26
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *27
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *28
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *29
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *30
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &21 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &22 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &23 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &24 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The animation will play in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &25 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *21
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *22
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *25
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable tells the game from which floor the playe came inside the
+          elevator.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 4
+        - 12
+        - 16
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &26 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &27 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &28 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &29 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *26
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *27
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *30
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The animation will play in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 33
     y: 15
   3: !ruby/object:RPG::Event
@@ -1257,966 +1256,966 @@ events:
     name: !binary |-
       wqcgQ29tcHV0ZXI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Computer-screen
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &31
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_on
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &32
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &33
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand &34
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &35
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &36
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &37
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *31
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *32
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *33
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *34
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *35
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *36
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *37
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_pc
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &38
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_off
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &39
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &40
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &41
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &42
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &43
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &44
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *38
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *39
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *40
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *41
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *42
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *43
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *44
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Computer-screen
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: computer_on
+              pitch: 100
+              volume: 80
+          - &32 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 3
+          - &33 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - &34 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &35 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &36 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &37 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *31
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *34
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *35
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *36
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *37
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_pc
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &38 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: computer_off
+              pitch: 100
+              volume: 80
+          - &39 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &40 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &41 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &42 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &43 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 0
+          - &44 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *38
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *39
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *40
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *41
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *42
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *43
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *44
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 30
     y: 16
   4: !ruby/object:RPG::Event
     id: 4
     name: Suie[sprite=off]
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We verify the player has the Soot Sack
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - "$bag.has_item?(:soot_sack)"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - We get the data of the tile under the player's on the second
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - layer
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - "@ground_tile_id = gm.data[gp.x, gp.y, 1]"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - This condition verifies if the tile is the very first in the tileset
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - "(the ashen grass)"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 12
+        - "@ground_tile_id == 384"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - 'We change the data for this specific tile and make it a '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - normal grass
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - gm.data[gp.x, gp.y, 1] += 1
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 2
+        parameters:
+        - 42
+        - 42
+        - 1
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We verify the player has the Soot Sack
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - "$bag.has_item?(:soot_sack)"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - We get the data of the tile under the player's on the second
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - layer
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "@ground_tile_id = gm.data[gp.x, gp.y, 1]"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - This condition verifies if the tile is the very first in the tileset
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - "(the ashen grass)"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 12
-              - "@ground_tile_id == 384"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - "We change the data for this specific tile and make it a "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - normal grass
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - gm.data[gp.x, gp.y, 1] += 1
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 2
-            parameters:
-              - 42
-              - 42
-              - 1
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 31
     y: 14
   5: !ruby/object:RPG::Event
     id: 5
     name: "$Hypochondriac scientist"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Scientist-M
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 19 How can I collect all these ashes without getting my hands dirty...?
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &45
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &46
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *45
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *46
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:exclamation, 0, 50, oy_offset: 8)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 20 Can I help you, young \f[lady§man]?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 21 ...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 22 You're interested by this "collecting ashes" thing I mumbled?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 23 These ashes, heavier than air, fall and stick to grass, giving those
-                a grayish tint.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 24 They are are very useful to those you can use all their fingers, but
-                also to scientists like me!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "8, 25 But here's the thing: I hate to get my hands dirty. Literally."
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 26 You seem like a helpful fellow, so here's the deal!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 27 You bring me back enough ash, and I'll give you this nice stone I
-                found on the top of the volcano.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 28 I believe it's called an Intriguing Stone?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 29 ...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 30 What do you mean it was installed there for you?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 31 Bring back the equivalent of what's currently on this floor and I'll
-                give you the stone.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - give_item(:soot_sack)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Scientist-M
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 19 How can I collect all these ashes without getting my hands dirty...?
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &45 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - &46 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *45
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *46
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:exclamation, 0, 50, oy_offset: 8)'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 20 Can I help you, young \f[lady§man]?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 21 ...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 22 You're interested by this "collecting ashes" thing I mumbled?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 23 These ashes, heavier than air, fall and stick to grass, giving those
+          a grayish tint.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 24 They are are very useful to those you can use all their fingers, but
+          also to scientists like me!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '8, 25 But here''s the thing: I hate to get my hands dirty. Literally.'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 26 You seem like a helpful fellow, so here's the deal!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 27 You bring me back enough ash, and I'll give you this nice stone I
+          found on the top of the volcano.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 28 I believe it's called an Intriguing Stone?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 29 ...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 30 What do you mean it was installed there for you?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 31 Bring back the equivalent of what's currently on this floor and I'll
+          give you the stone.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - give_item(:soot_sack)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 42
-              - 0
-              - 112
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 8, 32 Oh! I see you have the right amount!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - give_item(:intriguing_stone)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, "A", 10)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 42
-              - 42
-              - 2
-              - 0
-              - 112
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 8, 33 If you have any remaining soot, I can eventually buy it from you,
-                so don't hesitate to come see me back!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 8, 34 I'll buy 100 soot for 2000$.
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 8, 35 ... You clearly lack some soot.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 42
+        - 0
+        - 112
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 8, 32 Oh! I see you have the right amount!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - give_item(:intriguing_stone)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, "A", 10)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 42
+        - 42
+        - 2
+        - 0
+        - 112
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 8, 33 If you have any remaining soot, I can eventually buy it from you,
+          so don't hesitate to come see me back!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 8, 34 I'll buy 100 soot for 2000$.
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 8, 35 ... You clearly lack some soot.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 42
-              - 0
-              - 100
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 8, 36 I see you have enough soot.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - PFM.game_state.add_money(2000)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 42
-              - 42
-              - 2
-              - 0
-              - 100
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 8, 37 If you have any soot remaining, I can eventually buy it from you,
-                so don't hesitate to come see me back!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 8, 38 What a pleasure it is to keep my hands clean while collecting scientific
-                material.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 8, 39 In case you forgot, I buy 100 soot for 2000$.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 42
+        - 0
+        - 100
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 8, 36 I see you have enough soot.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - PFM.game_state.add_money(2000)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 42
+        - 42
+        - 2
+        - 0
+        - 100
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 8, 37 If you have any soot remaining, I can eventually buy it from you,
+          so don't hesitate to come see me back!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 8, 38 What a pleasure it is to keep my hands clean while collecting scientific
+          material.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 8, 39 In case you forgot, I buy 100 soot for 2000$.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 35
     y: 19
   6: !ruby/object:RPG::Event
     id: 6
     name: Parasol Lady
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Parasol-Lady
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Parasol-Lady
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 40 I like to step on this muddy puddle with my boots.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 41 It's not like the mud over there, in which you sink in an instant!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 40 I like to step on this muddy puddle with my boots.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 41 It's not like the mud over there, in which you sink in an instant!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - move_random_within_systemtag(GameData::SystemTags::Puddle)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: true
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - move_random_within_systemtag(GameData::SystemTags::Puddle)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: true
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 24
     y: 23
   7: !ruby/object:RPG::Event
     id: 7
     name: Farmer
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Rancher
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Rancher
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 42 I'm trying to collect soot for the speccy four-eyes over there.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 43 But trying to catch ash bare-handed is definitely not effective at
+          all!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 2
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 42 I'm trying to collect soot for the speccy four-eyes over there.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 43 But trying to catch ash bare-handed is definitely not effective at
-                all!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 2
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - move_random_within_zone(28,25,33,27)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - move_random_within_zone(28,25,33,27)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 30
     y: 26
   8: !ruby/object:RPG::Event
     id: 8
     name: Bug catcher
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Bug-Catcher-HGSS
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Bug-Catcher-HGSS
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 44 Shush!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 45 I'm trying to catch a wild Skorupi, don't make them flee!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 44 Shush!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 45 I'm trying to catch a wild Skorupi, don't make them flee!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 42
     y: 21
   9: !ruby/object:RPG::Event
     id: 9
     name: Black Belt
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Black-Belt-01
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Black-Belt-01
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 46 ...[WAIT 30]
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 47 I'm in full meditation mode to hone my muscles.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 48 The unbearable heat toughens my mind.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 8, 49 Don't disturb my exercise, please.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 46 ...[WAIT 30]
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 47 I'm in full meditation mode to hone my muscles.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 48 The unbearable heat toughens my mind.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 8, 49 Don't disturb my exercise, please.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 44
     y: 37
 height: 64

--- a/Data/Map009.rxdata.yml
+++ b/Data/Map009.rxdata.yml
@@ -1,5 +1,4 @@
----
-!ruby/object:RPG::Map
+--- !ruby/object:RPG::Map
 autoplay_bgm: true
 autoplay_bgs: false
 bgm: !ruby/object:RPG::AudioFile
@@ -7,7 +6,7 @@ bgm: !ruby/object:RPG::AudioFile
   pitch: 100
   volume: 100
 bgs: !ruby/object:RPG::AudioFile
-  name: ""
+  name: ''
   pitch: 100
   volume: 100
 data: !ruby/object:Table
@@ -216,398 +215,398 @@ events:
     name: !binary |-
       wqcgd2FycA==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Warp-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Warp-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 44
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Activating this self switch will play the descending
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - animation on the destination map.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",15,map_id = 3)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 236
+        indent: 0
+        parameters:
+        - 0
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 3
+        - 28
+        - 43
+        - 6
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 222
+        indent: 0
+        parameters:
+        - ''
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 44
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Activating this self switch will play the descending
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - animation on the destination map.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",15,map_id = 3)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 236
-            indent: 0
-            parameters:
-              - 0
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 3
-              - 28
-              - 43
-              - 6
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 222
-            indent: 0
-            parameters:
-              - ""
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
-            - !ruby/object:RPG::MoveCommand
-              code: 15
-              parameters:
-                - 960
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 3
-        step_anime: false
-        through: true
-        trigger: 2
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
+        - !ruby/object:RPG::MoveCommand
+          code: 15
+          parameters:
+          - 960
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 3
+      step_anime: false
+      through: true
+      trigger: 2
+      walk_anime: false
     x: 29
     y: 18
   10: !ruby/object:RPG::Event
     id: 10
     name: Chansey
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0113"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 0 Chan-chansey!
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &1
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &2
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &3
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &4
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &5
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &6
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &7
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &8
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &9
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &10
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &11
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &12
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &13
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &14
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &15
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &16
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &17
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &18
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &19
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &20
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *1
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *2
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *3
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *4
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *5
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *6
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *7
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *8
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *9
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *10
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *11
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *12
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *13
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *14
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *15
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *16
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *17
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *18
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *19
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *20
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: rosa_healpokemon
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 1 Chansey heals your team.[WAIT 90]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM.game_state.heal_party
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:music, 0, 0, oy_offset: 10)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0113'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 0 Chan-chansey!
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &2 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &3 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &4 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &5 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &6 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &7 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &8 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &9 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &10 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &11 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &12 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &13 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &14 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &15 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &16 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &17 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &20 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *1
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *2
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *3
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *4
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *5
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *6
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *7
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *8
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *9
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *10
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *11
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *12
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *13
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *14
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *15
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *16
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *17
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *18
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *19
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *20
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: rosa_healpokemon
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 1 Chansey heals your team.[WAIT 90]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM.game_state.heal_party
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:music, 0, 0, oy_offset: 10)'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 16
   2: !ruby/object:RPG::Event
@@ -615,409 +614,409 @@ events:
     name: !binary |-
       wqcgZWxldmF0b3IgZG9vcg==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 242
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &21
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &22
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &23
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &24
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &25
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *21
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *22
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *23
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *24
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *25
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable tells the game from which floor the playe came inside the
-                elevator.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 6
-          - !ruby/object:RPG::EventCommand
-            code: 236
-            indent: 0
-            parameters:
-              - 0
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 4
-              - 12
-              - 16
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 242
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &26
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &27
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &28
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &29
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &30
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *26
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *27
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *28
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *29
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *30
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &21 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &22 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &23 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &24 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The animation will play in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$game_temp.battleback_name = 'back_ice'"
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &25 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *21
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *22
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *25
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable tells the game from which floor the playe came inside the
+          elevator.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 6
+      - !ruby/object:RPG::EventCommand
+        code: 236
+        indent: 0
+        parameters:
+        - 0
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 4
+        - 12
+        - 16
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &26 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &27 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &28 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &29 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *26
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *27
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *30
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The animation will play in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$game_temp.battleback_name = 'back_ice'"
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 33
     y: 15
   3: !ruby/object:RPG::Event
@@ -1025,903 +1024,879 @@ events:
     name: !binary |-
       wqcgQ29tcHV0ZXI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Computer-screen
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &31
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_on
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &32
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &33
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand &34
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &35
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &36
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &37
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *31
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *32
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *33
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *34
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *35
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *36
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *37
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_pc
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &38
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_off
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &39
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &40
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &41
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &42
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &43
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &44
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *38
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *39
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *40
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *41
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *42
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *43
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *44
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Computer-screen
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 3
+          - &32 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - &33 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &34 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &35 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &36 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *31
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *34
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *35
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *36
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_pc
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &37 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &38 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &39 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &40 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &41 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 0
+          - &42 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *37
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *38
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *39
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *40
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *41
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *42
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 30
     y: 16
   4: !ruby/object:RPG::Event
     id: 4
     name: "[particle=off] Froslass"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 101
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0478"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 101
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0478'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:froslass)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 2 Frooooooss!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 3 The Froslass attacks you!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We create a Froslass and store it in the save. This way,
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'we only generate one the first time we encounter it, and '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - we reuse it every time.
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'We heal it just before each battle and then, we launch '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - the battle.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'froslass = ($user_data[:froslass_quest] ||= PFM::Pokemon.generate_from_hash(id:
+          :froslass, level: 30))'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - froslass.cure
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - froslass.hp = froslass.max_hp
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - froslass.skills_set.each { |skill| skill&.pp = skill.ppmax }
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - call_battle_wild(froslass, nil)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$game_temp.battle_proc = proc do |n|"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "  $game_map.events[4].opacity = 0 if n == -1 || n == 0"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - end
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 35
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 9, 4 The Froslass mocks you and goes back to its business.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 37
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 9, 5 The Froslass disappears to regain its strenghts.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - trigger_event_in(3, "B")
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - ge.opacity = 255
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 38
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 9, 6 You caught the Froslass!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - 'The Pokemon is caught, we delete the wild Froslass from '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - the $user_data
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - "$user_data.delete(:froslass_quest)"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - 'We tell PSDK to delete this event forever. This allows '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - PSDK to skip it and never load it again.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:froslass)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 2 Frooooooss!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 3 The Froslass attacks you!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We create a Froslass and store it in the save. This way,
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "we only generate one the first time we encounter it, and "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - we reuse it every time.
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "We heal it just before each battle and then, we launch "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - the battle.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "froslass = ($user_data[:froslass_quest] ||= PFM::Pokemon.generate_from_hash(id:
-                :froslass, level: 30))"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - froslass.cure
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - froslass.hp = froslass.max_hp
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - froslass.skills_set.each { |skill| skill&.pp = skill.ppmax }
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - call_battle_wild(froslass, nil)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$game_temp.battle_proc = proc do |n|"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "  $game_map.events[4].opacity = 0 if n == -1 || n == 0"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - end
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 35
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 9, 4 The Froslass mocks you and goes back to its business.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 37
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 9, 5 The Froslass disappears to regain its strenghts.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - trigger_event_in(3, "B")
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - ge.opacity = 255
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 38
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 9, 6 You caught the Froslass!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - "The Pokemon is caught, we delete the wild Froslass from "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - the $user_data
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "$user_data.delete(:froslass_quest)"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - "We tell PSDK to delete this event forever. This allows "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - PSDK to skip it and never load it again.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 1
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 101
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 1
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 101
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 2
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 2
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 21
     y: 21
   5: !ruby/object:RPG::Event
     id: 5
     name: "[particle=off]Intriguing Stone"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-Pokeball
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-Pokeball
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:intriguing_stone)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:intriguing_stone)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 19
     y: 42
   6: !ruby/object:RPG::Event
     id: 6
     name: Ice Rock
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          VG8gbWFrZSBhIFBva8OpbW9uIGV2b2x2ZSBuZXh0IHRvIHRoZSBJY2UgUm9jaywgc2ltcGx5
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - !binary |-
+          Y2hvc2UgdGhlIGNvcnJlY3QgZXZvbHV0aW9uIG1ldGhvZCBpbiBQb2vDqW1vbiBTdHVkaW8gYW5k
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - put the corresponding map ID
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 7 The rock is covered with a thick layer of ice.
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - It's very cold to the touch.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 8 A certain species of Pokémon could \c[5]evolve around it\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 9 But it seems like it can't be found on this Island...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                VG8gbWFrZSBhIFBva8OpbW9uIGV2b2x2ZSBuZXh0IHRvIHRoZSBJY2UgUm9jaywgc2ltcGx5
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - !binary |-
-                Y2hvc2UgdGhlIGNvcnJlY3QgZXZvbHV0aW9uIG1ldGhvZCBpbiBQb2vDqW1vbiBTdHVkaW8gYW5k
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - put the corresponding map ID
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 7 The rock is covered with a thick layer of ice.
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - It's very cold to the touch.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 8 A certain species of Pokémon could \c[5]evolve around it\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 9 But it seems like it can't be found on this Island...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 42
     y: 28
   7: !ruby/object:RPG::Event
     id: 7
     name: Ice Rock
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          VG8gbWFrZSBhIFBva8OpbW9uIGV2b2x2ZSBuZXh0IHRvIHRoZSBJY2UgUm9jaywgc2ltcGx5
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - !binary |-
+          Y2hvc2UgdGhlIGNvcnJlY3QgZXZvbHV0aW9uIG1ldGhvZCBpbiBQb2vDqW1vbiBTdHVkaW8gYW5k
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - put the corresponding map ID
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 10 The rock is covered with a thick layer of ice.
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - It's very cold to the touch.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 11 A certain species of Pokémon could \c[5]evolve around it\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 12 But it seems like it can't be found on this Island...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                VG8gbWFrZSBhIFBva8OpbW9uIGV2b2x2ZSBuZXh0IHRvIHRoZSBJY2UgUm9jaywgc2ltcGx5
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - !binary |-
-                Y2hvc2UgdGhlIGNvcnJlY3QgZXZvbHV0aW9uIG1ldGhvZCBpbiBQb2vDqW1vbiBTdHVkaW8gYW5k
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - put the corresponding map ID
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 10 The rock is covered with a thick layer of ice.
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - It's very cold to the touch.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 11 A certain species of Pokémon could \c[5]evolve around it\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 12 But it seems like it can't be found on this Island...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 43
     y: 28
   8: !ruby/object:RPG::Event
     id: 8
     name: Man
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Man-02
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Man-02
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 13 It's very chilly here!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 14 And with that, I'm under the impression I'm constantly observed...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 2
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 13 It's very chilly here!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 14 And with that, I'm under the impression I'm constantly observed...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 2
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - move_random_within_zone(30,35,23,27)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: true
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - move_random_within_zone(30,35,23,27)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: true
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 32
     y: 25
   9: !ruby/object:RPG::Event
     id: 9
     name: Skier
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Skier-F
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Skier-F
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 15 The powder snow is top quality to ski!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 16 On the other hand, I won't try to go on this \c[5]ice\c[0] just below...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 9, 17 Once you've started, it's impossible to stop!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 15 The powder snow is top quality to ski!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 16 On the other hand, I won't try to go on this \c[5]ice\c[0] just below...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 9, 17 Once you've started, it's impossible to stop!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - move_random_within_zone(25,28,37,39)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: true
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - move_random_within_zone(25,28,37,39)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: true
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 26
     y: 38
 height: 64

--- a/Data/Map010.rxdata.yml
+++ b/Data/Map010.rxdata.yml
@@ -2420,8 +2420,17 @@ events:
         code: 355
         indent: 0
         parameters:
-        - 'trainer_eye_sequence("10, 28 Hey, you there!", eye_bgm: ''audio/bgm/Spotted
-          - Tough Guy.ogg'')'
+        - 'trainer_eye_sequence("10, 28 Hey, you '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'there!", eye_bgm: ''Spotted - Tough '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - Guy.ogg')
       - !ruby/object:RPG::EventCommand
         code: 101
         indent: 0
@@ -2547,36 +2556,29 @@ events:
         - !ruby/object:RPG::MoveRoute
           list:
           - &35 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_on
-              pitch: 100
-              volume: 80
-          - &36 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 3
-          - &37 !ruby/object:RPG::MoveCommand
+          - &36 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 8
-          - &38 !ruby/object:RPG::MoveCommand
+          - &37 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
-          - &39 !ruby/object:RPG::MoveCommand
+          - &38 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
-          - &40 !ruby/object:RPG::MoveCommand
+          - &39 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12)
-          - &41 !ruby/object:RPG::MoveCommand
+          - &40 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
@@ -2616,11 +2618,6 @@ events:
         parameters:
         - *40
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *41
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -2636,37 +2633,30 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &42 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_off
-              pitch: 100
-              volume: 80
-          - &43 !ruby/object:RPG::MoveCommand
+          - &41 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
+          - &42 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &43 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
           - &44 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
           - &45 !ruby/object:RPG::MoveCommand
-            code: 45
-            parameters:
-            - animate_from_charset([1],12)
-          - &46 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 12
-          - &47 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 0
-          - &48 !ruby/object:RPG::MoveCommand
+          - &46 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 4
@@ -2675,6 +2665,11 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *41
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -2700,16 +2695,6 @@ events:
         indent: 0
         parameters:
         - *46
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *47
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *48
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -2914,7 +2899,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &49 !ruby/object:RPG::MoveCommand
+          - &47 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -2926,7 +2911,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *49
+        - *47
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -3131,11 +3116,45 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &50 !ruby/object:RPG::MoveCommand
+          - &48 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &51 !ruby/object:RPG::MoveCommand
+          - &49 !ruby/object:RPG::MoveCommand
             code: 3
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *48
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *49
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &50 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 3
+            - 0
+          - &51 !ruby/object:RPG::MoveCommand
+            code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
             code: 0
@@ -3152,40 +3171,6 @@ events:
         indent: 1
         parameters:
         - *51
-      - !ruby/object:RPG::EventCommand
-        code: 210
-        indent: 1
-        parameters: []
-      - !ruby/object:RPG::EventCommand
-        code: 209
-        indent: 1
-        parameters:
-        - -1
-        - !ruby/object:RPG::MoveRoute
-          list:
-          - &52 !ruby/object:RPG::MoveCommand
-            code: 14
-            parameters:
-            - 3
-            - 0
-          - &53 !ruby/object:RPG::MoveCommand
-            code: 38
-            parameters: []
-          - !ruby/object:RPG::MoveCommand
-            code: 0
-            parameters: []
-          repeat: false
-          skippable: false
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *52
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *53
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -3211,11 +3196,45 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &54 !ruby/object:RPG::MoveCommand
+          - &52 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &55 !ruby/object:RPG::MoveCommand
+          - &53 !ruby/object:RPG::MoveCommand
             code: 3
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *52
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *53
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &54 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 1
+            - 0
+          - &55 !ruby/object:RPG::MoveCommand
+            code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
             code: 0
@@ -3232,40 +3251,6 @@ events:
         indent: 1
         parameters:
         - *55
-      - !ruby/object:RPG::EventCommand
-        code: 210
-        indent: 1
-        parameters: []
-      - !ruby/object:RPG::EventCommand
-        code: 209
-        indent: 1
-        parameters:
-        - -1
-        - !ruby/object:RPG::MoveRoute
-          list:
-          - &56 !ruby/object:RPG::MoveCommand
-            code: 14
-            parameters:
-            - 1
-            - 0
-          - &57 !ruby/object:RPG::MoveCommand
-            code: 38
-            parameters: []
-          - !ruby/object:RPG::MoveCommand
-            code: 0
-            parameters: []
-          repeat: false
-          skippable: false
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *56
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *57
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -3337,11 +3322,45 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &58 !ruby/object:RPG::MoveCommand
+          - &56 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &59 !ruby/object:RPG::MoveCommand
+          - &57 !ruby/object:RPG::MoveCommand
             code: 3
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *56
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *57
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &58 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 3
+            - 0
+          - &59 !ruby/object:RPG::MoveCommand
+            code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
             code: 0
@@ -3358,40 +3377,6 @@ events:
         indent: 1
         parameters:
         - *59
-      - !ruby/object:RPG::EventCommand
-        code: 210
-        indent: 1
-        parameters: []
-      - !ruby/object:RPG::EventCommand
-        code: 209
-        indent: 1
-        parameters:
-        - -1
-        - !ruby/object:RPG::MoveRoute
-          list:
-          - &60 !ruby/object:RPG::MoveCommand
-            code: 14
-            parameters:
-            - 3
-            - 0
-          - &61 !ruby/object:RPG::MoveCommand
-            code: 38
-            parameters: []
-          - !ruby/object:RPG::MoveCommand
-            code: 0
-            parameters: []
-          repeat: false
-          skippable: false
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *60
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *61
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -3417,11 +3402,45 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &62 !ruby/object:RPG::MoveCommand
+          - &60 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &63 !ruby/object:RPG::MoveCommand
+          - &61 !ruby/object:RPG::MoveCommand
             code: 3
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *60
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *61
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &62 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 1
+            - 0
+          - &63 !ruby/object:RPG::MoveCommand
+            code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
             code: 0
@@ -3438,40 +3457,6 @@ events:
         indent: 1
         parameters:
         - *63
-      - !ruby/object:RPG::EventCommand
-        code: 210
-        indent: 1
-        parameters: []
-      - !ruby/object:RPG::EventCommand
-        code: 209
-        indent: 1
-        parameters:
-        - -1
-        - !ruby/object:RPG::MoveRoute
-          list:
-          - &64 !ruby/object:RPG::MoveCommand
-            code: 14
-            parameters:
-            - 1
-            - 0
-          - &65 !ruby/object:RPG::MoveCommand
-            code: 38
-            parameters: []
-          - !ruby/object:RPG::MoveCommand
-            code: 0
-            parameters: []
-          repeat: false
-          skippable: false
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *64
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *65
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -3543,11 +3528,45 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &66 !ruby/object:RPG::MoveCommand
+          - &64 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &67 !ruby/object:RPG::MoveCommand
+          - &65 !ruby/object:RPG::MoveCommand
             code: 1
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *64
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *65
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &66 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 3
+          - &67 !ruby/object:RPG::MoveCommand
+            code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
             code: 0
@@ -3564,40 +3583,6 @@ events:
         indent: 1
         parameters:
         - *67
-      - !ruby/object:RPG::EventCommand
-        code: 210
-        indent: 1
-        parameters: []
-      - !ruby/object:RPG::EventCommand
-        code: 209
-        indent: 1
-        parameters:
-        - -1
-        - !ruby/object:RPG::MoveRoute
-          list:
-          - &68 !ruby/object:RPG::MoveCommand
-            code: 14
-            parameters:
-            - 0
-            - 3
-          - &69 !ruby/object:RPG::MoveCommand
-            code: 38
-            parameters: []
-          - !ruby/object:RPG::MoveCommand
-            code: 0
-            parameters: []
-          repeat: false
-          skippable: false
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *68
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *69
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -3623,11 +3608,45 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &70 !ruby/object:RPG::MoveCommand
+          - &68 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &71 !ruby/object:RPG::MoveCommand
+          - &69 !ruby/object:RPG::MoveCommand
             code: 1
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *68
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *69
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &70 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 1
+          - &71 !ruby/object:RPG::MoveCommand
+            code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
             code: 0
@@ -3644,40 +3663,6 @@ events:
         indent: 1
         parameters:
         - *71
-      - !ruby/object:RPG::EventCommand
-        code: 210
-        indent: 1
-        parameters: []
-      - !ruby/object:RPG::EventCommand
-        code: 209
-        indent: 1
-        parameters:
-        - -1
-        - !ruby/object:RPG::MoveRoute
-          list:
-          - &72 !ruby/object:RPG::MoveCommand
-            code: 14
-            parameters:
-            - 0
-            - 1
-          - &73 !ruby/object:RPG::MoveCommand
-            code: 38
-            parameters: []
-          - !ruby/object:RPG::MoveCommand
-            code: 0
-            parameters: []
-          repeat: false
-          skippable: false
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *72
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *73
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -3890,7 +3875,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &74 !ruby/object:RPG::MoveCommand
+          - &72 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -3902,7 +3887,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *74
+        - *72
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0

--- a/Data/Map011.rxdata.yml
+++ b/Data/Map011.rxdata.yml
@@ -7560,36 +7560,29 @@ events:
         - !ruby/object:RPG::MoveRoute
           list:
           - &72 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_on
-              pitch: 100
-              volume: 80
-          - &73 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 3
-          - &74 !ruby/object:RPG::MoveCommand
+          - &73 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 8
-          - &75 !ruby/object:RPG::MoveCommand
+          - &74 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
-          - &76 !ruby/object:RPG::MoveCommand
+          - &75 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
-          - &77 !ruby/object:RPG::MoveCommand
+          - &76 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12)
-          - &78 !ruby/object:RPG::MoveCommand
+          - &77 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
@@ -7629,11 +7622,6 @@ events:
         parameters:
         - *77
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *78
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -7649,37 +7637,30 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &79 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_off
-              pitch: 100
-              volume: 80
-          - &80 !ruby/object:RPG::MoveCommand
+          - &78 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
+          - &79 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &80 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
           - &81 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
           - &82 !ruby/object:RPG::MoveCommand
-            code: 45
-            parameters:
-            - animate_from_charset([1],12)
-          - &83 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 12
-          - &84 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 0
-          - &85 !ruby/object:RPG::MoveCommand
+          - &83 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 4
@@ -7688,6 +7669,11 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *78
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -7713,16 +7699,6 @@ events:
         indent: 0
         parameters:
         - *83
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *84
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *85
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -7916,7 +7892,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &86 !ruby/object:RPG::MoveCommand
+          - &84 !ruby/object:RPG::MoveCommand
             code: 20
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -7928,7 +7904,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *86
+        - *84
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 2
@@ -7972,7 +7948,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &87 !ruby/object:RPG::MoveCommand
+          - &85 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
@@ -7985,7 +7961,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *87
+        - *85
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -8235,7 +8211,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &88 !ruby/object:RPG::MoveCommand
+          - &86 !ruby/object:RPG::MoveCommand
             code: 20
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -8247,7 +8223,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *88
+        - *86
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 2
@@ -8291,7 +8267,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &89 !ruby/object:RPG::MoveCommand
+          - &87 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
@@ -8304,7 +8280,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *89
+        - *87
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -8573,7 +8549,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &90 !ruby/object:RPG::MoveCommand
+          - &88 !ruby/object:RPG::MoveCommand
             code: 20
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -8585,7 +8561,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *90
+        - *88
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 2
@@ -8629,7 +8605,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &91 !ruby/object:RPG::MoveCommand
+          - &89 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
@@ -8642,7 +8618,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *91
+        - *89
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -8892,7 +8868,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &92 !ruby/object:RPG::MoveCommand
+          - &90 !ruby/object:RPG::MoveCommand
             code: 20
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -8904,7 +8880,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *92
+        - *90
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 2
@@ -8948,7 +8924,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &93 !ruby/object:RPG::MoveCommand
+          - &91 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
@@ -8961,7 +8937,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *93
+        - *91
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -9252,16 +9228,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &94 !ruby/object:RPG::MoveCommand
+          - &92 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &95 !ruby/object:RPG::MoveCommand
+          - &93 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &96 !ruby/object:RPG::MoveCommand
+          - &94 !ruby/object:RPG::MoveCommand
             code: 3
             parameters: []
-          - &97 !ruby/object:RPG::MoveCommand
+          - &95 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9273,6 +9249,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *92
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *93
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *94
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -9280,23 +9266,13 @@ events:
         parameters:
         - *95
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *96
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *97
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &98 !ruby/object:RPG::MoveCommand
+          - &96 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9308,7 +9284,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *98
+        - *96
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -9445,16 +9421,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &99 !ruby/object:RPG::MoveCommand
+          - &97 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &100 !ruby/object:RPG::MoveCommand
+          - &98 !ruby/object:RPG::MoveCommand
             code: 3
             parameters: []
-          - &101 !ruby/object:RPG::MoveCommand
+          - &99 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &102 !ruby/object:RPG::MoveCommand
+          - &100 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9466,6 +9442,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *97
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *98
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *99
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -9473,23 +9459,13 @@ events:
         parameters:
         - *100
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *101
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *102
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &103 !ruby/object:RPG::MoveCommand
+          - &101 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9501,7 +9477,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *103
+        - *101
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -9552,16 +9528,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &104 !ruby/object:RPG::MoveCommand
+          - &102 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &105 !ruby/object:RPG::MoveCommand
+          - &103 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &106 !ruby/object:RPG::MoveCommand
+          - &104 !ruby/object:RPG::MoveCommand
             code: 2
             parameters: []
-          - &107 !ruby/object:RPG::MoveCommand
+          - &105 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9573,6 +9549,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *102
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *103
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *104
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -9580,23 +9566,13 @@ events:
         parameters:
         - *105
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *106
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *107
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &108 !ruby/object:RPG::MoveCommand
+          - &106 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9608,7 +9584,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *108
+        - *106
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -9745,16 +9721,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &109 !ruby/object:RPG::MoveCommand
+          - &107 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &110 !ruby/object:RPG::MoveCommand
+          - &108 !ruby/object:RPG::MoveCommand
             code: 2
             parameters: []
-          - &111 !ruby/object:RPG::MoveCommand
+          - &109 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &112 !ruby/object:RPG::MoveCommand
+          - &110 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9766,6 +9742,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *107
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *108
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *109
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -9773,23 +9759,13 @@ events:
         parameters:
         - *110
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *111
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *112
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &113 !ruby/object:RPG::MoveCommand
+          - &111 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9801,7 +9777,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *113
+        - *111
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -10175,16 +10151,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &114 !ruby/object:RPG::MoveCommand
+          - &112 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &115 !ruby/object:RPG::MoveCommand
+          - &113 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &116 !ruby/object:RPG::MoveCommand
+          - &114 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
-          - &117 !ruby/object:RPG::MoveCommand
+          - &115 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -10196,6 +10172,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *112
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *113
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *114
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -10203,23 +10189,13 @@ events:
         parameters:
         - *115
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *116
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *117
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &118 !ruby/object:RPG::MoveCommand
+          - &116 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -10231,7 +10207,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *118
+        - *116
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -10363,16 +10339,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &119 !ruby/object:RPG::MoveCommand
+          - &117 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &120 !ruby/object:RPG::MoveCommand
+          - &118 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
-          - &121 !ruby/object:RPG::MoveCommand
+          - &119 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &122 !ruby/object:RPG::MoveCommand
+          - &120 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -10384,6 +10360,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *117
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *118
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *119
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -10391,23 +10377,13 @@ events:
         parameters:
         - *120
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *121
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *122
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &123 !ruby/object:RPG::MoveCommand
+          - &121 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -10419,7 +10395,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *123
+        - *121
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -10470,16 +10446,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &124 !ruby/object:RPG::MoveCommand
+          - &122 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &125 !ruby/object:RPG::MoveCommand
+          - &123 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &126 !ruby/object:RPG::MoveCommand
+          - &124 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
-          - &127 !ruby/object:RPG::MoveCommand
+          - &125 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -10491,6 +10467,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *122
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *123
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *124
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -10498,23 +10484,13 @@ events:
         parameters:
         - *125
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *126
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *127
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &128 !ruby/object:RPG::MoveCommand
+          - &126 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -10526,7 +10502,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *128
+        - *126
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -10658,16 +10634,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &129 !ruby/object:RPG::MoveCommand
+          - &127 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &130 !ruby/object:RPG::MoveCommand
+          - &128 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
-          - &131 !ruby/object:RPG::MoveCommand
+          - &129 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &132 !ruby/object:RPG::MoveCommand
+          - &130 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -10679,6 +10655,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *127
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *128
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *129
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -10686,23 +10672,13 @@ events:
         parameters:
         - *130
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *131
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *132
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &133 !ruby/object:RPG::MoveCommand
+          - &131 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -10714,7 +10690,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *133
+        - *131
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -11019,16 +10995,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &134 !ruby/object:RPG::MoveCommand
+          - &132 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &135 !ruby/object:RPG::MoveCommand
+          - &133 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &136 !ruby/object:RPG::MoveCommand
+          - &134 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
-          - &137 !ruby/object:RPG::MoveCommand
+          - &135 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -11040,6 +11016,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *132
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *133
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *134
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -11047,23 +11033,13 @@ events:
         parameters:
         - *135
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *136
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *137
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &138 !ruby/object:RPG::MoveCommand
+          - &136 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -11075,7 +11051,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *138
+        - *136
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -11207,16 +11183,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &139 !ruby/object:RPG::MoveCommand
+          - &137 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &140 !ruby/object:RPG::MoveCommand
+          - &138 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
-          - &141 !ruby/object:RPG::MoveCommand
+          - &139 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &142 !ruby/object:RPG::MoveCommand
+          - &140 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -11228,6 +11204,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *137
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *138
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *139
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -11235,23 +11221,13 @@ events:
         parameters:
         - *140
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *141
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *142
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &143 !ruby/object:RPG::MoveCommand
+          - &141 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -11263,7 +11239,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *143
+        - *141
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -11294,16 +11270,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &144 !ruby/object:RPG::MoveCommand
+          - &142 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &145 !ruby/object:RPG::MoveCommand
+          - &143 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &146 !ruby/object:RPG::MoveCommand
+          - &144 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
-          - &147 !ruby/object:RPG::MoveCommand
+          - &145 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -11315,6 +11291,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *142
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *143
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *144
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -11322,23 +11308,13 @@ events:
         parameters:
         - *145
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *146
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *147
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &148 !ruby/object:RPG::MoveCommand
+          - &146 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -11350,7 +11326,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *148
+        - *146
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -11482,16 +11458,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &149 !ruby/object:RPG::MoveCommand
+          - &147 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &150 !ruby/object:RPG::MoveCommand
+          - &148 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
-          - &151 !ruby/object:RPG::MoveCommand
+          - &149 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &152 !ruby/object:RPG::MoveCommand
+          - &150 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -11503,6 +11479,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *147
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *148
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *149
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -11510,23 +11496,13 @@ events:
         parameters:
         - *150
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *151
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *152
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &153 !ruby/object:RPG::MoveCommand
+          - &151 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -11538,7 +11514,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *153
+        - *151
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -11641,13 +11617,13 @@ events:
         - 56
         - !ruby/object:RPG::MoveRoute
           list:
-          - &154 !ruby/object:RPG::MoveCommand
+          - &152 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &155 !ruby/object:RPG::MoveCommand
+          - &153 !ruby/object:RPG::MoveCommand
             code: 3
             parameters: []
-          - &156 !ruby/object:RPG::MoveCommand
+          - &154 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -11659,17 +11635,17 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *152
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *153
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *154
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *155
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *156
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -11759,13 +11735,13 @@ events:
         - 56
         - !ruby/object:RPG::MoveRoute
           list:
-          - &157 !ruby/object:RPG::MoveCommand
+          - &155 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &158 !ruby/object:RPG::MoveCommand
+          - &156 !ruby/object:RPG::MoveCommand
             code: 2
             parameters: []
-          - &159 !ruby/object:RPG::MoveCommand
+          - &157 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -11777,17 +11753,17 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *155
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *156
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *157
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *158
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *159
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -12439,11 +12415,17 @@ events:
         - 34
         - !ruby/object:RPG::MoveRoute
           list:
-          - &160 !ruby/object:RPG::MoveCommand
+          - &158 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &161 !ruby/object:RPG::MoveCommand
+          - &159 !ruby/object:RPG::MoveCommand
             code: 39
+            parameters: []
+          - &160 !ruby/object:RPG::MoveCommand
+            code: 2
+            parameters: []
+          - &161 !ruby/object:RPG::MoveCommand
+            code: 2
             parameters: []
           - &162 !ruby/object:RPG::MoveCommand
             code: 2
@@ -12464,15 +12446,9 @@ events:
             code: 2
             parameters: []
           - &168 !ruby/object:RPG::MoveCommand
-            code: 2
-            parameters: []
-          - &169 !ruby/object:RPG::MoveCommand
-            code: 2
-            parameters: []
-          - &170 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &171 !ruby/object:RPG::MoveCommand
+          - &169 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -12480,6 +12456,16 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *158
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *159
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -12530,16 +12516,6 @@ events:
         indent: 0
         parameters:
         - *169
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *170
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *171
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -13100,16 +13076,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &172 !ruby/object:RPG::MoveCommand
+          - &170 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &173 !ruby/object:RPG::MoveCommand
+          - &171 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &174 !ruby/object:RPG::MoveCommand
+          - &172 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
-          - &175 !ruby/object:RPG::MoveCommand
+          - &173 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -13121,6 +13097,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *170
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *171
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *172
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -13128,23 +13114,13 @@ events:
         parameters:
         - *173
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *174
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *175
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &176 !ruby/object:RPG::MoveCommand
+          - &174 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -13156,7 +13132,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *176
+        - *174
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -13288,16 +13264,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &177 !ruby/object:RPG::MoveCommand
+          - &175 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &178 !ruby/object:RPG::MoveCommand
+          - &176 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
-          - &179 !ruby/object:RPG::MoveCommand
+          - &177 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &180 !ruby/object:RPG::MoveCommand
+          - &178 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -13309,6 +13285,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *175
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *176
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *177
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -13316,23 +13302,13 @@ events:
         parameters:
         - *178
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *179
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *180
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &181 !ruby/object:RPG::MoveCommand
+          - &179 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -13344,7 +13320,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *181
+        - *179
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -13395,16 +13371,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &182 !ruby/object:RPG::MoveCommand
+          - &180 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &183 !ruby/object:RPG::MoveCommand
+          - &181 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &184 !ruby/object:RPG::MoveCommand
+          - &182 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
-          - &185 !ruby/object:RPG::MoveCommand
+          - &183 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -13416,6 +13392,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *180
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *181
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *182
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -13423,23 +13409,13 @@ events:
         parameters:
         - *183
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *184
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *185
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &186 !ruby/object:RPG::MoveCommand
+          - &184 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -13451,7 +13427,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *186
+        - *184
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -13583,16 +13559,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &187 !ruby/object:RPG::MoveCommand
+          - &185 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &188 !ruby/object:RPG::MoveCommand
+          - &186 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
-          - &189 !ruby/object:RPG::MoveCommand
+          - &187 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &190 !ruby/object:RPG::MoveCommand
+          - &188 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -13604,6 +13580,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *185
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *186
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *187
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -13611,23 +13597,13 @@ events:
         parameters:
         - *188
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *189
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *190
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &191 !ruby/object:RPG::MoveCommand
+          - &189 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -13639,7 +13615,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *191
+        - *189
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -14785,16 +14761,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &192 !ruby/object:RPG::MoveCommand
+          - &190 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &193 !ruby/object:RPG::MoveCommand
+          - &191 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &194 !ruby/object:RPG::MoveCommand
+          - &192 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
-          - &195 !ruby/object:RPG::MoveCommand
+          - &193 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -14806,6 +14782,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *190
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *191
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *192
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -14813,23 +14799,13 @@ events:
         parameters:
         - *193
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *194
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *195
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &196 !ruby/object:RPG::MoveCommand
+          - &194 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -14841,7 +14817,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *196
+        - *194
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -14973,16 +14949,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &197 !ruby/object:RPG::MoveCommand
+          - &195 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &198 !ruby/object:RPG::MoveCommand
+          - &196 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
-          - &199 !ruby/object:RPG::MoveCommand
+          - &197 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &200 !ruby/object:RPG::MoveCommand
+          - &198 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -14994,6 +14970,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *195
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *196
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *197
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -15001,23 +14987,13 @@ events:
         parameters:
         - *198
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *199
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *200
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &201 !ruby/object:RPG::MoveCommand
+          - &199 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -15029,7 +15005,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *201
+        - *199
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -15075,16 +15051,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &202 !ruby/object:RPG::MoveCommand
+          - &200 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &203 !ruby/object:RPG::MoveCommand
+          - &201 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &204 !ruby/object:RPG::MoveCommand
+          - &202 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
-          - &205 !ruby/object:RPG::MoveCommand
+          - &203 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -15096,6 +15072,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *200
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *201
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *202
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -15103,23 +15089,13 @@ events:
         parameters:
         - *203
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *204
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *205
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &206 !ruby/object:RPG::MoveCommand
+          - &204 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -15131,7 +15107,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *206
+        - *204
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -15263,16 +15239,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &207 !ruby/object:RPG::MoveCommand
+          - &205 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &208 !ruby/object:RPG::MoveCommand
+          - &206 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
-          - &209 !ruby/object:RPG::MoveCommand
+          - &207 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &210 !ruby/object:RPG::MoveCommand
+          - &208 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -15284,6 +15260,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *205
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *206
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *207
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -15291,23 +15277,13 @@ events:
         parameters:
         - *208
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *209
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *210
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &211 !ruby/object:RPG::MoveCommand
+          - &209 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -15319,7 +15295,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *211
+        - *209
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -15470,10 +15446,10 @@ events:
         - 59
         - !ruby/object:RPG::MoveRoute
           list:
-          - &212 !ruby/object:RPG::MoveCommand
+          - &210 !ruby/object:RPG::MoveCommand
             code: 19
             parameters: []
-          - &213 !ruby/object:RPG::MoveCommand
+          - &211 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 4
@@ -15486,12 +15462,12 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *212
+        - *210
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
         parameters:
-        - *213
+        - *211
       - !ruby/object:RPG::EventCommand
         code: 355
         indent: 0
@@ -15545,7 +15521,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &214 !ruby/object:RPG::MoveCommand
+          - &212 !ruby/object:RPG::MoveCommand
             code: 16
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -15557,7 +15533,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *214
+        - *212
       - !ruby/object:RPG::EventCommand
         code: 101
         indent: 0
@@ -15591,21 +15567,21 @@ events:
         - 59
         - !ruby/object:RPG::MoveRoute
           list:
-          - &215 !ruby/object:RPG::MoveCommand
+          - &213 !ruby/object:RPG::MoveCommand
             code: 17
+            parameters: []
+          - &214 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 20
+          - &215 !ruby/object:RPG::MoveCommand
+            code: 18
             parameters: []
           - &216 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 20
           - &217 !ruby/object:RPG::MoveCommand
-            code: 18
-            parameters: []
-          - &218 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 20
-          - &219 !ruby/object:RPG::MoveCommand
             code: 19
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -15613,6 +15589,16 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *213
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *214
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -15628,16 +15614,6 @@ events:
         indent: 0
         parameters:
         - *217
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *218
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *219
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -15670,10 +15646,10 @@ events:
         - 59
         - !ruby/object:RPG::MoveRoute
           list:
-          - &220 !ruby/object:RPG::MoveCommand
+          - &218 !ruby/object:RPG::MoveCommand
             code: 18
             parameters: []
-          - &221 !ruby/object:RPG::MoveCommand
+          - &219 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 4
@@ -15686,12 +15662,12 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *220
+        - *218
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
         parameters:
-        - *221
+        - *219
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -15744,13 +15720,47 @@ events:
         - 59
         - !ruby/object:RPG::MoveRoute
           list:
-          - &222 !ruby/object:RPG::MoveCommand
+          - &220 !ruby/object:RPG::MoveCommand
             code: 16
             parameters: []
-          - &223 !ruby/object:RPG::MoveCommand
+          - &221 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *220
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *221
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 58
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &222 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &223 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 1
           - !ruby/object:RPG::MoveCommand
             code: 0
             parameters: []
@@ -15766,40 +15776,6 @@ events:
         indent: 0
         parameters:
         - *223
-      - !ruby/object:RPG::EventCommand
-        code: 210
-        indent: 0
-        parameters: []
-      - !ruby/object:RPG::EventCommand
-        code: 209
-        indent: 0
-        parameters:
-        - 58
-        - !ruby/object:RPG::MoveRoute
-          list:
-          - &224 !ruby/object:RPG::MoveCommand
-            code: 42
-            parameters:
-            - 255
-          - &225 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 1
-          - !ruby/object:RPG::MoveCommand
-            code: 0
-            parameters: []
-          repeat: false
-          skippable: false
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *224
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *225
       - !ruby/object:RPG::EventCommand
         code: 355
         indent: 0
@@ -15817,7 +15793,7 @@ events:
         - 59
         - !ruby/object:RPG::MoveRoute
           list:
-          - &226 !ruby/object:RPG::MoveCommand
+          - &224 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
@@ -15830,7 +15806,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *226
+        - *224
       - !ruby/object:RPG::EventCommand
         code: 106
         indent: 0
@@ -15843,7 +15819,7 @@ events:
         - 58
         - !ruby/object:RPG::MoveRoute
           list:
-          - &227 !ruby/object:RPG::MoveCommand
+          - &225 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
@@ -15856,7 +15832,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *227
+        - *225
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -16264,13 +16240,13 @@ events:
         - 56
         - !ruby/object:RPG::MoveRoute
           list:
-          - &228 !ruby/object:RPG::MoveCommand
+          - &226 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &229 !ruby/object:RPG::MoveCommand
+          - &227 !ruby/object:RPG::MoveCommand
             code: 2
             parameters: []
-          - &230 !ruby/object:RPG::MoveCommand
+          - &228 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -16282,17 +16258,17 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *226
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *227
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *228
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *229
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *230
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -16554,16 +16530,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &231 !ruby/object:RPG::MoveCommand
+          - &229 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &232 !ruby/object:RPG::MoveCommand
+          - &230 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &233 !ruby/object:RPG::MoveCommand
+          - &231 !ruby/object:RPG::MoveCommand
             code: 3
             parameters: []
-          - &234 !ruby/object:RPG::MoveCommand
+          - &232 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -16575,6 +16551,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *229
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *230
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *231
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -16582,23 +16568,13 @@ events:
         parameters:
         - *232
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *233
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *234
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &235 !ruby/object:RPG::MoveCommand
+          - &233 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -16610,7 +16586,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *235
+        - *233
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -16747,16 +16723,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &236 !ruby/object:RPG::MoveCommand
+          - &234 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &237 !ruby/object:RPG::MoveCommand
+          - &235 !ruby/object:RPG::MoveCommand
             code: 3
             parameters: []
-          - &238 !ruby/object:RPG::MoveCommand
+          - &236 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &239 !ruby/object:RPG::MoveCommand
+          - &237 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -16768,6 +16744,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *234
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *235
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *236
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -16775,23 +16761,13 @@ events:
         parameters:
         - *237
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *238
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *239
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &240 !ruby/object:RPG::MoveCommand
+          - &238 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -16803,7 +16779,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *240
+        - *238
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -16854,16 +16830,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &241 !ruby/object:RPG::MoveCommand
+          - &239 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &242 !ruby/object:RPG::MoveCommand
+          - &240 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &243 !ruby/object:RPG::MoveCommand
+          - &241 !ruby/object:RPG::MoveCommand
             code: 2
             parameters: []
-          - &244 !ruby/object:RPG::MoveCommand
+          - &242 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -16875,6 +16851,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *239
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *240
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *241
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -16882,23 +16868,13 @@ events:
         parameters:
         - *242
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *243
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *244
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &245 !ruby/object:RPG::MoveCommand
+          - &243 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -16910,7 +16886,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *245
+        - *243
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -17047,16 +17023,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &246 !ruby/object:RPG::MoveCommand
+          - &244 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &247 !ruby/object:RPG::MoveCommand
+          - &245 !ruby/object:RPG::MoveCommand
             code: 2
             parameters: []
-          - &248 !ruby/object:RPG::MoveCommand
+          - &246 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &249 !ruby/object:RPG::MoveCommand
+          - &247 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -17068,6 +17044,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *244
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *245
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *246
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -17075,23 +17061,13 @@ events:
         parameters:
         - *247
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *248
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *249
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &250 !ruby/object:RPG::MoveCommand
+          - &248 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -17103,7 +17079,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *250
+        - *248
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -17346,16 +17322,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &251 !ruby/object:RPG::MoveCommand
+          - &249 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &252 !ruby/object:RPG::MoveCommand
+          - &250 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &253 !ruby/object:RPG::MoveCommand
+          - &251 !ruby/object:RPG::MoveCommand
             code: 3
             parameters: []
-          - &254 !ruby/object:RPG::MoveCommand
+          - &252 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -17367,6 +17343,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *249
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *250
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *251
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -17374,23 +17360,13 @@ events:
         parameters:
         - *252
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *253
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *254
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &255 !ruby/object:RPG::MoveCommand
+          - &253 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -17402,7 +17378,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *255
+        - *253
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -17539,16 +17515,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &256 !ruby/object:RPG::MoveCommand
+          - &254 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &257 !ruby/object:RPG::MoveCommand
+          - &255 !ruby/object:RPG::MoveCommand
             code: 3
             parameters: []
-          - &258 !ruby/object:RPG::MoveCommand
+          - &256 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &259 !ruby/object:RPG::MoveCommand
+          - &257 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -17560,6 +17536,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *254
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *255
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *256
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -17567,23 +17553,13 @@ events:
         parameters:
         - *257
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *258
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *259
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &260 !ruby/object:RPG::MoveCommand
+          - &258 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -17595,7 +17571,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *260
+        - *258
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -17646,16 +17622,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &261 !ruby/object:RPG::MoveCommand
+          - &259 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &262 !ruby/object:RPG::MoveCommand
+          - &260 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &263 !ruby/object:RPG::MoveCommand
+          - &261 !ruby/object:RPG::MoveCommand
             code: 2
             parameters: []
-          - &264 !ruby/object:RPG::MoveCommand
+          - &262 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -17667,6 +17643,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *259
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *260
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *261
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -17674,23 +17660,13 @@ events:
         parameters:
         - *262
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *263
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *264
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &265 !ruby/object:RPG::MoveCommand
+          - &263 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -17702,7 +17678,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *265
+        - *263
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -17839,16 +17815,16 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &266 !ruby/object:RPG::MoveCommand
+          - &264 !ruby/object:RPG::MoveCommand
             code: 37
             parameters: []
-          - &267 !ruby/object:RPG::MoveCommand
+          - &265 !ruby/object:RPG::MoveCommand
             code: 2
             parameters: []
-          - &268 !ruby/object:RPG::MoveCommand
+          - &266 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
-          - &269 !ruby/object:RPG::MoveCommand
+          - &267 !ruby/object:RPG::MoveCommand
             code: 38
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -17860,6 +17836,16 @@ events:
         code: 509
         indent: 1
         parameters:
+        - *264
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *265
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
         - *266
       - !ruby/object:RPG::EventCommand
         code: 509
@@ -17867,23 +17853,13 @@ events:
         parameters:
         - *267
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *268
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 1
-        parameters:
-        - *269
-      - !ruby/object:RPG::EventCommand
         code: 209
         indent: 1
         parameters:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &270 !ruby/object:RPG::MoveCommand
+          - &268 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -17895,7 +17871,7 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *270
+        - *268
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 1
@@ -18107,7 +18083,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &271 !ruby/object:RPG::MoveCommand
+          - &269 !ruby/object:RPG::MoveCommand
             code: 20
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -18119,7 +18095,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *271
+        - *269
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 2
@@ -18163,7 +18139,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &272 !ruby/object:RPG::MoveCommand
+          - &270 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
@@ -18176,7 +18152,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *272
+        - *270
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -18350,10 +18326,10 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &273 !ruby/object:RPG::MoveCommand
+          - &271 !ruby/object:RPG::MoveCommand
             code: 39
             parameters: []
-          - &274 !ruby/object:RPG::MoveCommand
+          - &272 !ruby/object:RPG::MoveCommand
             code: 18
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -18365,12 +18341,12 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *273
+        - *271
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
         parameters:
-        - *274
+        - *272
       - !ruby/object:RPG::EventCommand
         code: 355
         indent: 0
@@ -18393,7 +18369,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &275 !ruby/object:RPG::MoveCommand
+          - &273 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 255
@@ -18406,7 +18382,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *275
+        - *273
       - !ruby/object:RPG::EventCommand
         code: 106
         indent: 0
@@ -18474,7 +18450,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &276 !ruby/object:RPG::MoveCommand
+          - &274 !ruby/object:RPG::MoveCommand
             code: 20
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -18486,7 +18462,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *276
+        - *274
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 2
@@ -18515,7 +18491,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &277 !ruby/object:RPG::MoveCommand
+          - &275 !ruby/object:RPG::MoveCommand
             code: 40
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -18527,7 +18503,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *277
+        - *275
       - !ruby/object:RPG::EventCommand
         code: 106
         indent: 0

--- a/Data/Map013.rxdata.yml
+++ b/Data/Map013.rxdata.yml
@@ -9679,36 +9679,29 @@ events:
         - !ruby/object:RPG::MoveRoute
           list:
           - &50 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_on
-              pitch: 100
-              volume: 80
-          - &51 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 3
-          - &52 !ruby/object:RPG::MoveCommand
+          - &51 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 8
-          - &53 !ruby/object:RPG::MoveCommand
+          - &52 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
-          - &54 !ruby/object:RPG::MoveCommand
+          - &53 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
-          - &55 !ruby/object:RPG::MoveCommand
+          - &54 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12)
-          - &56 !ruby/object:RPG::MoveCommand
+          - &55 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
@@ -9748,11 +9741,6 @@ events:
         parameters:
         - *55
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *56
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -9768,37 +9756,30 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &57 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_off
-              pitch: 100
-              volume: 80
-          - &58 !ruby/object:RPG::MoveCommand
+          - &56 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
+          - &57 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &58 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
           - &59 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
           - &60 !ruby/object:RPG::MoveCommand
-            code: 45
-            parameters:
-            - animate_from_charset([1],12)
-          - &61 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 12
-          - &62 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 0
-          - &63 !ruby/object:RPG::MoveCommand
+          - &61 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 4
@@ -9807,6 +9788,11 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *56
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -9832,16 +9818,6 @@ events:
         indent: 0
         parameters:
         - *61
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *62
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *63
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0

--- a/Data/Map014.rxdata.yml
+++ b/Data/Map014.rxdata.yml
@@ -2927,36 +2927,29 @@ events:
         - !ruby/object:RPG::MoveRoute
           list:
           - &11 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_on
-              pitch: 100
-              volume: 80
-          - &12 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 3
-          - &13 !ruby/object:RPG::MoveCommand
+          - &12 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 8
-          - &14 !ruby/object:RPG::MoveCommand
+          - &13 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
-          - &15 !ruby/object:RPG::MoveCommand
+          - &14 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
-          - &16 !ruby/object:RPG::MoveCommand
+          - &15 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12)
-          - &17 !ruby/object:RPG::MoveCommand
+          - &16 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
@@ -2996,11 +2989,6 @@ events:
         parameters:
         - *16
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *17
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -3016,37 +3004,30 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &18 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_off
-              pitch: 100
-              volume: 80
-          - &19 !ruby/object:RPG::MoveCommand
+          - &17 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
           - &20 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
           - &21 !ruby/object:RPG::MoveCommand
-            code: 45
-            parameters:
-            - animate_from_charset([1],12)
-          - &22 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 12
-          - &23 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 0
-          - &24 !ruby/object:RPG::MoveCommand
+          - &22 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 4
@@ -3055,6 +3036,11 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *17
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -3080,16 +3066,6 @@ events:
         indent: 0
         parameters:
         - *22
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *23
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *24
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -4260,13 +4236,13 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &25 !ruby/object:RPG::MoveCommand
+          - &23 !ruby/object:RPG::MoveCommand
             code: 36
             parameters: []
-          - &26 !ruby/object:RPG::MoveCommand
+          - &24 !ruby/object:RPG::MoveCommand
             code: 25
             parameters: []
-          - &27 !ruby/object:RPG::MoveCommand
+          - &25 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 5
@@ -4279,17 +4255,17 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *25
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *26
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *27
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -4333,10 +4309,10 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &28 !ruby/object:RPG::MoveCommand
+          - &26 !ruby/object:RPG::MoveCommand
             code: 13
             parameters: []
-          - &29 !ruby/object:RPG::MoveCommand
+          - &27 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 5
@@ -4349,12 +4325,12 @@ events:
         code: 509
         indent: 1
         parameters:
-        - *28
+        - *26
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 1
         parameters:
-        - *29
+        - *27
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 1
@@ -4374,16 +4350,16 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &30 !ruby/object:RPG::MoveCommand
+          - &28 !ruby/object:RPG::MoveCommand
             code: 3
             parameters: []
-          - &31 !ruby/object:RPG::MoveCommand
+          - &29 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
-          - &32 !ruby/object:RPG::MoveCommand
+          - &30 !ruby/object:RPG::MoveCommand
             code: 16
             parameters: []
-          - &33 !ruby/object:RPG::MoveCommand
+          - &31 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 5
@@ -4396,22 +4372,22 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *30
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
         parameters:
         - *31
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *32
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *33
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -4617,13 +4593,13 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &34 !ruby/object:RPG::MoveCommand
+          - &32 !ruby/object:RPG::MoveCommand
             code: 36
             parameters: []
-          - &35 !ruby/object:RPG::MoveCommand
+          - &33 !ruby/object:RPG::MoveCommand
             code: 25
             parameters: []
-          - &36 !ruby/object:RPG::MoveCommand
+          - &34 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 15
@@ -4636,17 +4612,17 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *34
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *35
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *36
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -4670,13 +4646,13 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &37 !ruby/object:RPG::MoveCommand
+          - &35 !ruby/object:RPG::MoveCommand
             code: 19
             parameters: []
-          - &38 !ruby/object:RPG::MoveCommand
+          - &36 !ruby/object:RPG::MoveCommand
             code: 35
             parameters: []
-          - &39 !ruby/object:RPG::MoveCommand
+          - &37 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 15
@@ -4689,17 +4665,17 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *35
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *36
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *37
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *38
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *39
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -4951,13 +4927,13 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &40 !ruby/object:RPG::MoveCommand
+          - &38 !ruby/object:RPG::MoveCommand
             code: 36
             parameters: []
-          - &41 !ruby/object:RPG::MoveCommand
+          - &39 !ruby/object:RPG::MoveCommand
             code: 25
             parameters: []
-          - &42 !ruby/object:RPG::MoveCommand
+          - &40 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 15
@@ -4970,17 +4946,17 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *38
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *39
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *40
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *41
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *42
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -5002,14 +4978,14 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &43 !ruby/object:RPG::MoveCommand
+          - &41 !ruby/object:RPG::MoveCommand
             code: 17
             parameters: []
-          - &44 !ruby/object:RPG::MoveCommand
+          - &42 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 15
-          - &45 !ruby/object:RPG::MoveCommand
+          - &43 !ruby/object:RPG::MoveCommand
             code: 35
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -5021,17 +4997,17 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *41
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *42
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *43
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *44
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *45
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0

--- a/Data/Map015.rxdata.yml
+++ b/Data/Map015.rxdata.yml
@@ -1,5 +1,4 @@
----
-!ruby/object:RPG::Map
+--- !ruby/object:RPG::Map
 autoplay_bgm: true
 autoplay_bgs: false
 bgm: !ruby/object:RPG::AudioFile
@@ -7,7 +6,7 @@ bgm: !ruby/object:RPG::AudioFile
   pitch: 100
   volume: 100
 bgs: !ruby/object:RPG::AudioFile
-  name: ""
+  name: ''
   pitch: 100
   volume: 100
 data: !ruby/object:Table
@@ -216,600 +215,600 @@ events:
     name: !binary |-
       wqcgd2FycA==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Warp-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Warp-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 44
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Activating this self switch will play the descending
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - animation on the destination map.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",15,map_id = 3)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 3
+        - 28
+        - 43
+        - 6
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 222
+        indent: 0
+        parameters:
+        - ''
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 44
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Activating this self switch will play the descending
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - animation on the destination map.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",15,map_id = 3)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 3
-              - 28
-              - 43
-              - 6
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 222
-            indent: 0
-            parameters:
-              - ""
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
-            - !ruby/object:RPG::MoveCommand
-              code: 15
-              parameters:
-                - 960
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 3
-        step_anime: false
-        through: true
-        trigger: 2
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - animate_from_charset([0,1,2,3],80,reverse:false,repeat:true)
+        - !ruby/object:RPG::MoveCommand
+          code: 15
+          parameters:
+          - 960
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 3
+      step_anime: false
+      through: true
+      trigger: 2
+      walk_anime: false
     x: 35
     y: 16
   10: !ruby/object:RPG::Event
     id: 10
     name: Move follower
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Cowgirl
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 0 I can teach a little trick to following Pokémon.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the Follow-me system is enabled
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 19
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Initializing the @follower variable, that will stock the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - follower, whether it is in Let's Go mode or HGSS mode
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - The @followers variable stores the humans AND PKMN
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - followers
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - fm = Yuki::FollowMe
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "@follower = fm.in_lets_go_mode? ? fm.player_pokemon_lets_go_entity[0] :
-                fm.player_pokemon_entities[0]"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "@followers = fm.follower_entities"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - !binary |-
-                Q2hlY2tpbmcgaWYgdGhlcmUncyBtb3JlIHRoYW4gMSBmb2xsb3dpbmcgUG9rw6ltb24=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - !binary |-
-                YW5kIGlmIHRoZSBmb2xsb3dpbmcgZW50aXR5IGlzbid0IHRoZSBmaXJzdCBmb2xsb3dpbmcgUG9rw6ltb24=
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 12
-              - gp.follower.is_a?(Game_Event) || @followers.size != 1 || @followers[0] !=
-                @follower
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 1 But only one Pokémon would have to follow you...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 2 You can ask the Pokéfan seated on the right to change the number of
-                following Pokémon and come back!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 3 Check that.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - Creating a dynamic text that will display the name
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - of the follower.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - PFM::Text.set_variable("[POKE]", @follower.name)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - Variable 21 replaces any move applied to the player
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - !binary |-
-                YnkgdGhlIGZvbGxvd2VycyAoMSA9IDFzdCBQb2vDqW1vbiBpbiB0aGUgcGFydHksIGV0Yy4p
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 2
-            parameters:
-              - 21
-              - 21
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 4 [POKE], do a backstep!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - cry_pokemon(@follower.db_symbol)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &1
-                    code: 13
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *1
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 5 Now, jump!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &2
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: SE_Jump
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &3
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &4
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand &5
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: SE_Jump (landing)
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *2
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *3
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *4
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *5
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 6 And now, do a spin!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &6
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &7
-                    code: 15
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &8
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &9
-                    code: 15
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &10
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &11
-                    code: 15
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &12
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *6
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *7
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *8
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *9
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *10
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *11
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *12
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 7 Very good, [POKE]!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 8 Come back.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - cry_pokemon(@follower.db_symbol)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &13
-                    code: 12
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *13
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 2
-            parameters:
-              - 21
-              - 21
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 9 Et voilà!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 10 By changing the \c[5]variable 21\c[0], you can apply the move routes
-                of the player to the selected Pokémon.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 11 Oh, I see you prefer to keep your Pokémon inside their Poké Balls...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "Warning: you must ALWAYS reset the variables at the"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "end of the event with: PFM::Text.reset_variables"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM::Text.reset_variables
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Cowgirl
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 0 I can teach a little trick to following Pokémon.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the Follow-me system is enabled
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 19
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Initializing the @follower variable, that will stock the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - follower, whether it is in Let's Go mode or HGSS mode
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - The @followers variable stores the humans AND PKMN
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - followers
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - fm = Yuki::FollowMe
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "@follower = fm.in_lets_go_mode? ? fm.player_pokemon_lets_go_entity[0] :
+          fm.player_pokemon_entities[0]"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "@followers = fm.follower_entities"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - !binary |-
+          Q2hlY2tpbmcgaWYgdGhlcmUncyBtb3JlIHRoYW4gMSBmb2xsb3dpbmcgUG9rw6ltb24=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - !binary |-
+          YW5kIGlmIHRoZSBmb2xsb3dpbmcgZW50aXR5IGlzbid0IHRoZSBmaXJzdCBmb2xsb3dpbmcgUG9rw6ltb24=
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 12
+        - gp.follower.is_a?(Game_Event) || @followers.size != 1 || @followers[0] !=
+          @follower
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 1 But only one Pokémon would have to follow you...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 2 You can ask the Pokéfan seated on the right to change the number of
+          following Pokémon and come back!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 3 Check that.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - Creating a dynamic text that will display the name
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - of the follower.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - PFM::Text.set_variable("[POKE]", @follower.name)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - Variable 21 replaces any move applied to the player
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - !binary |-
+          YnkgdGhlIGZvbGxvd2VycyAoMSA9IDFzdCBQb2vDqW1vbiBpbiB0aGUgcGFydHksIGV0Yy4p
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 2
+        parameters:
+        - 21
+        - 21
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 4 [POKE], do a backstep!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - cry_pokemon(@follower.db_symbol)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 13
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *1
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 5 Now, jump!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &2 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: SE_Jump
+              pitch: 100
+              volume: 80
+          - &3 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &4 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - &5 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: SE_Jump (landing)
+              pitch: 100
+              volume: 80
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *2
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *3
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *4
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *5
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 6 And now, do a spin!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &6 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &7 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 2
+          - &8 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &9 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 2
+          - &10 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &11 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 2
+          - &12 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *6
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *7
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *8
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *9
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *10
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *11
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *12
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 7 Very good, [POKE]!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 8 Come back.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - cry_pokemon(@follower.db_symbol)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &13 !ruby/object:RPG::MoveCommand
+            code: 12
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *13
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 2
+        parameters:
+        - 21
+        - 21
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 9 Et voilà!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 10 By changing the \c[5]variable 21\c[0], you can apply the move routes
+          of the player to the selected Pokémon.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 11 Oh, I see you prefer to keep your Pokémon inside their Poké Balls...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'Warning: you must ALWAYS reset the variables at the'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'end of the event with: PFM::Text.reset_variables'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM::Text.reset_variables
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 22
     y: 24
   11: !ruby/object:RPG::Event
@@ -817,2134 +816,2134 @@ events:
     name: !binary |-
       wqcgc2VydmVyIG1hY2hpbmU=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Electronics-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Electronics-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 12 A green light flashes across the screen.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - '"animate_from_charset" is set inside the Autonomous Movement'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - section of this event so it's automatically animated.
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'If you want it to loop, you need to specify "repeat: true" and'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - add a waiting time after the script command. The number of
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - waiting frame must be a multiple of animation duration.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 12 A green light flashes across the screen.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - '"animate_from_charset" is set inside the Autonomous Movement'
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - section of this event so it's automatically animated.
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - 'If you want it to loop, you need to specify "repeat: true" and'
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - add a waiting time after the script command. The number of
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - waiting frame must be a multiple of animation duration.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - animate_from_charset([0,1,2],60,repeat:true)
-            - !ruby/object:RPG::MoveCommand
-              code: 15
-              parameters:
-                - 960
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - animate_from_charset([0,1,2],60,repeat:true)
+        - !ruby/object:RPG::MoveCommand
+          code: 15
+          parameters:
+          - 960
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 40
     y: 16
   12: !ruby/object:RPG::Event
     id: 12
     name: Animate from charset
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Scientist-M
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Scientist-M
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 13 The machine right there has a little animated screen.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 14 I installed the \c[5]"animate_from_charset"\c[0] command on it to
+          animate it easily.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 15 You can directly put it inside the autonomous movement settings of
+          an event, but also in a distinct event as well.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 16 Use this command to animate one or several lines of an event's character.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 17 You just need to indicate which lines to animate and the total duration
+          of the animation!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 18 You can even loop the animation (\c[5]"repeat: true"\c[0]) or reverse
+          it (\c[5]"reverse: true"\c[0]).'
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 13 The machine right there has a little animated screen.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 14 I installed the \c[5]"animate_from_charset"\c[0] command on it to
-                animate it easily.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 15 You can directly put it inside the autonomous movement settings of
-                an event, but also in a distinct event as well.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 16 Use this command to animate one or several lines of an event's character.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 17 You just need to indicate which lines to animate and the total duration
-                of the animation!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - '15, 18 You can even loop the animation (\c[5]"repeat: true"\c[0]) or reverse
-                it (\c[5]"reverse: true"\c[0]).'
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 39
     y: 16
   13: !ruby/object:RPG::Event
     id: 13
     name: Runner
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Jogger
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Jogger
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 19 I'm training for a marathon.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 20 My Croagunk is following me because I put the \c[5]nametag "[follow=ID]"\c[0]
+          in its name and I filled in my ID.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 19 I'm training for a marathon.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 20 My Croagunk is following me because I put the \c[5]nametag "[follow=ID]"\c[0]
-                in its name and I filled in my ID.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 1
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 1
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 1
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 4
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 4
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 4
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 1
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 1
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 1
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 4
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 4
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 4
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 36
     y: 21
   14: !ruby/object:RPG::Event
     id: 14
     name: "[follow=13]"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0453"
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0453'
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:croagunk)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 21 Croaaa!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 50
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:croagunk)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 21 Croaaa!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 50
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 35
     y: 21
   15: !ruby/object:RPG::Event
     id: 15
     name: LGPE follow-me
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: Chase
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: Chase
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 29
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 22 Hi!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - If you want, I can make it so the Pokémon that follows you isn't necessarily
+          the first in your Party.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 23 Would you like me to?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 1
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 24 Let me just change a little something...[WAIT 60]
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - There it is!
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 2
+        parameters:
+        - 19
+        - 19
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 2
+        parameters:
+        - 29
+        - 29
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 2
+        parameters:
+        - 19
+        - 19
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 25 Now, you can simply select the Pokémon you want in your Party menu.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 26 Each to their own, after all.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 27 Tired of the "Let's Go" mode?
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - I can disable it, if you want.
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 1
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 28 Done!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - If you want to enable the followers, come see me or the Pokéfan just in
+          front of me.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - Reseting the variable that stores which Pokemon
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - is the follower in Let's Go mode
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - "$storage.lets_go_follower = nil"
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 2
+        parameters:
+        - 29
+        - 29
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 2
+        parameters:
+        - 19
+        - 19
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 2
+        parameters:
+        - 19
+        - 19
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 29 It's nicer this way, isn't it?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 29
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 22 Hi!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - If you want, I can make it so the Pokémon that follows you isn't necessarily
-                the first in your Party.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 23 Would you like me to?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 1
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 24 Let me just change a little something...[WAIT 60]
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - There it is!
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 2
-            parameters:
-              - 19
-              - 19
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 2
-            parameters:
-              - 29
-              - 29
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 2
-            parameters:
-              - 19
-              - 19
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 25 Now, you can simply select the Pokémon you want in your Party menu.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 26 Each to their own, after all.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 27 Tired of the "Let's Go" mode?
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - I can disable it, if you want.
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 1
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 28 Done!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - If you want to enable the followers, come see me or the Pokéfan just in
-                front of me.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - Reseting the variable that stores which Pokemon
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - is the follower in Let's Go mode
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - "$storage.lets_go_follower = nil"
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 2
-            parameters:
-              - 29
-              - 29
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 2
-            parameters:
-              - 19
-              - 19
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 2
-            parameters:
-              - 19
-              - 19
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 29 It's nicer this way, isn't it?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 27
     y: 23
   16: !ruby/object:RPG::Event
     id: 16
     name: "$Human follower"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Waiter
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Waiter
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 30 I study people's travel habits.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 31 Can I follow you for a while?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 32 I notice you're already followed.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 33 Would you like to keep your Pokémon outside or recall them?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 1
+        parameters:
+        - - 15, 34 Keep outside
+          - 15, 35 Recall
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 0
+        - 15, 34 Keep outside
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 36 Ok!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 1
+        - 15, 35 Recall
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 37 Ok!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 38 Act like if I wasn't there.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Character 0 = player
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - gp.set_follower(get_character(0))
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 39 I'm not a weirdo, I swear!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 30 I study people's travel habits.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 31 Can I follow you for a while?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 32 I notice you're already followed.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 33 Would you like to keep your Pokémon outside or recall them?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 1
-            parameters:
-              - - 15, 34 Keep outside
-                - 15, 35 Recall
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 0
-              - 15, 34 Keep outside
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 36 Ok!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 1
-              - 15, 35 Recall
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 37 Ok!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 38 Act like if I wasn't there.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Character 0 = player
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - gp.set_follower(get_character(0))
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 39 I'm not a weirdo, I swear!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - DO NOT FORGET THE OTHER EVENT
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(right above this one)"
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - ''
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - Do not forget to set this page on "through",
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - or you'll be blocked by the follower
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 26
+        - 26
+        - 0
+        - 2
+        - 0
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 40 Hmm... Very interesting.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 1
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 41 Oh! I wouldn't have done it that way.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 2
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 42 Fascinating!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 3
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 43 What a funny trajectory!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 4
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 44 Oh? Act like if I wasn't there.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 45 Phew, what a stride!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 46 Do you want to stop there?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 47 I'll go back to my spot, then.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 231
+        indent: 1
+        parameters:
+        - 50
+        - black
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 1
+        parameters:
+        - 50
+        - 10
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 26
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - This commands are mandatory when you want
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - to stop the event from following the player
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - gp.reset_follower
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.update
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.return_to_previous_state
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.follower&.move_toward_player
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 0
+        - 0
+        - 18
+        - 16
+        - 8
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 8
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 1
+        parameters:
+        - 50
+        - 10
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 14
+      - !ruby/object:RPG::EventCommand
+        code: 235
+        indent: 1
+        parameters:
+        - 50
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 48 Great, I still have notes to take!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - DO NOT FORGET THE OTHER EVENT
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(right above this one)"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - ""
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - Do not forget to set this page on "through",
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - or you'll be blocked by the follower
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 26
-              - 26
-              - 0
-              - 2
-              - 0
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 40 Hmm... Very interesting.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 1
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 41 Oh! I wouldn't have done it that way.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 2
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 42 Fascinating!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 3
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 43 What a funny trajectory!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 4
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 44 Oh? Act like if I wasn't there.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 45 Phew, what a stride!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 46 Do you want to stop there?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 47 I'll go back to my spot, then.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 231
-            indent: 1
-            parameters:
-              - 50
-              - black
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 1
-            parameters:
-              - 50
-              - 10
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 26
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - This commands are mandatory when you want
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - to stop the event from following the player
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - gp.reset_follower
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.update
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.return_to_previous_state
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.follower&.move_toward_player
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 0
-              - 0
-              - 18
-              - 16
-              - 8
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 8
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 1
-            parameters:
-              - 50
-              - 10
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 14
-          - !ruby/object:RPG::EventCommand
-            code: 235
-            indent: 1
-            parameters:
-              - 50
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 48 Great, I still have notes to take!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 0
+      walk_anime: true
     x: 18
     y: 16
   17: !ruby/object:RPG::Event
     id: 17
     name: Follower check
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - DO NOT FORGET!
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - ''
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - This event will automatically reset the event follower
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - in case you leave the map while event 16 is following you
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gp.follower != ge(16)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - gp.reset_follower
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.return_to_previous_state
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 16
+        - 0
+        - 18
+        - 16
+        - 8
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(false,"A",16)
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - DO NOT FORGET!
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - ""
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - This event will automatically reset the event follower
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - in case you leave the map while event 16 is following you
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gp.follower != ge(16)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - gp.reset_follower
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.return_to_previous_state
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 16
-              - 0
-              - 18
-              - 16
-              - 8
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(false,"A",16)
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 18
     y: 15
   18: !ruby/object:RPG::Event
     id: 18
     name: "$Nuri Yuri"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Book-girl
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Book-girl
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 49 I like hanging out in this place.:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 50 If you answer all my questions, I''ll give you a pretty trinket!:[name=Nuri
+          Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 51 Are you in?:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - 15, 52 Let's go!
+          - 15, 53 Later...
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - 15, 52 Let's go!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Question 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - '15, 54 Question 1:'
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - 'What is the nametag to delete the shadows under an event?:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 1
+        parameters:
+        - - 15, 55 $
+          - 15, 56 *
+          - 15, 57 §
+          - 15, 58 [no_shadow]
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 0
+        - 15, 55 $
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 59 Wrong!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 1
+        - 15, 56 *
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 60 Wrong!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 2
+        - 15, 57 §
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: menu_get
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 61 Correct![WAIT 40]
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Next question.:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 3
+        - 15, 58 [no_shadow]
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 62 Wrong!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Question 2
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - '15, 63 Question 2:'
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - 'How can you change the height of an event?:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 1
+        parameters:
+        - - 15, 64 With a loop and "offset_screen_y"
+          - 15, 65 Nametag [fly]
+          - 15, 66 Set Move Route
+          - 15, 67 It's impossible
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 0
+        - 15, 64 With a loop and "offset_screen_y"
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: menu_get
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 68 Correct![WAIT 40]
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Next question.:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 1
+        - 15, 65 Nametag [fly]
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 69 Wrong!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 2
+        - 15, 66 Set Move Route
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 70 Wrong!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 3
+        - 15, 67 It's impossible
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 71 Hey! We're not slackers!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Question 3
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - '15, 72 Question 3:'
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - 'How many entities can follow you at maximum?:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 1
+        parameters:
+        - - 15, 73 1
+          - 15, 74 2
+          - 15, 75 6
+          - 15, 76 More than 6
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 0
+        - 15, 73 1
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 77 A bit more...
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 1
+        - 15, 74 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 78 Wrong!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 2
+        - 15, 75 6
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 79 Wrong!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 3
+        - 15, 76 More than 6
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: menu_get
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 80 Correct![WAIT 40]
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Next question.:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Question 4
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - '15, 81 Question 4:'
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - 'How can you set the route of a follower without having the player move?:[name=Nuri
+          Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 1
+        parameters:
+        - - 15, 82 Asking them
+          - 15, 83 Changing variable 21
+          - 15, 84 Set Move Route
+          - 15, 85 It's impossible
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 0
+        - 15, 82 Asking them
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 86 What are you saying...?
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 1
+        - 15, 83 Changing variable 21
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: menu_get
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 87 Correct![WAIT 40]
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'You answered perfectly!:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 2
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 2
+        - 15, 84 Set Move Route
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 88 Wrong!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 3
+        - 15, 85 It's impossible
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: computerclose
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 89 Wrong!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - 'Try again...[WAIT 40]:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - 15, 53 Later...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "15, 49 I like hanging out in this place.:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "15, 50 If you answer all my questions, I'll give you a pretty trinket!:[name=Nuri
-                Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "15, 51 Are you in?:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - 15, 52 Let's go!
-                - 15, 53 Later...
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - 15, 52 Let's go!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Question 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - "15, 54 Question 1:"
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - "What is the nametag to delete the shadows under an event?:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 1
-            parameters:
-              - - 15, 55 $
-                - 15, 56 *
-                - 15, 57 §
-                - 15, 58 [no_shadow]
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 0
-              - 15, 55 $
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 59 Wrong!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 1
-              - 15, 56 *
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 60 Wrong!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 2
-              - 15, 57 §
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: menu_get
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 61 Correct![WAIT 40]
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Next question.:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 3
-              - 15, 58 [no_shadow]
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 62 Wrong!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Question 2
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - "15, 63 Question 2:"
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - "How can you change the height of an event?:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 1
-            parameters:
-              - - 15, 64 With a loop and "offset_screen_y"
-                - 15, 65 Nametag [fly]
-                - 15, 66 Set Move Route
-                - 15, 67 It's impossible
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 0
-              - 15, 64 With a loop and "offset_screen_y"
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: menu_get
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 68 Correct![WAIT 40]
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Next question.:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 1
-              - 15, 65 Nametag [fly]
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 69 Wrong!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 2
-              - 15, 66 Set Move Route
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 70 Wrong!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 3
-              - 15, 67 It's impossible
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 71 Hey! We're not slackers!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Question 3
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - "15, 72 Question 3:"
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - "How many entities can follow you at maximum?:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 1
-            parameters:
-              - - 15, 73 1
-                - 15, 74 2
-                - 15, 75 6
-                - 15, 76 More than 6
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 0
-              - 15, 73 1
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 77 A bit more...
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 1
-              - 15, 74 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 78 Wrong!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 2
-              - 15, 75 6
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 79 Wrong!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 3
-              - 15, 76 More than 6
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: menu_get
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 80 Correct![WAIT 40]
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Next question.:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Question 4
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - "15, 81 Question 4:"
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - "How can you set the route of a follower without having the player move?:[name=Nuri
-                Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 1
-            parameters:
-              - - 15, 82 Asking them
-                - 15, 83 Changing variable 21
-                - 15, 84 Set Move Route
-                - 15, 85 It's impossible
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 0
-              - 15, 82 Asking them
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 86 What are you saying...?
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 1
-              - 15, 83 Changing variable 21
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: menu_get
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 87 Correct![WAIT 40]
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "You answered perfectly!:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 2
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 2
-              - 15, 84 Set Move Route
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 88 Wrong!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 3
-              - 15, 85 It's impossible
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: computerclose
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 89 Wrong!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - "Try again...[WAIT 40]:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - 15, 53 Later...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 90 Congratulations! You answered all my questions.:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - !binary |-
+          VHUgYXMgcsOpcG9uZHUgw6AgdG91dGVzIG1lcyBxdWVzdGlvbnMu
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 91 They weren''t super hard, but I can see you spoke to everybody in
+          this room.:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 92 Here''s the present I promised you.:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - give_item(:intriguing_stone)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 93 I believe SirMalo collects these kind of odd rocks.:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 94 You should go talk to him in the Tower''s Hall!:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "15, 90 Congratulations! You answered all my questions.:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - !binary |-
-                VHUgYXMgcsOpcG9uZHUgw6AgdG91dGVzIG1lcyBxdWVzdGlvbnMu
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "15, 91 They weren't super hard, but I can see you spoke to everybody in
-                this room.:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "15, 92 Here's the present I promised you.:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - give_item(:intriguing_stone)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "15, 93 I believe SirMalo collects these kind of odd rocks.:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "15, 94 You should go talk to him in the Tower's Hall!:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 95 I believe SirMalo collects these kind of odd rocks.:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '15, 96 You should go talk to him in the Tower''s Hall!:[name=Nuri Yuri]:'
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "15, 95 I believe SirMalo collects these kind of odd rocks.:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "15, 96 You should go talk to him in the Tower's Hall!:[name=Nuri Yuri]:"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 46
     y: 16
   19: !ruby/object:RPG::Event
     id: 19
     name: "[sprite=off] Mug"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 97 As this mug doesn't need to have an event graphics, its name has
+          the nametag \c[5]"[sprite=off]"\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 97 As this mug doesn't need to have an event graphics, its name has
-                the nametag \c[5]"[sprite=off]"\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 42
     y: 23
   2: !ruby/object:RPG::Event
@@ -2952,838 +2951,838 @@ events:
     name: !binary |-
       wqcgZWxldmF0b3IgZG9vcg==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 242
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &14
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &15
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &16
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &17
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &18
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *14
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *15
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *16
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *17
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *18
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable tells the game from which floor the playe came inside the
-                elevator.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 12
-              - 12
-              - 16
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 242
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &19
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &20
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &21
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &22
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &23
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *19
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *20
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *21
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *22
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *23
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &14 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &15 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &16 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &17 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The animation will play in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *14
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *15
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *16
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *17
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *18
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable tells the game from which floor the playe came inside the
+          elevator.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 12
+        - 12
+        - 16
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &20 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &21 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &22 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &23 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *19
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *20
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *21
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *22
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The animation will play in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 32
     y: 15
   20: !ruby/object:RPG::Event
     id: 20
     name: Psychic
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Psychic
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 98 My Kirlia can teleport objects and people!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 99 It's thanks to its move Teleport, but also with the \c[5]"$game_player.moveto"\c[0]
-                command.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 100 Unlike the basic warping command, \c[5]"moveto"\c[0] doesn't reinitialize
-                the map or the music.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 101 It's quite handy in some situations.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 102 Do you want to try it yourself?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &24
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &25
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *24
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *25
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 103 Kirlia, use Teleport!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - cry_pokemon(:kirlia)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 104 :[name=Kirlia]:Kiii ![WAIT 50]
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 21
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &26
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &27
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *26
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *27
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 105 Kirlia uses \c[1]Teleport\c[0]!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: SE_Warp
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &28
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &29
-                    code: 15
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: true
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *28
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *29
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - When teleporting on the same map, depending on if you
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - want the map and the BGM to be reloaded, either use the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - RMXP teleportation command or the moveto command of
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - "$game_player."
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - "The RMXP command will reset the map and the BGM (the "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - "tone too if you keep the fading parameter) while moveto "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - will just move your character on the same map.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 1
-            parameters:
-              - 16
-              - 0
-              - 18
-              - 16
-              - 8
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - gp.reset_follower
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.return_to_previous_state
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(false,"A",16)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "$game_player.moveto(32, 18)"
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &30
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *30
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 106 Don't you like thrilling sensations?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Psychic
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 98 My Kirlia can teleport objects and people!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 99 It's thanks to its move Teleport, but also with the \c[5]"$game_player.moveto"\c[0]
+          command.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 100 Unlike the basic warping command, \c[5]"moveto"\c[0] doesn't reinitialize
+          the map or the music.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 101 It's quite handy in some situations.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 102 Do you want to try it yourself?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
+          - &24 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - &25 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *25
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 103 Kirlia, use Teleport!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - cry_pokemon(:kirlia)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 104 :[name=Kirlia]:Kiii ![WAIT 50]
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 21
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &26 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &27 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *26
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *27
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 105 Kirlia uses \c[1]Teleport\c[0]!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: SE_Warp
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &28 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &29 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 2
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
           repeat: true
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - When teleporting on the same map, depending on if you
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - want the map and the BGM to be reloaded, either use the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - RMXP teleportation command or the moveto command of
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - "$game_player."
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - 'The RMXP command will reset the map and the BGM (the '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - 'tone too if you keep the fading parameter) while moveto '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - will just move your character on the same map.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 1
+        parameters:
+        - 16
+        - 0
+        - 18
+        - 16
+        - 8
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - gp.reset_follower
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.return_to_previous_state
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(false,"A",16)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - "$game_player.moveto(32, 18)"
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *30
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 106 Don't you like thrilling sensations?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 18
     y: 24
   21: !ruby/object:RPG::Event
     id: 21
     name: Kirlia
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0281"
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0281'
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:kirlia)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 107 :[name=Kirlia]:Kiii ![WAIT 50]
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:kirlia)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 107 :[name=Kirlia]:Kiii ![WAIT 50]
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 18
     y: 25
   3: !ruby/object:RPG::Event
@@ -3791,428 +3790,404 @@ events:
     name: !binary |-
       wqcgQ29tcHV0ZXI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Computer-screen
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &31
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_on
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &32
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &33
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand &34
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &35
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &36
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &37
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *31
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *32
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *33
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *34
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *35
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *36
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *37
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_pc
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &38
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_off
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &39
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &40
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &41
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &42
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &43
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &44
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *38
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *39
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *40
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *41
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *42
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *43
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *44
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Computer-screen
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 3
+          - &32 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - &33 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &34 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &35 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &36 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *31
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *34
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *35
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *36
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_pc
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &37 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &38 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &39 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &40 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &41 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 0
+          - &42 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *37
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *38
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *39
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *40
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *41
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *42
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 29
     y: 16
   4: !ruby/object:RPG::Event
     id: 4
     name: "$ Beauty"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Ace-Trainer-F-01
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Ace-Trainer-F-01
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 108 Hello!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 109 I've got the \c[5]nametag $\c[0] in my event's name, so my graphics
+          stay the same on all the pages of my event.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 110 What do you think about that?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - 15, 111 It's handy
+          - 15, 112 It's useful
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - 15, 111 It's handy
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - 15, 112 It's useful
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 108 Hello!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 109 I've got the \c[5]nametag $\c[0] in my event's name, so my graphics
-                stay the same on all the pages of my event.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 110 What do you think about that?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - 15, 111 It's handy
-                - 15, 112 It's useful
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - 15, 111 It's handy
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - 15, 112 It's useful
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 113 It is! So you don't have to set the graphics each time.
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 113 It is! So you don't have to set the graphics each time.
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 114 It is! So you won't forget to set the graphics on a page...
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 114 It is! So you won't forget to set the graphics on a page...
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 26
     y: 16
   5: !ruby/object:RPG::Event
@@ -4220,886 +4195,886 @@ events:
     name: !binary |-
       wqcgR2hvc3Q=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Ninja
-          direction: 8
-          opacity: 128
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Ninja
+        direction: 8
+        opacity: 128
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 115 I asked my Ghost Pokémon to make me half-transparent like him!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 116 I also used the \c[5]nametag §\c[0] to delete my shadow.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 117 Sheesh!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 115 I asked my Ghost Pokémon to make me half-transparent like him!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 116 I also used the \c[5]nametag §\c[0] to delete my shadow.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 117 Sheesh!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 46
     y: 24
   6: !ruby/object:RPG::Event
     id: 6
     name: Follow-me
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Pokefan-M-02
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Pokefan-M-02
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 29
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 118 I see you enabled the "Let's Go" mode for followers.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 15, 119 If you want to make some manipulations on followers based on the
+          HGSS versions, I need to disable it first.
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - Is it OK for you?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 1
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 120 All right! I disable the system then.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - "$storage.lets_go_follower = nil"
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 2
+        parameters:
+        - 19
+        - 19
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 2
+        parameters:
+        - 29
+        - 29
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 2
+        parameters:
+        - 19
+        - 19
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - Enable
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 121 Very fine.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 0
+        - 19
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 122 So, do your Pokémon enjoy the walk?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 123 Do you want to change somehting?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 2
+        parameters:
+        - - 15, 124 Stop
+          - 15, 125 Change the number
+          - 15, 126 Nothing
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 2
+        parameters:
+        - 0
+        - 15, 124 Stop
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 15, 127 It's up to you.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 15, 128 I put the \c[5]switch 19\c[0] on Off, then.
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 3
+        parameters:
+        - 19
+        - 19
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 3
+        parameters:
+        - 19
+        - 19
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 2
+        parameters:
+        - 1
+        - 15, 125 Change the number
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 15, 129 The more, the merrier, right?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 15, 130 How many following Pokémon would you like?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 3
+        parameters:
+        - - 15, 131 One
+          - 15, 132 Two
+          - 15, 133 Three
+          - 15, 134 The whole party
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 3
+        parameters:
+        - 0
+        - 15, 131 One
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 4
+        parameters:
+        - 19
+        - 19
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 4
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 3
+        parameters:
+        - 1
+        - 15, 132 Two
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 4
+        parameters:
+        - 19
+        - 19
+        - 0
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 4
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 3
+        parameters:
+        - 2
+        - 15, 133 Three
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 4
+        parameters:
+        - 19
+        - 19
+        - 0
+        - 0
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 4
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 3
+        parameters:
+        - 3
+        - 15, 134 The whole party
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 4
+        parameters:
+        - 19
+        - 19
+        - 0
+        - 0
+        - 6
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 4
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 2
+        parameters:
+        - 2
+        - 15, 126 Nothing
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 135 I notice you keep your Pokémon in their Poké Balls...
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 2
+        parameters:
+        - Enable
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 15, 136 Would you like to be followed by the first Pokémon in your Party?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 2
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 2
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 15, 137 Enjoy the fresh air!
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 3
+        parameters:
+        - 19
+        - 19
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 3
+        parameters:
+        - 19
+        - 19
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 15, 138 I just enabled \c[5]switch 19\c[0] and set \c[5]variable 19\c[0]
+          to 1.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 15, 139 Don't forget the \c[5]Yuki::FollowMe.smart_disable \c[0] command
+          to enable or disable the follow-me system dynamically.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 2
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 15, 140 If they're feeling good there, that's the main thing.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 29
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 118 I see you enabled the "Let's Go" mode for followers.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 15, 119 If you want to make some manipulations on followers based on the
-                HGSS versions, I need to disable it first.
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - Is it OK for you?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 1
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 120 All right! I disable the system then.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - "$storage.lets_go_follower = nil"
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 2
-            parameters:
-              - 19
-              - 19
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 2
-            parameters:
-              - 29
-              - 29
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 2
-            parameters:
-              - 19
-              - 19
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - Enable
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 121 Very fine.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 0
-              - 19
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 122 So, do your Pokémon enjoy the walk?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 123 Do you want to change somehting?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 2
-            parameters:
-              - - 15, 124 Stop
-                - 15, 125 Change the number
-                - 15, 126 Nothing
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 2
-            parameters:
-              - 0
-              - 15, 124 Stop
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 15, 127 It's up to you.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 15, 128 I put the \c[5]switch 19\c[0] on Off, then.
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 3
-            parameters:
-              - 19
-              - 19
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 3
-            parameters:
-              - 19
-              - 19
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 2
-            parameters:
-              - 1
-              - 15, 125 Change the number
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 15, 129 The more, the merrier, right?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 15, 130 How many following Pokémon would you like?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 3
-            parameters:
-              - - 15, 131 One
-                - 15, 132 Two
-                - 15, 133 Three
-                - 15, 134 The whole party
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 3
-            parameters:
-              - 0
-              - 15, 131 One
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 4
-            parameters:
-              - 19
-              - 19
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 4
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 3
-            parameters:
-              - 1
-              - 15, 132 Two
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 4
-            parameters:
-              - 19
-              - 19
-              - 0
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 4
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 3
-            parameters:
-              - 2
-              - 15, 133 Three
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 4
-            parameters:
-              - 19
-              - 19
-              - 0
-              - 0
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 4
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 3
-            parameters:
-              - 3
-              - 15, 134 The whole party
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 4
-            parameters:
-              - 19
-              - 19
-              - 0
-              - 0
-              - 6
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 4
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 2
-            parameters:
-              - 2
-              - 15, 126 Nothing
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 135 I notice you keep your Pokémon in their Poké Balls...
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 2
-            parameters:
-              - Enable
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 15, 136 Would you like to be followed by the first Pokémon in your Party?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 2
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 2
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 15, 137 Enjoy the fresh air!
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 3
-            parameters:
-              - 19
-              - 19
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 3
-            parameters:
-              - 19
-              - 19
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 15, 138 I just enabled \c[5]switch 19\c[0] and set \c[5]variable 19\c[0]
-                to 1.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 15, 139 Don't forget the \c[5]Yuki::FollowMe.smart_disable \c[0] command
-                to enable or disable the follow-me system dynamically.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 2
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 15, 140 If they're feeling good there, that's the main thing.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 30
     y: 22
   7: !ruby/object:RPG::Event
     id: 7
     name: "[sprite=off] Mug"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 141 Since this mug's graphics are already on the tileset, it has the
+          nametag \c[5]"[sprite=off]"\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 141 Since this mug's graphics are already on the tileset, it has the
-                nametag \c[5]"[sprite=off]"\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 28
     y: 22
   8: !ruby/object:RPG::Event
     id: 8
     name: Event height
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Juggler
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 142 I train my Tynamo so that it levitates very high.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 143 With its Ability Levitate, it has no weakness!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 144 The technic might look quite complex, but if you read the comments
-                in the event carrefully, you'll get it.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 145 Check that.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &45
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &46
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *45
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *46
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - get_character(9).offset_screen_y = 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Creating a loop where Tynamo is moved up by 4 pixels
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - every 2 frames
-          - !ruby/object:RPG::EventCommand
-            code: 112
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Once Tynamo's height has reached -36, the loop breaks
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 12
-              - get_character(9).offset_screen_y == -36
-          - !ruby/object:RPG::EventCommand
-            code: 113
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - get_character(9).offset_screen_y -= 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 413
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 146 Nice!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:tynamo)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 50
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 147 Now, back down.
-          - !ruby/object:RPG::EventCommand
-            code: 112
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Once Tynamo's height has reached -39, the loop breaks
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 12
-              - get_character(9).offset_screen_y == 0
-          - !ruby/object:RPG::EventCommand
-            code: 113
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - get_character(9).offset_screen_y += 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 413
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &47
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &48
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *47
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *48
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 148 It's a long-term job.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 149 The \c[5]"offset_screen_y"\c[0] coupled with a loop helped me well.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Juggler
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 142 I train my Tynamo so that it levitates very high.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 143 With its Ability Levitate, it has no weakness!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 144 The technic might look quite complex, but if you read the comments
+          in the event carrefully, you'll get it.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 145 Check that.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &43 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - &44 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *43
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *44
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - get_character(9).offset_screen_y = 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Creating a loop where Tynamo is moved up by 4 pixels
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - every 2 frames
+      - !ruby/object:RPG::EventCommand
+        code: 112
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Once Tynamo's height has reached -36, the loop breaks
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 12
+        - get_character(9).offset_screen_y == -36
+      - !ruby/object:RPG::EventCommand
+        code: 113
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - get_character(9).offset_screen_y -= 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 413
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 146 Nice!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:tynamo)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 50
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 147 Now, back down.
+      - !ruby/object:RPG::EventCommand
+        code: 112
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Once Tynamo's height has reached -39, the loop breaks
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 12
+        - get_character(9).offset_screen_y == 0
+      - !ruby/object:RPG::EventCommand
+        code: 113
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - get_character(9).offset_screen_y += 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 413
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &45 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &46 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *45
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *46
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 148 It's a long-term job.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 149 The \c[5]"offset_screen_y"\c[0] coupled with a loop helped me well.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 34
     y: 26
   9: !ruby/object:RPG::Event
     id: 9
     name: Tynamo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0602"
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0602'
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:tynamo)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 15, 150 :[name=Tynamo]:Namo, Namo![WAIT 50]
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:tynamo)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 15, 150 :[name=Tynamo]:Namo, Namo![WAIT 50]
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 35
     y: 26
 height: 64

--- a/Data/Map016.rxdata.yml
+++ b/Data/Map016.rxdata.yml
@@ -4864,36 +4864,29 @@ events:
         - !ruby/object:RPG::MoveRoute
           list:
           - &11 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_on
-              pitch: 100
-              volume: 80
-          - &12 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 3
-          - &13 !ruby/object:RPG::MoveCommand
+          - &12 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 8
-          - &14 !ruby/object:RPG::MoveCommand
+          - &13 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
-          - &15 !ruby/object:RPG::MoveCommand
+          - &14 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
-          - &16 !ruby/object:RPG::MoveCommand
+          - &15 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12)
-          - &17 !ruby/object:RPG::MoveCommand
+          - &16 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
@@ -4933,11 +4926,6 @@ events:
         parameters:
         - *16
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *17
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -4953,37 +4941,30 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &18 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_off
-              pitch: 100
-              volume: 80
-          - &19 !ruby/object:RPG::MoveCommand
+          - &17 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
           - &20 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
           - &21 !ruby/object:RPG::MoveCommand
-            code: 45
-            parameters:
-            - animate_from_charset([1],12)
-          - &22 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 12
-          - &23 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 0
-          - &24 !ruby/object:RPG::MoveCommand
+          - &22 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 4
@@ -4992,6 +4973,11 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *17
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -5017,16 +5003,6 @@ events:
         indent: 0
         parameters:
         - *22
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *23
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *24
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -6171,10 +6147,10 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &25 !ruby/object:RPG::MoveCommand
+          - &23 !ruby/object:RPG::MoveCommand
             code: 36
             parameters: []
-          - &26 !ruby/object:RPG::MoveCommand
+          - &24 !ruby/object:RPG::MoveCommand
             code: 25
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -6186,12 +6162,12 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *25
+        - *23
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
         parameters:
-        - *26
+        - *24
       - !ruby/object:RPG::EventCommand
         code: 101
         indent: 0
@@ -6319,7 +6295,7 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &27 !ruby/object:RPG::MoveCommand
+          - &25 !ruby/object:RPG::MoveCommand
             code: 17
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -6331,7 +6307,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *27
+        - *25
       - !ruby/object:RPG::EventCommand
         code: 123
         indent: 0
@@ -6440,7 +6416,7 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &28 !ruby/object:RPG::MoveCommand
+          - &26 !ruby/object:RPG::MoveCommand
             code: 29
             parameters:
             - 5
@@ -6453,7 +6429,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *28
+        - *26
       - !ruby/object:RPG::EventCommand
         code: 355
         indent: 2
@@ -6471,7 +6447,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &29 !ruby/object:RPG::MoveCommand
+          - &27 !ruby/object:RPG::MoveCommand
             code: 19
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -6483,7 +6459,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *29
+        - *27
       - !ruby/object:RPG::EventCommand
         code: 355
         indent: 2
@@ -6521,7 +6497,7 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &30 !ruby/object:RPG::MoveCommand
+          - &28 !ruby/object:RPG::MoveCommand
             code: 25
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -6533,7 +6509,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *30
+        - *28
       - !ruby/object:RPG::EventCommand
         code: 209
         indent: 2
@@ -6541,7 +6517,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &31 !ruby/object:RPG::MoveCommand
+          - &29 !ruby/object:RPG::MoveCommand
             code: 17
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -6553,7 +6529,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *31
+        - *29
       - !ruby/object:RPG::EventCommand
         code: 101
         indent: 2
@@ -6586,7 +6562,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &32 !ruby/object:RPG::MoveCommand
+          - &30 !ruby/object:RPG::MoveCommand
             code: 19
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -6598,7 +6574,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *32
+        - *30
       - !ruby/object:RPG::EventCommand
         code: 355
         indent: 2
@@ -7184,7 +7160,7 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &33 !ruby/object:RPG::MoveCommand
+          - &31 !ruby/object:RPG::MoveCommand
             code: 25
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -7196,7 +7172,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *33
+        - *31
       - !ruby/object:RPG::EventCommand
         code: 106
         indent: 0
@@ -7219,7 +7195,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &34 !ruby/object:RPG::MoveCommand
+          - &32 !ruby/object:RPG::MoveCommand
             code: 17
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -7231,7 +7207,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *34
+        - *32
       - !ruby/object:RPG::EventCommand
         code: 101
         indent: 0
@@ -7376,7 +7352,7 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &35 !ruby/object:RPG::MoveCommand
+          - &33 !ruby/object:RPG::MoveCommand
             code: 16
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -7388,7 +7364,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *35
+        - *33
       - !ruby/object:RPG::EventCommand
         code: 123
         indent: 0

--- a/Data/Map017.rxdata.yml
+++ b/Data/Map017.rxdata.yml
@@ -7280,36 +7280,29 @@ events:
         - !ruby/object:RPG::MoveRoute
           list:
           - &31 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_on
-              pitch: 100
-              volume: 80
-          - &32 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 3
-          - &33 !ruby/object:RPG::MoveCommand
+          - &32 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 8
-          - &34 !ruby/object:RPG::MoveCommand
+          - &33 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
-          - &35 !ruby/object:RPG::MoveCommand
+          - &34 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
-          - &36 !ruby/object:RPG::MoveCommand
+          - &35 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12)
-          - &37 !ruby/object:RPG::MoveCommand
+          - &36 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
@@ -7349,11 +7342,6 @@ events:
         parameters:
         - *36
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *37
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -7369,37 +7357,30 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &38 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_off
-              pitch: 100
-              volume: 80
-          - &39 !ruby/object:RPG::MoveCommand
+          - &37 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([1],12,reverse:true)
+          - &38 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &39 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
           - &40 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
           - &41 !ruby/object:RPG::MoveCommand
-            code: 45
-            parameters:
-            - animate_from_charset([1],12)
-          - &42 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 12
-          - &43 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 4
             - 0
-          - &44 !ruby/object:RPG::MoveCommand
+          - &42 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 4
@@ -7408,6 +7389,11 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *37
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -7433,16 +7419,6 @@ events:
         indent: 0
         parameters:
         - *42
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *43
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *44
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -7645,7 +7621,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &45 !ruby/object:RPG::MoveCommand
+          - &43 !ruby/object:RPG::MoveCommand
             code: 19
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -7657,7 +7633,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *45
+        - *43
       - !ruby/object:RPG::EventCommand
         code: 106
         indent: 0
@@ -7739,51 +7715,51 @@ events:
         - 11
         - !ruby/object:RPG::MoveRoute
           list:
-          - &46 !ruby/object:RPG::MoveCommand
+          - &44 !ruby/object:RPG::MoveCommand
             code: 14
             parameters:
             - 0
             - 0
-          - &47 !ruby/object:RPG::MoveCommand
+          - &45 !ruby/object:RPG::MoveCommand
             code: 44
             parameters:
             - !ruby/object:RPG::AudioFile
               name: Psycho_Cut_part_1
               pitch: 100
               volume: 80
-          - &48 !ruby/object:RPG::MoveCommand
+          - &46 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 5
-          - &49 !ruby/object:RPG::MoveCommand
+          - &47 !ruby/object:RPG::MoveCommand
             code: 14
             parameters:
             - 0
             - 0
-          - &50 !ruby/object:RPG::MoveCommand
+          - &48 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 20
-          - &51 !ruby/object:RPG::MoveCommand
+          - &49 !ruby/object:RPG::MoveCommand
             code: 32
             parameters: []
-          - &52 !ruby/object:RPG::MoveCommand
+          - &50 !ruby/object:RPG::MoveCommand
             code: 34
             parameters: []
-          - &53 !ruby/object:RPG::MoveCommand
+          - &51 !ruby/object:RPG::MoveCommand
             code: 29
             parameters:
             - 5
+          - &52 !ruby/object:RPG::MoveCommand
+            code: 2
+            parameters: []
+          - &53 !ruby/object:RPG::MoveCommand
+            code: 2
+            parameters: []
           - &54 !ruby/object:RPG::MoveCommand
             code: 2
             parameters: []
           - &55 !ruby/object:RPG::MoveCommand
-            code: 2
-            parameters: []
-          - &56 !ruby/object:RPG::MoveCommand
-            code: 2
-            parameters: []
-          - &57 !ruby/object:RPG::MoveCommand
             code: 44
             parameters:
             - !ruby/object:RPG::AudioFile
@@ -7795,6 +7771,16 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *44
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *45
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -7846,16 +7832,6 @@ events:
         parameters:
         - *55
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *56
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *57
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -7886,25 +7862,25 @@ events:
         - 11
         - !ruby/object:RPG::MoveRoute
           list:
-          - &58 !ruby/object:RPG::MoveCommand
+          - &56 !ruby/object:RPG::MoveCommand
             code: 35
             parameters: []
-          - &59 !ruby/object:RPG::MoveCommand
+          - &57 !ruby/object:RPG::MoveCommand
             code: 14
             parameters:
             - 3
             - 0
-          - &60 !ruby/object:RPG::MoveCommand
+          - &58 !ruby/object:RPG::MoveCommand
             code: 31
             parameters: []
-          - &61 !ruby/object:RPG::MoveCommand
+          - &59 !ruby/object:RPG::MoveCommand
             code: 33
             parameters: []
-          - &62 !ruby/object:RPG::MoveCommand
+          - &60 !ruby/object:RPG::MoveCommand
             code: 29
             parameters:
             - 3
-          - &63 !ruby/object:RPG::MoveCommand
+          - &61 !ruby/object:RPG::MoveCommand
             code: 36
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -7912,6 +7888,16 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *56
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *57
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -7932,16 +7918,6 @@ events:
         indent: 0
         parameters:
         - *61
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *62
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *63
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -7968,37 +7944,48 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &64 !ruby/object:RPG::MoveCommand
+          - &62 !ruby/object:RPG::MoveCommand
             code: 44
             parameters:
             - !ruby/object:RPG::AudioFile
               name: Extreme_Speed
               pitch: 100
               volume: 80
-          - &65 !ruby/object:RPG::MoveCommand
+          - &63 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 6
-          - &66 !ruby/object:RPG::MoveCommand
+          - &64 !ruby/object:RPG::MoveCommand
             code: 29
             parameters:
             - 6
-          - &67 !ruby/object:RPG::MoveCommand
+          - &65 !ruby/object:RPG::MoveCommand
             code: 34
             parameters: []
-          - &68 !ruby/object:RPG::MoveCommand
+          - &66 !ruby/object:RPG::MoveCommand
             code: 32
             parameters: []
-          - &69 !ruby/object:RPG::MoveCommand
+          - &67 !ruby/object:RPG::MoveCommand
             code: 3
             parameters: []
-          - &70 !ruby/object:RPG::MoveCommand
+          - &68 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - npc_raticate_extreme_speed
             - 0
             - 6
             - 1
+          - &69 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 2
+          - &70 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - npc_raticate_extreme_speed
+            - 0
+            - 6
+            - 2
           - &71 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
@@ -8009,23 +7996,12 @@ events:
             - npc_raticate_extreme_speed
             - 0
             - 6
-            - 2
+            - 3
           - &73 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 2
           - &74 !ruby/object:RPG::MoveCommand
-            code: 41
-            parameters:
-            - npc_raticate_extreme_speed
-            - 0
-            - 6
-            - 3
-          - &75 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 2
-          - &76 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
@@ -8034,6 +8010,16 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *62
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *63
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -8090,16 +8076,6 @@ events:
         parameters:
         - *74
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *75
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *76
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -8115,24 +8091,35 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &77 !ruby/object:RPG::MoveCommand
+          - &75 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - moveto(20, 16)
-          - &78 !ruby/object:RPG::MoveCommand
+          - &76 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - npc_raticate_extreme_speed
             - 0
             - 2
             - 1
-          - &79 !ruby/object:RPG::MoveCommand
+          - &77 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 255
-          - &80 !ruby/object:RPG::MoveCommand
+          - &78 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
+          - &79 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 2
+          - &80 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - npc_raticate_extreme_speed
+            - 0
+            - 2
+            - 2
           - &81 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
@@ -8143,27 +8130,16 @@ events:
             - npc_raticate_extreme_speed
             - 0
             - 2
-            - 2
+            - 3
           - &83 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 2
           - &84 !ruby/object:RPG::MoveCommand
-            code: 41
-            parameters:
-            - npc_raticate_extreme_speed
-            - 0
-            - 2
-            - 3
-          - &85 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 2
-          - &86 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
-          - &87 !ruby/object:RPG::MoveCommand
+          - &85 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 6
@@ -8172,6 +8148,16 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *75
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *76
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -8218,16 +8204,6 @@ events:
         parameters:
         - *85
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *86
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *87
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -8250,21 +8226,32 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &88 !ruby/object:RPG::MoveCommand
+          - &86 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - moveto(21, 18)
-          - &89 !ruby/object:RPG::MoveCommand
+          - &87 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - npc_raticate_extreme_speed
             - 0
             - 4
             - 1
-          - &90 !ruby/object:RPG::MoveCommand
+          - &88 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 255
+          - &89 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 2
+          - &90 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - npc_raticate_extreme_speed
+            - 0
+            - 4
+            - 2
           - &91 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
@@ -8275,27 +8262,16 @@ events:
             - npc_raticate_extreme_speed
             - 0
             - 4
-            - 2
+            - 3
           - &93 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 2
           - &94 !ruby/object:RPG::MoveCommand
-            code: 41
-            parameters:
-            - npc_raticate_extreme_speed
-            - 0
-            - 4
-            - 3
-          - &95 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 2
-          - &96 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
-          - &97 !ruby/object:RPG::MoveCommand
+          - &95 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 6
@@ -8304,6 +8280,16 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *86
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *87
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -8345,16 +8331,6 @@ events:
         parameters:
         - *95
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *96
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *97
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -8377,24 +8353,35 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &98 !ruby/object:RPG::MoveCommand
+          - &96 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - moveto(20, 20)
-          - &99 !ruby/object:RPG::MoveCommand
+          - &97 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - npc_raticate_extreme_speed
             - 0
             - 8
             - 1
-          - &100 !ruby/object:RPG::MoveCommand
+          - &98 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 255
-          - &101 !ruby/object:RPG::MoveCommand
+          - &99 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
+          - &100 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 2
+          - &101 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - npc_raticate_extreme_speed
+            - 0
+            - 8
+            - 2
           - &102 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
@@ -8405,27 +8392,16 @@ events:
             - npc_raticate_extreme_speed
             - 0
             - 8
-            - 2
+            - 3
           - &104 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 2
           - &105 !ruby/object:RPG::MoveCommand
-            code: 41
-            parameters:
-            - npc_raticate_extreme_speed
-            - 0
-            - 8
-            - 3
-          - &106 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 2
-          - &107 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 0
-          - &108 !ruby/object:RPG::MoveCommand
+          - &106 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 6
@@ -8434,6 +8410,16 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *96
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *97
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -8480,16 +8466,6 @@ events:
         parameters:
         - *106
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *107
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *108
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -8512,21 +8488,32 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &109 !ruby/object:RPG::MoveCommand
+          - &107 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - moveto(16, 18)
-          - &110 !ruby/object:RPG::MoveCommand
+          - &108 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - npc_raticate_extreme_speed
             - 0
             - 6
             - 3
-          - &111 !ruby/object:RPG::MoveCommand
+          - &109 !ruby/object:RPG::MoveCommand
             code: 42
             parameters:
             - 255
+          - &110 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 2
+          - &111 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - npc_raticate_extreme_speed
+            - 0
+            - 6
+            - 2
           - &112 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
@@ -8537,7 +8524,7 @@ events:
             - npc_raticate_extreme_speed
             - 0
             - 6
-            - 2
+            - 1
           - &114 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
@@ -8545,28 +8532,17 @@ events:
           - &115 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
-            - npc_raticate_extreme_speed
-            - 0
-            - 6
-            - 1
-          - &116 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 2
-          - &117 !ruby/object:RPG::MoveCommand
-            code: 41
-            parameters:
             - '0020'
             - 0
             - 6
             - 0
-          - &118 !ruby/object:RPG::MoveCommand
+          - &116 !ruby/object:RPG::MoveCommand
             code: 31
             parameters: []
-          - &119 !ruby/object:RPG::MoveCommand
+          - &117 !ruby/object:RPG::MoveCommand
             code: 33
             parameters: []
-          - &120 !ruby/object:RPG::MoveCommand
+          - &118 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
@@ -8575,6 +8551,16 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *107
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *108
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -8626,16 +8612,6 @@ events:
         parameters:
         - *118
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *119
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *120
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -8659,13 +8635,13 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &121 !ruby/object:RPG::MoveCommand
+          - &119 !ruby/object:RPG::MoveCommand
             code: 31
             parameters: []
-          - &122 !ruby/object:RPG::MoveCommand
+          - &120 !ruby/object:RPG::MoveCommand
             code: 33
             parameters: []
-          - &123 !ruby/object:RPG::MoveCommand
+          - &121 !ruby/object:RPG::MoveCommand
             code: 29
             parameters:
             - 3
@@ -8678,17 +8654,17 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *119
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *120
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *121
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *122
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *123
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -8732,7 +8708,7 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &124 !ruby/object:RPG::MoveCommand
+          - &122 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - npc_raticate_psyko
@@ -8748,7 +8724,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *124
+        - *122
       - !ruby/object:RPG::EventCommand
         code: 355
         indent: 0
@@ -8771,7 +8747,7 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &125 !ruby/object:RPG::MoveCommand
+          - &123 !ruby/object:RPG::MoveCommand
             code: 33
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -8783,7 +8759,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *125
+        - *123
       - !ruby/object:RPG::EventCommand
         code: 112
         indent: 0
@@ -8824,7 +8800,7 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &126 !ruby/object:RPG::MoveCommand
+          - &124 !ruby/object:RPG::MoveCommand
             code: 24
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -8836,7 +8812,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *126
+        - *124
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 2
@@ -8908,7 +8884,7 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &127 !ruby/object:RPG::MoveCommand
+          - &125 !ruby/object:RPG::MoveCommand
             code: 24
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -8920,7 +8896,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *127
+        - *125
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 2
@@ -8982,7 +8958,7 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &128 !ruby/object:RPG::MoveCommand
+          - &126 !ruby/object:RPG::MoveCommand
             code: 24
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -8994,7 +8970,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *128
+        - *126
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 2
@@ -9056,7 +9032,7 @@ events:
         - 10
         - !ruby/object:RPG::MoveRoute
           list:
-          - &129 !ruby/object:RPG::MoveCommand
+          - &127 !ruby/object:RPG::MoveCommand
             code: 24
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9068,7 +9044,7 @@ events:
         code: 509
         indent: 2
         parameters:
-        - *129
+        - *127
       - !ruby/object:RPG::EventCommand
         code: 0
         indent: 2
@@ -9250,7 +9226,7 @@ events:
         - 9
         - !ruby/object:RPG::MoveRoute
           list:
-          - &130 !ruby/object:RPG::MoveCommand
+          - &128 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9262,7 +9238,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *130
+        - *128
       - !ruby/object:RPG::EventCommand
         code: 101
         indent: 0
@@ -9370,13 +9346,13 @@ events:
         - 7
         - !ruby/object:RPG::MoveRoute
           list:
+          - &129 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &130 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
           - &131 !ruby/object:RPG::MoveCommand
-            code: 1
-            parameters: []
-          - &132 !ruby/object:RPG::MoveCommand
-            code: 1
-            parameters: []
-          - &133 !ruby/object:RPG::MoveCommand
             code: 1
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9388,17 +9364,17 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *129
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *130
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *131
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *132
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *133
       - !ruby/object:RPG::EventCommand
         code: 106
         indent: 0
@@ -9421,7 +9397,7 @@ events:
         - 7
         - !ruby/object:RPG::MoveRoute
           list:
-          - &134 !ruby/object:RPG::MoveCommand
+          - &132 !ruby/object:RPG::MoveCommand
             code: 18
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9433,7 +9409,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *134
+        - *132
       - !ruby/object:RPG::EventCommand
         code: 101
         indent: 0
@@ -9463,13 +9439,13 @@ events:
         - 7
         - !ruby/object:RPG::MoveRoute
           list:
+          - &133 !ruby/object:RPG::MoveCommand
+            code: 3
+            parameters: []
+          - &134 !ruby/object:RPG::MoveCommand
+            code: 3
+            parameters: []
           - &135 !ruby/object:RPG::MoveCommand
-            code: 3
-            parameters: []
-          - &136 !ruby/object:RPG::MoveCommand
-            code: 3
-            parameters: []
-          - &137 !ruby/object:RPG::MoveCommand
             code: 3
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9481,17 +9457,17 @@ events:
         code: 509
         indent: 0
         parameters:
+        - *133
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *134
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
         - *135
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *136
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *137
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -9510,10 +9486,10 @@ events:
         - 7
         - !ruby/object:RPG::MoveRoute
           list:
-          - &138 !ruby/object:RPG::MoveCommand
+          - &136 !ruby/object:RPG::MoveCommand
             code: 4
             parameters: []
-          - &139 !ruby/object:RPG::MoveCommand
+          - &137 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 15
@@ -9526,12 +9502,12 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *138
+        - *136
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
         parameters:
-        - *139
+        - *137
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
@@ -9549,7 +9525,7 @@ events:
         - -1
         - !ruby/object:RPG::MoveRoute
           list:
-          - &140 !ruby/object:RPG::MoveCommand
+          - &138 !ruby/object:RPG::MoveCommand
             code: 16
             parameters: []
           - !ruby/object:RPG::MoveCommand
@@ -9561,7 +9537,7 @@ events:
         code: 509
         indent: 0
         parameters:
-        - *140
+        - *138
       - !ruby/object:RPG::EventCommand
         code: 106
         indent: 0

--- a/Data/Map017.rxdata.yml
+++ b/Data/Map017.rxdata.yml
@@ -1943,7 +1943,7 @@ events:
         code: 655
         indent: 0
         parameters:
-        - bi.battle_bgm = 'audio/bgm/xy_trainer_battle'
+        - bi.battle_bgm = 'xy_trainer_battle'
       - !ruby/object:RPG::EventCommand
         code: 655
         indent: 0
@@ -5166,7 +5166,7 @@ events:
         code: 655
         indent: 0
         parameters:
-        - bi.battle_bgm = 'audio/bgm/xy_trainer_battle'
+        - bi.battle_bgm = 'xy_trainer_battle'
       - !ruby/object:RPG::EventCommand
         code: 655
         indent: 0
@@ -5177,13 +5177,23 @@ events:
         indent: 0
         parameters:
         - 'party << PFM::Pokemon.generate_from_hash(id: :porygon_z, level: 32, shiny:
-          true, given_name: ''Crash'', trainer_name: ''Marie'')'
+          true, given_name: ''Crash'', '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'trainer_name: ''Marie'')'
       - !ruby/object:RPG::EventCommand
         code: 655
         indent: 0
         parameters:
         - 'party << PFM::Pokemon.generate_from_hash(id: :scizor, level: 33, given_name:
-          ''Razor'', item: :scizorite, trainer_name: ''Marie'')'
+          ''Razor'', item: :scizorite, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'trainer_name: ''Marie'')'
       - !ruby/object:RPG::EventCommand
         code: 655
         indent: 0
@@ -5198,9 +5208,19 @@ events:
         code: 655
         indent: 0
         parameters:
-        - bi.add_party(1, party, 'Marie', 'Scientifique', 'dp_scientist_F', bag, 255,
-          4, "17, 225 I predicted you as easily as I can predict the prime numbers.",
-          "17, 226 Your patterns follows the chaos theory, I couldn't do anything...")
+        - 'bi.add_party(1, party, ''Marie'', ''Scientifique'', ''dp_scientist_F'',
+          bag, 255, 4, "17, 225 I predicted you as easily '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'as I can predict the prime numbers.", "17, 226 Your patterns follows the
+          chaos theory, I couldn''t do '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - anything...")
       - !ruby/object:RPG::EventCommand
         code: 655
         indent: 0
@@ -6184,7 +6204,7 @@ events:
         code: 655
         indent: 0
         parameters:
-        - bi.battle_bgm = 'audio/bgm/teruterusky_zinnia_hgss'
+        - bi.battle_bgm = 'teruterusky_zinnia_hgss'
       - !ruby/object:RPG::EventCommand
         code: 655
         indent: 0

--- a/Data/Map018.rxdata.yml
+++ b/Data/Map018.rxdata.yml
@@ -1299,36 +1299,29 @@ events:
         - !ruby/object:RPG::MoveRoute
           list:
           - &23 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_on
-              pitch: 100
-              volume: 80
-          - &24 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 2
             - 3
-          - &25 !ruby/object:RPG::MoveCommand
+          - &24 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 8
-          - &26 !ruby/object:RPG::MoveCommand
+          - &25 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([0],12,reverse:true)
-          - &27 !ruby/object:RPG::MoveCommand
+          - &26 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
-          - &28 !ruby/object:RPG::MoveCommand
+          - &27 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([0],12)
-          - &29 !ruby/object:RPG::MoveCommand
+          - &28 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
@@ -1368,11 +1361,6 @@ events:
         parameters:
         - *28
       - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *29
-      - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0
         parameters: []
@@ -1388,37 +1376,30 @@ events:
         - 0
         - !ruby/object:RPG::MoveRoute
           list:
-          - &30 !ruby/object:RPG::MoveCommand
-            code: 44
-            parameters:
-            - !ruby/object:RPG::AudioFile
-              name: computer_off
-              pitch: 100
-              volume: 80
-          - &31 !ruby/object:RPG::MoveCommand
+          - &29 !ruby/object:RPG::MoveCommand
             code: 45
             parameters:
             - animate_from_charset([0],12,reverse:true)
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([0],12)
           - &32 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 12
           - &33 !ruby/object:RPG::MoveCommand
-            code: 45
-            parameters:
-            - animate_from_charset([0],12)
-          - &34 !ruby/object:RPG::MoveCommand
-            code: 15
-            parameters:
-            - 12
-          - &35 !ruby/object:RPG::MoveCommand
             code: 41
             parameters:
             - fx_Computer-screen
             - 0
             - 2
             - 0
-          - &36 !ruby/object:RPG::MoveCommand
+          - &34 !ruby/object:RPG::MoveCommand
             code: 15
             parameters:
             - 4
@@ -1427,6 +1408,11 @@ events:
             parameters: []
           repeat: false
           skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *29
       - !ruby/object:RPG::EventCommand
         code: 509
         indent: 0
@@ -1452,16 +1438,6 @@ events:
         indent: 0
         parameters:
         - *34
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *35
-      - !ruby/object:RPG::EventCommand
-        code: 509
-        indent: 0
-        parameters:
-        - *36
       - !ruby/object:RPG::EventCommand
         code: 210
         indent: 0

--- a/Data/Map020.rxdata.yml
+++ b/Data/Map020.rxdata.yml
@@ -1,5 +1,4 @@
----
-!ruby/object:RPG::Map
+--- !ruby/object:RPG::Map
 autoplay_bgm: true
 autoplay_bgs: false
 bgm: !ruby/object:RPG::AudioFile
@@ -7,7 +6,7 @@ bgm: !ruby/object:RPG::AudioFile
   pitch: 100
   volume: 100
 bgs: !ruby/object:RPG::AudioFile
-  name: ""
+  name: ''
   pitch: 100
   volume: 100
 data: !ruby/object:Table
@@ -311,3926 +310,3956 @@ events:
     id: 1
     name: Roaming Legendary
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0380"
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0380'
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 1
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - cry_pokemon(:latias)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - ge.find_path(to:[11, 38])
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(1)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true,"A",6)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 1
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - cry_pokemon(:latias)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - ge.find_path(to:[11, 38])
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(1)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true,"A",6)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0381"
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0381'
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:latios)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - ge(1).find_path(to:[11, 38])
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - wait_event(1)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",6)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:latios)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - ge(1).find_path(to:[11, 38])
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - wait_event(1)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",6)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 11
     y: 45
   10: !ruby/object:RPG::Event
     id: 10
     name: "[offset_y=-16]Metapod"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0011"
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &1
-                    code: 33
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *1
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 11
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &2
-                    code: 33
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &3
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *2
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *3
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:metapod)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 0 :[name=Metapod]:Ziaaaaoum[WAIT 60]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - emotion(:exclamation, -1)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 1 You've awakened the Bug Pokémon!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - You can simply start a double wild battle by setting
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - two foes in the command line.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - call_battle_wild(:metapod, 12, :kakuna, 12)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$game_temp.battle_proc = proc do |n|"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "  $game_map.events[10].opacity = 0"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "  $game_map.events[11].opacity = 0"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - end
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - '"Deleting" the Kakuna event'
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_event_forever(11)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0011'
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 33
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 1
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *1
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 11
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &2 !ruby/object:RPG::MoveCommand
+            code: 33
+            parameters: []
+          - &3 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *2
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *3
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:metapod)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 0 :[name=Metapod]:Ziaaaaoum[WAIT 60]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - emotion(:exclamation, -1)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 1 You've awakened the Bug Pokémon!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - You can simply start a double wild battle by setting
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - two foes in the command line.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - call_battle_wild(:metapod, 12, :kakuna, 12)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$game_temp.battle_proc = proc do |n|"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "  $game_map.events[10].opacity = 0"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "  $game_map.events[11].opacity = 0"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - end
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - '"Deleting" the Kakuna event'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_event_forever(11)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 1
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 15
     y: 30
   11: !ruby/object:RPG::Event
     id: 11
     name: "[offset_y=-16] Kakuna"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0014"
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &4
-                    code: 33
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 10
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &5
-                    code: 33
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &6
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *5
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *6
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:kakuna)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 2 :[name=Kakuna]:...[WAIT 90]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - emotion(:exclamation, -1)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 3 You've awakened the Bug Pokémon!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - You can simply start a double wild battle by setting
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - two foes in the command line.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - call_battle_wild(:metapod, 12, :kakuna, 12)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$game_temp.battle_proc = proc do |n|"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "  $game_map.events[10].opacity = 0"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "  $game_map.events[11].opacity = 0"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - end
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - '"Deleting" the Metapod event'
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_event_forever(10)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0014'
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 3
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 2
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &4 !ruby/object:RPG::MoveCommand
+            code: 33
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 1
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 10
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &5 !ruby/object:RPG::MoveCommand
+            code: 33
+            parameters: []
+          - &6 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *5
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *6
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:kakuna)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 2 :[name=Kakuna]:...[WAIT 90]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - emotion(:exclamation, -1)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 3 You've awakened the Bug Pokémon!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - You can simply start a double wild battle by setting
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - two foes in the command line.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - call_battle_wild(:metapod, 12, :kakuna, 12)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$game_temp.battle_proc = proc do |n|"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "  $game_map.events[10].opacity = 0"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "  $game_map.events[11].opacity = 0"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - end
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - '"Deleting" the Metapod event'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_event_forever(10)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 3
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 2
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 1
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 16
     y: 30
   12: !ruby/object:RPG::Event
     id: 12
     name: Rey Cinematic
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_ranger
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_ranger
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 10
     y: 24
   13: !ruby/object:RPG::Event
     id: 13
     name: The Item Searcher
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Ruin-Maniac
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Ruin-Maniac
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - The custom move route uses "move_random_within_zone",
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - which means the character will move randomly but
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - only within given values (left, right, top, bottom).
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 2
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 4 Do you know how to hide an item and make it searchable using the Dowsing
+          Machine?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 5 To do that, the name of the event needs to start with \c[5]"invisible_"\c[0]
+          or be exactly named \c[5]"OBJ_INVISIBLE"\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 6 Hello, young explorer!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - Are you also interested in the treasures that litters the ground?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 7 Everyone on this Island calls me the "Item Finder," name of which
+          was given to me for the countless hours I spent searching rarities in the
+          wild...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 8 ... with the help of my marvelous Dowsing Machine!
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 12
+        - "$bag.contain_item?(:dowsing_machine)"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 9 ... Wait... You have one too?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 10 You seem to like it.
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - Do you also want to be part of this great hunt?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 11 Here, take this!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 2
+        parameters:
+        - Put it to good use!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - give_item(:dowsing_machine)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 12 Do you know how to hide an item and make it searchable using the
+          Dowsing Machine?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 13 To do that, the name of the said event needs to start with \c[5]"invisible_"\c[0]
+          or be exactly named \c[5]"OBJ_INVISIBLE"\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - The custom move route uses "move_random_within_zone",
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - which means the character will move randomly but
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - only within given values (left, right, top, bottom).
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 2
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 4 Do you know how to hide an item and make it searchable using the Dowsing
-                Machine?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 5 To do that, the name of the event needs to start with \c[5]"invisible_"\c[0]
-                or be exactly named \c[5]"OBJ_INVISIBLE"\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 6 Hello, young explorer!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - Are you also interested in the treasures that litters the ground?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 7 Everyone on this Island calls me the "Item Finder," name of which
-                was given to me for the countless hours I spent searching rarities in the
-                wild...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 8 ... with the help of my marvelous Dowsing Machine!
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 12
-              - "$bag.contain_item?(:dowsing_machine)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 9 ... Wait... You have one too?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 10 You seem to like it.
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - Do you also want to be part of this great hunt?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 11 Here, take this!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 2
-            parameters:
-              - Put it to good use!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - give_item(:dowsing_machine)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 12 Do you know how to hide an item and make it searchable using the
-                Dowsing Machine?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 13 To do that, the name of the said event needs to start with \c[5]"invisible_"\c[0]
-                or be exactly named \c[5]"OBJ_INVISIBLE"\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - move_random_within_zone(25, 29, 32, 34)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - move_random_within_zone(25, 29, 32, 34)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 28
     y: 32
   14: !ruby/object:RPG::Event
     id: 14
     name: invisible_great_ball
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:great_ball)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:great_ball)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 16
     y: 34
   15: !ruby/object:RPG::Event
     id: 15
     name: OBJ_INVISIBLE
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:big_mushroom)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:big_mushroom)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 5
     y: 26
   16: !ruby/object:RPG::Event
     id: 16
     name: Rey the ranger
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_ranger
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_ranger
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We check if we caught the Roaming Eon Pokemon
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - "$pokedex.creature_caught?($user_data[:roaming_eon].db_symbol)"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 14 :[name=Rey]:Did you catch it? Good job! It's really not easy to find
+          an Eon Pokémon with their abilities.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 15 :[name=Rey]:Well, congratulations then, here's my Intriguing Stone!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - give_item(:intriguing_stone)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 16 :[name=Rey]:Well then Maker, seems like we are done!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - We ensure to delete this info from the save as it's now
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - useless
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - "$user_data.delete(:roaming_eon)"
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 12
+        - "$user_data[:roaming_eon].dead?"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 17 :[name=Rey]:Oh, well, seems like someone might have been a little
+          too hard on the poor beast, to the point of defeating it...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 18 :[name=Rey]:These things happen, don't worry.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 19 :[name=Rey]:Time for a magic trick!
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: healing
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 90
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - If the Eon is dead, we revive it properly and register it
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - 'again as a Roaming Pokemon. In the official games, '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - 'this process is generally done when beating the '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - League and entering the Hall of Fame.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - pokemon = $user_data[:roaming_eon]
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 2
+        parameters:
+        - pokemon.cure
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 2
+        parameters:
+        - pokemon.hp = pokemon.max_hp
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 2
+        parameters:
+        - pokemon.skills_set.compact.each { |j| j.pp = j.ppmax }
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 2
+        parameters:
+        - "$wild_battle.add_roaming_pokemon(1, 1, $user_data[:roaming_eon])"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 20 :[name=Rey]:And done! You can go back to it with peace of mind!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 21 :[name=Rey]:Hey \N[1]! So, hopefully not having too much trouble
+          with this little runaway Pokémon hunt?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We check if we caught the Roaming Eon Pokemon
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - "$pokedex.creature_caught?($user_data[:roaming_eon].db_symbol)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 14 :[name=Rey]:Did you catch it? Good job! It's really not easy to find
-                an Eon Pokémon with their abilities.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 15 :[name=Rey]:Well, congratulations then, here's my Intriguing Stone!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - give_item(:intriguing_stone)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 16 :[name=Rey]:Well then Maker, seems like we are done!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - We ensure to delete this info from the save as it's now
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - useless
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "$user_data.delete(:roaming_eon)"
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 12
-              - "$user_data[:roaming_eon].dead?"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 17 :[name=Rey]:Oh, well, seems like someone might have been a little
-                too hard on the poor beast, to the point of defeating it...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 18 :[name=Rey]:These things happen, don't worry.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 19 :[name=Rey]:Time for a magic trick!
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: healing
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 90
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - If the Eon is dead, we revive it properly and register it
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - "again as a Roaming Pokemon. In the official games, "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - "this process is generally done when beating the "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - League and entering the Hall of Fame.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - pokemon = $user_data[:roaming_eon]
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 2
-            parameters:
-              - pokemon.cure
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 2
-            parameters:
-              - pokemon.hp = pokemon.max_hp
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 2
-            parameters:
-              - pokemon.skills_set.compact.each { |j| j.pp = j.ppmax }
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 2
-            parameters:
-              - "$wild_battle.add_roaming_pokemon(1, 1, $user_data[:roaming_eon])"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 20 :[name=Rey]:And done! You can go back to it with peace of mind!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 21 :[name=Rey]:Hey \N[1]! So, hopefully not having too much trouble
-                with this little runaway Pokémon hunt?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - moveto(21, 22)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: false
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_ranger
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - moveto(21, 22)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: false
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_ranger
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 22 :[name=Rey]:Can you believe it?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 23 :[name=Rey]:Who's the other? I can't tell you that, you'll have to
+          find by yourself!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 22 :[name=Rey]:Can you believe it?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 23 :[name=Rey]:Who's the other? I can't tell you that, you'll have to
-                find by yourself!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - moveto(21, 22)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - moveto(21, 22)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 21
     y: 22
   17: !ruby/object:RPG::Event
     id: 17
     name: "$John the Scout"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Bug-Catcher-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Bug-Catcher-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - If you want the most generic way to create a trainer, you
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'can copy paste this event and modify it as you like. '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - Make sure to read the comments in the other pages to
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - know what to change!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Here, change the 4 depending on how many cases this
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - event is able to spot the player.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - trainer_spotted(4)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - 'We change the Trainer Transition to 2 to play the '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - D/P/Pl transition (Gen 4)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 31
+        - 31
+        - 0
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - If you want the most generic way to create a trainer, you
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "can copy paste this event and modify it as you like. "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - Make sure to read the comments in the other pages to
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - know what to change!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Here, change the 4 depending on how many cases this
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - event is able to spot the player.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - trainer_spotted(4)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - "We change the Trainer Transition to 2 to play the "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - D/P/Pl transition (Gen 4)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 31
-              - 31
-              - 0
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'Here we put the trainer eye sequence, which automates:'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - the ! emotion + moving to the player + pre-battle message
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'The eye_bgm: parameters designates the little music'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - playing just before the battle. If you input the ID of the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - trainer in Studio and the trainer has an encounter music
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - setup, PSDK will play it directly.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - trainer_eye_sequence("20, 63 I was waiting to ambush you!",
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'eye_bgm: 13)'
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Here we start the battle with trainer 13 from the project's
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - !binary |-
+          ZGF0YWJhc2UgaW5zaWRlIFBva8OpbW9uIFN0dWRpby4gQ2hhbmdlIHRoZSAxMyB0byB0aGU=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - ID of your trainer in the Studio database of your project.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - As of Studio 2.0, trainers can have their own music. Just
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'add it in the trainers resources in its Studio entry and '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - PSDK will load it directly.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - By default, PSDK disables and enables the needed local
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - switches itself. It'll disable local switch A, and enable local
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - switch B if the player wins. You can change the letters in
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'the disable: and enable: parameters if you need others to'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - be changed, else, just delete these as they are like this by
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - default.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'start_trainer_battle(13, disable: ''A'', enable: ''B'')'
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'Note: This battle doesn''t allow the player to lose. This'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - means the player will be teleported to the latest safe
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - point known to PSDK. To see how to setup a return
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - point, please check the Nurse event and/or the Tower's
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - exit event.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "Here we put the trainer eye sequence, which automates:"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - the ! emotion + moving to the player + pre-battle message
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "The eye_bgm: parameters designates the little music"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - playing just before the battle. If you input the ID of the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - trainer in Studio and the trainer has an encounter music
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - setup, PSDK will play it directly.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - trainer_eye_sequence("20, 63 I was waiting to ambush you!",
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "eye_bgm: 13)"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Here we start the battle with trainer 13 from the project's
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - !binary |-
-                ZGF0YWJhc2UgaW5zaWRlIFBva8OpbW9uIFN0dWRpby4gQ2hhbmdlIHRoZSAxMyB0byB0aGU=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - ID of your trainer in the Studio database of your project.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - As of Studio 2.0, trainers can have their own music. Just
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "add it in the trainers resources in its Studio entry and "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - PSDK will load it directly.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - By default, PSDK disables and enables the needed local
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - switches itself. It'll disable local switch A, and enable local
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - switch B if the player wins. You can change the letters in
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "the disable: and enable: parameters if you need others to"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - be changed, else, just delete these as they are like this by
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - default.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "start_trainer_battle(13, disable: 'A', enable: 'B')"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "Note: This battle doesn't allow the player to lose. This"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - means the player will be teleported to the latest safe
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - point known to PSDK. To see how to setup a return
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - point, please check the Nurse event and/or the Tower's
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - exit event.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 64 Sorry, that was a mean thing to do...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 64 Sorry, that was a mean thing to do...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 25
     y: 31
   2: !ruby/object:RPG::Event
     id: 2
     name: Chansey
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0113"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 24 Chan-chansey!
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &7
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &8
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &9
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &10
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &11
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &12
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &13
-                    code: 20
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &14
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &15
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &16
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &17
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &18
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &19
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &20
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &21
-                    code: 21
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &22
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &23
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &24
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand &25
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &26
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *7
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *8
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *9
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *10
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *11
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *12
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *13
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *14
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *15
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *16
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *17
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *18
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *19
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *20
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *21
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *22
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *23
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *24
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *25
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *26
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: rosa_healpokemon
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 25 Chansey heals your team.[WAIT 90]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM.game_state.heal_party
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:music, 0, 0, oy_offset: 10)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:chansey)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0113'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 24 Chan-chansey!
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &7 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &8 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &9 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &10 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &11 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &12 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &13 !ruby/object:RPG::MoveCommand
+            code: 20
+            parameters: []
+          - &14 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &15 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &16 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &17 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &20 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &21 !ruby/object:RPG::MoveCommand
+            code: 21
+            parameters: []
+          - &22 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &23 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &24 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - &25 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - &26 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *7
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *8
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *9
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *10
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *11
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *12
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *13
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *14
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *15
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *16
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *17
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *18
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *19
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *20
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *21
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *22
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *25
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *26
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: rosa_healpokemon
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 25 Chansey heals your team.[WAIT 90]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM.game_state.heal_party
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:music, 0, 0, oy_offset: 10)'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:chansey)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 24
     y: 30
   3: !ruby/object:RPG::Event
     id: 3
     name: "$Gary the Scout"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Bug-Catcher-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Bug-Catcher-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - This event showcases a battle that is LOSABLE!
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - If you want to copy paste an event for a generic trainer,
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - please check the event "John the Scout" (ID 17).
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We're spotting the player up to 4 cases in front of this
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - event
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - trainer_spotted(4)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 31
+        - 31
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - This event showcases a battle that is LOSABLE!
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - If you want to copy paste an event for a generic trainer,
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - please check the event "John the Scout" (ID 17).
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We're spotting the player up to 4 cases in front of this
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - event
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - trainer_spotted(4)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 31
-              - 31
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'Here we put the trainer eye sequence, which automates:'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - the ! emotion + moving to the player + pre-battle message
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'trainer_eye_sequence("20, 60 Wait, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - !binary |-
+          ZGlkIGEgbGVnZW5kYXJ5IFBva8OpbW9uIGp1c3QgZmx5IGluIA==
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - front of me just now?!",
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'eye_bgm: ''spotted - youngster.ogg'')'
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Here we start the battle with trainer 10 from the project's
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - !binary |-
+          ZGF0YWJhc2UgaW5zaWRlIFBva8OpbW9uIFN0dWRpby4=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - We're allowing the player to lose so
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - they're not sent back to the Pokemon Center
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_trainer_battle(10)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "# Must be done after start_trainer_battle:"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$game_temp.battle_can_lose = true"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 37
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 26 Wondering how I spotted you?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 27 However, I didn't expect to lose...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 28 The next trainers are strong, but you can dodge them if you are fast
+          enough!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 29 Wondering how I spotted you?
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Defeat, we heal the player and set another page for rematch
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 30 By the way, despite the fact I beat you, I will heal your team to
+          save you the trip to the Pokémon Center.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 31 With that said, the next trainers of the Route won't be as kind.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 32 You can however dodge them if you're fast enough!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - "$pokemon_party.heal_party"
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: ROSA_HealPokemon
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - emotion(:interrogation, 0, 0)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 33 Come talk to me if you want to challenge me again!
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+          - &27 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &28 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &29 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *27
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - C
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 31
+        - 31
+        - 0
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "Here we put the trainer eye sequence, which automates:"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - the ! emotion + moving to the player + pre-battle message
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - !binary |-
-                dHJhaW5lcl9leWVfc2VxdWVuY2UoIjIwLCA2MCBXYWl0LCBkaWQgYSBsZWdlbmRhcnkgUG9rw6ltb24ganVzdCBmbHkgaW4gZnJvbnQgb2YgbWUganVzdCBub3c/ISIs
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "eye_bgm: 'audio/bgm/spotted - youngster.ogg')"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Here we start the battle with trainer 10 from the project's
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - !binary |-
-                ZGF0YWJhc2UgaW5zaWRlIFBva8OpbW9uIFN0dWRpby4=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - We're allowing the player to lose so
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - they're not sent back to the Pokemon Center
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_trainer_battle(10)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "# Must be done after start_trainer_battle:"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$game_temp.battle_can_lose = true"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 37
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 26 Wondering how I spotted you?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 27 However, I didn't expect to lose...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 28 The next trainers are strong, but you can dodge them if you are fast
-                enough!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 29 Wondering how I spotted you?
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Defeat, we heal the player and set another page for rematch
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 30 By the way, despite the fact I beat you, I will heal your team to
-                save you the trip to the Pokémon Center.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 31 With that said, the next trainers of the Route won't be as kind.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 32 You can however dodge them if you're fast enough!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "$pokemon_party.heal_party"
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: ROSA_HealPokemon
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - emotion(:interrogation, 0, 0)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 33 Come talk to me if you want to challenge me again!
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &27
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &28
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &29
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: true
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *27
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *28
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *29
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - C
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 31
-              - 31
-              - 0
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 34 In the end, what became of the legendary Pokémon?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 34 In the end, what became of the legendary Pokémon?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: C
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: C
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 35 You want to have a rematch?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 31
+        - 31
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - We setup a specific background for this battle
+      - !ruby/object:RPG::EventCommand
+        code: 204
+        indent: 1
+        parameters:
+        - 2
+        - back_grass
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Here we start the battle with trainer 130 from the project's
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - !binary |-
+          ZGF0YWJhc2UgaW5zaWRlIFBva8OpbW9uIFN0dWRpby4=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - We're allowing the player to lose so
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - they're not sent back to the Pokemon Center
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - start_trainer_battle(130)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "# Must be done after start_trainer_battle:"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "$game_temp.battle_can_lose = true"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 0
+        - 37
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 36 I didn't expect to lose...
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 2
+        parameters:
+        - C
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 2
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 37 I won again, and as you're courageous enough to come for a rematch,
+          I will heal you team once again!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - Defeat, we heal the player
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - "$pokemon_party.heal_party"
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 2
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: ROSA_HealPokemon
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - emotion(:interrogation, 0, 0)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 20, 38 Come talk to me if you want to challenge me again.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 20, 39 No problem, I understand.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 31
+        - 31
+        - 0
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 35 You want to have a rematch?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 31
-              - 31
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - We setup a specific background for this battle
-          - !ruby/object:RPG::EventCommand
-            code: 204
-            indent: 1
-            parameters:
-              - 2
-              - back_grass
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Here we start the battle with trainer 130 from the project's
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - !binary |-
-                ZGF0YWJhc2UgaW5zaWRlIFBva8OpbW9uIFN0dWRpby4=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - We're allowing the player to lose so
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - they're not sent back to the Pokemon Center
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - start_trainer_battle(130)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "# Must be done after start_trainer_battle:"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "$game_temp.battle_can_lose = true"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 0
-              - 37
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 36 I didn't expect to lose...
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 2
-            parameters:
-              - C
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 2
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 37 I won again, and as you're courageous enough to come for a rematch,
-                I will heal you team once again!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - Defeat, we heal the player
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - "$pokemon_party.heal_party"
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 2
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: ROSA_HealPokemon
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - emotion(:interrogation, 0, 0)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 20, 38 Come talk to me if you want to challenge me again.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 20, 39 No problem, I understand.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 31
-              - 31
-              - 0
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 21
     y: 42
   4: !ruby/object:RPG::Event
     id: 4
     name: "$Lucie the Camper"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Camper-F
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Camper-F
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We're spotting the player in a variable amount of cases
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - depending on the side this event's looking at.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - 'player_spotted_directional?(up: 3, down: 4, left: 4, right: 4)'
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 31
+        - 31
+        - 0
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We're spotting the player in a variable amount of cases
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - depending on the side this event's looking at.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - "player_spotted_directional?(up: 3, down: 4, left: 4, right: 4)"
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 31
-              - 31
-              - 0
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 15
-              parameters:
-                - 90
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 15
+          parameters:
+          - 90
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'Here we put the trainer eye sequence, which automates:'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - the ! emotion + moving to the player + pre-battle message
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'trainer_eye_sequence("20, 61 Don''t '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - !binary |-
+          eW91IHRoaW5rIHRoaXMgaHVnZSBQb2vDqW1vbiBpcyBqdXN0IA==
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - too cute?",
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'eye_bgm: ''spotted - lass.ogg'')'
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Here we start the battle with trainer 11 from the project's
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - !binary |-
+          ZGF0YWJhc2UgaW5zaWRlIFBva8OpbW9uIFN0dWRpby4=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - If the player loses, they will be sent to the latest safe point,
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - !binary |-
+          d2hpY2ggaXMgdGhlIFRvd2VyJ3MgUG9rw6ltb24gQ2VudGVyIGluIHRoaXMgY2FzZS4g
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'Please check the Nurse event and/or the Tower''s exit to '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - see how to setup a return point.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_trainer_battle(11)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "Here we put the trainer eye sequence, which automates:"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - the ! emotion + moving to the player + pre-battle message
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - !binary |-
-                dHJhaW5lcl9leWVfc2VxdWVuY2UoIjIwLCA2MSBEb24ndCB5b3UgdGhpbmsgdGhpcyBodWdlIFBva8OpbW9uIGlzIGp1c3QgdG9vIGN1dGU/Iiw=
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "eye_bgm: 'audio/bgm/spotted - lass.ogg')"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Here we start the battle with trainer 11 from the project's
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - !binary |-
-                ZGF0YWJhc2UgaW5zaWRlIFBva8OpbW9uIFN0dWRpby4=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - If the player loses, they will be sent to the latest safe point,
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - !binary |-
-                d2hpY2ggaXMgdGhlIFRvd2VyJ3MgUG9rw6ltb24gQ2VudGVyIGluIHRoaXMgY2FzZS4g
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "Please check the Nurse event and/or the Tower's exit to "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - see how to setup a return point.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_trainer_battle(11)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 40 In the end, what became of the legendary Pokémon?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 40 In the end, what became of the legendary Pokémon?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 19
     y: 35
   5: !ruby/object:RPG::Event
     id: 5
     name: "$Robin the Camper"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Camper-M
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Camper-M
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - The "_rect" at the end of the player_spotted means
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - the trainer will able to spot the player within a rectangle of
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 3x2 tiles and not only in a direct line.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - player_spotted_rect?(3, 2)
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 31
+        - 31
+        - 0
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - The "_rect" at the end of the player_spotted means
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - the trainer will able to spot the player within a rectangle of
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - 3x2 tiles and not only in a direct line.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - player_spotted_rect?(3, 2)
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 31
-              - 31
-              - 0
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 15
-              parameters:
-                - 90
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 15
+          parameters:
+          - 90
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'Here we put the trainer eye sequence, which automates:'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - the ! emotion + moving to the player + pre-battle message
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'trainer_eye_sequence("20, 62 I was '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'just grazed by a huge beast!\nlIt''s '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - !binary |-
+          Y2VydGFpbmx5IGEgcmFyZSBQb2vDqW1vbiEiLA==
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'eye_bgm: ''spotted - youngster.ogg'')'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_trainer_battle(12)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "Here we put the trainer eye sequence, which automates:"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - the ! emotion + moving to the player + pre-battle message
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - !binary |-
-                dHJhaW5lcl9leWVfc2VxdWVuY2UoIjIwLCA2MiBJIHdhcyBqdXN0IGdyYXplZCBieSBhIGh1Z2UgYmVhc3QhXG5sSXQncyBjZXJ0YWlubHkgYSByYXJlIFBva8OpbW9uISIs
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "eye_bgm: 'audio/bgm/spotted - youngster.ogg')"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_trainer_battle(12)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 41 I should refill my Ultra Balls stock...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 41 I should refill my Ultra Balls stock...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 15
     y: 24
   6: !ruby/object:RPG::Event
     id: 6
     name: Roaming Legendary 2
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0380"
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0380'
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:latias)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'ge.find_path(to:[21, 27], tries: :infinity)'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - wait_event(6)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",7)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:latias)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "ge.find_path(to:[21, 27], tries: :infinity)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - wait_event(6)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",7)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0381"
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0381'
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:latios)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'ge.find_path(to:[21, 27], tries: :infinity)'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - wait_event(6)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",7)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:latios)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "ge.find_path(to:[21, 27], tries: :infinity)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - wait_event(6)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",7)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 11
     y: 38
   7: !ruby/object:RPG::Event
     id: 7
     name: Roaming Legendary 3
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0380"
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:latias)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &30
-                    code: 41
-                    parameters:
-                      - ""
-                      - 0
-                      - 2
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *30
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: fleee
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We generate the Latias to make it unique and ensure we
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - will be able to revive it if the player faints it later on
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "@latias = {id: :latias, level: 40, moves:[:ice_beam, :thunder_wave, :roost,
-                :psychic], stats:[31,31,31,31,31,31], bonus:[248, 0, 8, 252, 0, 0], nature:
-                :timid, item: :latiasite}"
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$pokedex.mark_seen(:latias, forced: true)"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We add the generated Latias as a Roaming Pokemon, and
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - we add the Latias to the player's save ($user_data)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pokemon = $wild_battle.add_roaming_pokemon(1, 1, @latias)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$user_data[:roaming_eon] = pokemon"
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0380'
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:latias)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 6
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0381"
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 41
             parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:latios)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 60
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &31
-                    code: 41
-                    parameters:
-                      - ""
-                      - 0
-                      - 2
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *31
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: fleee
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We generate the Latios to make it unique and ensure we
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - will be able to revive it if the player faints it later on
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "@latios = {id: :latios, level: 40, moves:[:draco_meteor, :earthquake, :roost,
-                :psychic], stats:[31,31,31,31,31,31], bonus:[0, 4, 0, 252, 252, 0], nature:
-                :naive, item: :latiosite}"
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$pokedex.mark_seen(:latios, forced: true)"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We add the generated Latios as a Roaming Pokemon, and
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - we add the Latias to the player's save ($user_data)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pokemon = $wild_battle.add_roaming_pokemon(1, 1, @latios)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$user_data[:roaming_eon] = pokemon"
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
+            - ''
+            - 0
+            - 2
+            - 0
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 6
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0380"
-          direction: 8
-          opacity: 0
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *30
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: fleee
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We generate the Latias to make it unique and ensure we
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - will be able to revive it if the player faints it later on
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "@latias = {id: :latias, level: 40, moves:[:ice_beam, :thunder_wave, :roost,
+          :psychic], stats:[31,31,31,31,31,31], bonus:[248, 0, 8, 252, 0, 0], nature:
+          :timid, item: :latiasite}"
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$pokedex.mark_seen(:latias, forced: true)"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We add the generated Latias as a Roaming Pokemon, and
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - we add the Latias to the player's save ($user_data)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pokemon = $wild_battle.add_roaming_pokemon(1, 1, @latias)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$user_data[:roaming_eon] = pokemon"
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - From this page, we refer to the Eon Pokemon as the text
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - variable [POKEMON] and get its info from $user_data
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM::Text.set_variable("[POKEMON]", $user_data[:roaming_eon].name)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true, "A", 12)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - ge(12).find_path(to:[gp.x, gp.y - 1])
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - wait_event(12)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 12
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &32
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *32
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &33
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &34
-                    code: 15
-                    parameters:
-                      - 5
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *33
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *34
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 42 :[name=???]:Hey, did you see that too?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 43 :[name=???]:Sorry, rhetorical question, of course you saw it, as
-                it was guiding you here!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 44 :[name=Rey]:My name's Rey, I'm the titular Ranger of the Island!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "20, 45 :[name=Rey]:In other terms: I help everyone."
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 46 :[name=Rey]:Did you know about me already?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 47 :[name=Rey]:I see, SirMalo talked to you about me, right?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 48 :[name=Rey]:Then you should be the new Maker!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 49 :[name=Rey]:And I deduct that you are doing your tour of the Island
-                to collect the Intriguing Stones...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 50 :[name=Rey]:Of course, I have one on me, but I can't give it to you
-                just like that...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 51 :[name=Rey]:Oh, I know what to do!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "20, 52 :[name=Rey]:Here's the deal I propose to you: you catch the [POKEMON]
-                and show it to me, and I'll give you my Intriguing Stone!"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "20, 53 :[name=Rey]:Honestly, you are winning on every point: you add a
-                super rare Pokémon to your team and you get the Stone."
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 54 :[name=Rey]:Also, in case you were to knock out the poor thing without
-                being able to catch it, come see me and I'll do a bit of magic.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 55 :[name=Rey]:Finally, if you take a look at the \c[5]Map\c[0], you'll
-                be able to easily see where the roaming Pokémon are.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 56 :[name=Rey]:Generally, it likes to hang out around this place and
-                those with encounters in the left wing of the Tower!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 57 :[name=Rey]:So you should be able to find it quite easily.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 58 :[name=Rey]:Alright, go hunting, Maker!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - ge(12).find_path(to:[21, 22])
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - wait_event(12)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_event_forever(12)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true, "A", 16)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - C
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0381'
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:latios)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 60
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - ''
+            - 0
+            - 2
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 6
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: C
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *31
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: fleee
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We generate the Latios to make it unique and ensure we
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - will be able to revive it if the player faints it later on
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "@latios = {id: :latios, level: 40, moves:[:draco_meteor, :earthquake, :roost,
+          :psychic], stats:[31,31,31,31,31,31], bonus:[0, 4, 0, 252, 252, 0], nature:
+          :naive, item: :latiosite}"
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$pokedex.mark_seen(:latios, forced: true)"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We add the generated Latios as a Roaming Pokemon, and
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - we add the Latias to the player's save ($user_data)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pokemon = $wild_battle.add_roaming_pokemon(1, 1, @latios)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$user_data[:roaming_eon] = pokemon"
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0380'
+        direction: 8
+        opacity: 0
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - From this page, we refer to the Eon Pokemon as the text
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - variable [POKEMON] and get its info from $user_data
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM::Text.set_variable("[POKEMON]", $user_data[:roaming_eon].name)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true, "A", 12)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - ge(12).find_path(to:[gp.x, gp.y - 1])
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - wait_event(12)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 12
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &32 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &33 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - &34 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 5
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *34
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 42 :[name=???]:Hey, did you see that too?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 43 :[name=???]:Sorry, rhetorical question, of course you saw it, as
+          it was guiding you here!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 44 :[name=Rey]:My name's Rey, I'm the titular Ranger of the Island!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '20, 45 :[name=Rey]:In other terms: I help everyone.'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 46 :[name=Rey]:Did you know about me already?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 47 :[name=Rey]:I see, SirMalo talked to you about me, right?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 48 :[name=Rey]:Then you should be the new Maker!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 49 :[name=Rey]:And I deduct that you are doing your tour of the Island
+          to collect the Intriguing Stones...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 50 :[name=Rey]:Of course, I have one on me, but I can't give it to you
+          just like that...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 51 :[name=Rey]:Oh, I know what to do!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '20, 52 :[name=Rey]:Here''s the deal I propose to you: you catch the [POKEMON]
+          and show it to me, and I''ll give you my Intriguing Stone!'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '20, 53 :[name=Rey]:Honestly, you are winning on every point: you add a
+          super rare Pokémon to your team and you get the Stone.'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 54 :[name=Rey]:Also, in case you were to knock out the poor thing without
+          being able to catch it, come see me and I'll do a bit of magic.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 55 :[name=Rey]:Finally, if you take a look at the \c[5]Map\c[0], you'll
+          be able to easily see where the roaming Pokémon are.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 56 :[name=Rey]:Generally, it likes to hang out around this place and
+          those with encounters in the left wing of the Tower!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 57 :[name=Rey]:So you should be able to find it quite easily.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 58 :[name=Rey]:Alright, go hunting, Maker!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - ge(12).find_path(to:[21, 22])
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - wait_event(12)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_event_forever(12)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true, "A", 16)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - C
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 6
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: C
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 21
     y: 27
   8: !ruby/object:RPG::Event
     id: 8
     name: Item on ground
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-Pokeball
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-Pokeball
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:full_restore)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:full_restore)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 29
     y: 24
   9: !ruby/object:RPG::Event
     id: 9
     name: Rattata
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0019"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0019'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - The custom move route uses "move_random_within_systemtag",
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - which means the Rattata will move randomly but only
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - on the selected systemtag.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:rattata)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 20, 59 :[name=Rattata]:Krkrkrkr![WAIT 45]
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - call_battle_wild(:rattata, 30)
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 2
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - The custom move route uses "move_random_within_systemtag",
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - which means the Rattata will move randomly but only
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - on the selected systemtag.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:rattata)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 20, 59 :[name=Rattata]:Krkrkrkr![WAIT 45]
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - call_battle_wild(:rattata, 30)
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 2
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - move_random_within_systemtag(GameData::SystemTags::TGrass)
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: true
-        through: false
-        trigger: 2
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - move_random_within_systemtag(GameData::SystemTags::TGrass)
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: true
+      through: false
+      trigger: 2
+      walk_anime: true
     x: 4
     y: 33
 height: 96

--- a/Data/Map021.rxdata.yml
+++ b/Data/Map021.rxdata.yml
@@ -1,5 +1,4 @@
----
-!ruby/object:RPG::Map
+--- !ruby/object:RPG::Map
 autoplay_bgm: true
 autoplay_bgs: false
 bgm: !ruby/object:RPG::AudioFile
@@ -7,7 +6,7 @@ bgm: !ruby/object:RPG::AudioFile
   pitch: 100
   volume: 100
 bgs: !ruby/object:RPG::AudioFile
-  name: ""
+  name: ''
   pitch: 100
   volume: 100
 data: !ruby/object:Table
@@ -210,49 +209,49 @@ events:
     name: !binary |-
       wqdMSUdIVDE=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 16
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 16
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 14
     y: 9
   10: !ruby/object:RPG::Event
@@ -260,197 +259,197 @@ events:
     name: !binary |-
       wqdMSUdIVDEw
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - dynamic_light.started? == false
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This condition ensures the flickering of the light will only
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - happen if the system and the lights are properly initialized
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - dynamic_light.light_sprite(10).nil?
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - We jump to the end of the event
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - SafeLabel
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "@flickering ||= Array.new(120) { rand(0..100) }"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - set_local_variable(0, :flickering_index)
+      - !ruby/object:RPG::EventCommand
+        code: 112
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 12
+        - "@flickering[get_local_variable(:flickering_index)] > 33"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - if dynamic_light.light_sprite(10) && !dynamic_light.light_sprite(10).on
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 2
+        parameters:
+        - "  NuriYuri::DynamicLight.switch_on(10)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 2
+        parameters:
+        - "  NuriYuri::DynamicLight.light_sprite(10).update"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 2
+        parameters:
+        - end
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - if dynamic_light.light_sprite(10) && dynamic_light.light_sprite(10).on
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 2
+        parameters:
+        - "  dynamic_light.switch_off(10)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 2
+        parameters:
+        - end
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - index = get_local_variable(:flickering_index, :add, 1)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - set_local_variable(0, :flickering_index) if index >= 120
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 413
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - SafeLabel
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - dynamic_light.started? == false
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This condition ensures the flickering of the light will only
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - happen if the system and the lights are properly initialized
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - dynamic_light.light_sprite(10).nil?
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - We jump to the end of the event
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - SafeLabel
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "@flickering ||= Array.new(120) { rand(0..100) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - set_local_variable(0, :flickering_index)
-          - !ruby/object:RPG::EventCommand
-            code: 112
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 12
-              - "@flickering[get_local_variable(:flickering_index)] > 33"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - if dynamic_light.light_sprite(10) && !dynamic_light.light_sprite(10).on
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 2
-            parameters:
-              - "  NuriYuri::DynamicLight.switch_on(10)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 2
-            parameters:
-              - "  NuriYuri::DynamicLight.light_sprite(10).update"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 2
-            parameters:
-              - end
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - if dynamic_light.light_sprite(10) && dynamic_light.light_sprite(10).on
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 2
-            parameters:
-              - "  dynamic_light.switch_off(10)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 2
-            parameters:
-              - end
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - index = get_local_variable(:flickering_index, :add, 1)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - set_local_variable(0, :flickering_index) if index >= 120
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 413
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - SafeLabel
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 23
     y: 23
   11: !ruby/object:RPG::Event
@@ -458,46 +457,46 @@ events:
     name: !binary |-
       wqdMSUdIVDEx
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 32
     y: 23
   12: !ruby/object:RPG::Event
@@ -505,46 +504,46 @@ events:
     name: !binary |-
       wqdMSUdIVDEy
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 26
     y: 30
   13: !ruby/object:RPG::Event
@@ -552,683 +551,683 @@ events:
     name: !binary |-
       wqdMSUdIVDEz
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 38
     y: 30
   15: !ruby/object:RPG::Event
     id: 15
     name: TP out
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 6
-              - 6
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &1
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &2
-                    code: 7
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &3
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: Door exit
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *1
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *2
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *3
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 242
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We call the stop_delay command just before the TP to
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - ensure there won't be any weird graphical glitch.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - NuriYuri::DynamicLight.stop_delay
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 19
-              - 33
-              - 26
-              - 6
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &4
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &5
-                    code: 8
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &6
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &7
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *4
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *5
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *6
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *7
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 6
+        - 6
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &2 !ruby/object:RPG::MoveCommand
+            code: 7
+            parameters: []
+          - &3 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: Door exit
+              pitch: 100
+              volume: 80
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *1
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *2
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *3
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 242
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We call the stop_delay command just before the TP to
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - ensure there won't be any weird graphical glitch.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - NuriYuri::DynamicLight.stop_delay
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 19
+        - 33
+        - 26
+        - 6
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &4 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &5 !ruby/object:RPG::MoveCommand
+            code: 8
+            parameters: []
+          - &6 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &7 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *4
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *5
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *6
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *7
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: true
     x: 11
     y: 12
   16: !ruby/object:RPG::Event
     id: 16
     name: Scorbutics
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Veteran-02
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 0 :[name=???]:Now the only thing left is to bind this to that and...
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &8
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &9
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *8
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *9
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &10
-                    code: 14
-                    parameters:
-                      - 0
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *10
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - emotion(:exclamation)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 1 :[name=???]:Are you crazy, scaring people like that without announcing
-                yourself?!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 2 :[name=???]:I almost had a heart attack...
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:nocomment, 0, 34, oy_offset: 10)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 3 :[name=???]:Alright, okay, I'm calm now...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 4 :[name=???]:\N[1]? It does ring a bell...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 5 :[name=Scor]:The name's Scorbutics, but you can call me Scor.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 6 :[name=Scor]:I'm what you might call a "shadow-dev"...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 7 :[name=Scor]:Talking about dark rooms, I hope you like the \c[5]DynamicLight\c[0]?
-                Nuri Yuri made it.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 8 :[name=Scor]:It's a very cool feature of PokémonSDK that lets you
-                create dynamic "lighting", as indicated by its name.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 9 :[name=Scor]:By the way, for an unknown reason, it seems like your
-                light isn't the same size as mine...
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Changing the size of the circle of the player
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - NuriYuri::DynamicLight.light_sprite(0).scale_to(0.6, 30)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 10 :[name=Scor]:Right, now we have the same light size!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 11 :[name=Scor]:On the other hand, all this darkness is fun, but it's
-                tiring my poor eyes.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 12 :[name=Scor]:There's another room to the south-east. Maybe you've
-                already gone there?
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:nocomment, 0, 34, oy_offset: 10)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 13 :[name=Scor]:If you could step aside...
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &11
-                    code: 13
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &12
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &13
-                    code: 13
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *11
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *12
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *13
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "find_path(to: [34, 12])"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - wait_event
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true, 'A', 22)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Veteran-02
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 0 :[name=???]:Now the only thing left is to bind this to that and...
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We verify if the DynamicLight is on. If it is, we check if the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - light index 16 exists (the light attributed to this event). If yes,
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - then we switch off this light and delete the event. If the light
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - isn't initialized yet, we do nothing until it's the case.
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - And if the DynamicLight isn't on, then we delete the event.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - NuriYuri::DynamicLight.started?
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 12
-              - PFM.game_state.nuri_yuri_dynamic_light[14]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 2
-            parameters:
-              - NuriYuri::DynamicLight.switch_off(14)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 2
-            parameters:
-              - NuriYuri::DynamicLight.switch_on(15)
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 2
+          - &8 !ruby/object:RPG::MoveCommand
+            code: 36
             parameters: []
-          - !ruby/object:RPG::EventCommand
+          - &9 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 2
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
           repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *8
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *9
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &10 !ruby/object:RPG::MoveCommand
+            code: 14
+            parameters:
+            - 0
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *10
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - emotion(:exclamation)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 1 :[name=???]:Are you crazy, scaring people like that without announcing
+          yourself?!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 2 :[name=???]:I almost had a heart attack...
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:nocomment, 0, 34, oy_offset: 10)'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 3 :[name=???]:Alright, okay, I'm calm now...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 4 :[name=???]:\N[1]? It does ring a bell...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 5 :[name=Scor]:The name's Scorbutics, but you can call me Scor.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 6 :[name=Scor]:I'm what you might call a "shadow-dev"...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 7 :[name=Scor]:Talking about dark rooms, I hope you like the \c[5]DynamicLight\c[0]?
+          Nuri Yuri made it.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 8 :[name=Scor]:It's a very cool feature of PokémonSDK that lets you
+          create dynamic "lighting", as indicated by its name.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 9 :[name=Scor]:By the way, for an unknown reason, it seems like your
+          light isn't the same size as mine...
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Changing the size of the circle of the player
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - NuriYuri::DynamicLight.light_sprite(0).scale_to(0.6, 30)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 10 :[name=Scor]:Right, now we have the same light size!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 11 :[name=Scor]:On the other hand, all this darkness is fun, but it's
+          tiring my poor eyes.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 12 :[name=Scor]:There's another room to the south-east. Maybe you've
+          already gone there?
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:nocomment, 0, 34, oy_offset: 10)'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 13 :[name=Scor]:If you could step aside...
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &11 !ruby/object:RPG::MoveCommand
+            code: 13
+            parameters: []
+          - &12 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - &13 !ruby/object:RPG::MoveCommand
+            code: 13
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *11
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *12
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *13
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'find_path(to: [34, 12])'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - wait_event
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true, 'A', 22)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We verify if the DynamicLight is on. If it is, we check if the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - light index 16 exists (the light attributed to this event). If yes,
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - then we switch off this light and delete the event. If the light
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - isn't initialized yet, we do nothing until it's the case.
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - And if the DynamicLight isn't on, then we delete the event.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - NuriYuri::DynamicLight.started?
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 12
+        - PFM.game_state.nuri_yuri_dynamic_light[14]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 2
+        parameters:
+        - NuriYuri::DynamicLight.switch_off(14)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 2
+        parameters:
+        - NuriYuri::DynamicLight.switch_on(15)
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: false
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 16
     y: 20
   17: !ruby/object:RPG::Event
@@ -1236,450 +1235,450 @@ events:
     name: !binary |-
       wqcgVFYtbGVmdA==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_television
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_television
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 14 The television flickers strangely...
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - It's safer to not deal with it right now.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 14 The television flickers strangely...
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - It's safer to not deal with it right now.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_television
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Storing the data of the Rotom
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$user_data[:basement_rotom] ||= PFM::Pokemon.generate_from_hash(id: :rotom,
+          level: 30)"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$user_data[:basement_rotom].hp = $user_data[:basement_rotom].max_hp"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 15 The television flickers strangely...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 16 You feel something watching you from inside the screen.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:rotom)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 17 The creature attacks you!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - call_battle_wild($user_data[:basement_rotom], nil)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$game_temp.battle_can_lose = true"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 38
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 17
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &14 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_television
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *14
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 18
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &15 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *15
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 18 :[name=Scor]:Did you catch it?
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'ge(22).find_path(to: [gp.x - 1, gp.y])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(22)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 22
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &16 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *16
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &17 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *17
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 19 :[name=Scor]:As I thought, it was a Rotom.
+      - !ruby/object:RPG::EventCommand
+        code: 224
+        indent: 1
+        parameters:
+        - !ruby/object:Color
+          red: 255
+          green: 255
+          blue: 255
+          alpha: 255
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - dynamic_light.stop
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 20 :[name=Scor]:Now.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 21 :[name=Scor]:That was fast.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 22 :[name=Scor]:Thanks for the helping hand, alone it would have been
+          a much harder task, with all the wild Pokémon that tried to enter the room!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 23 :[name=Scor]:Here, take this gift as a token of thanks.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - give_item(:intriguing_stone)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 24 :[name=Scor]:Now that I think about it, I believe a scientist brought
+          a lof of different devices to the Laboratory floor...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 25 :[name=Scor]:If you want to come see me again, you know where to
+          find me!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'ge(22).find_path(to: [44, 53])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(22)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - delete_event_forever(22)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - set_self_switch(true, 'B', 17)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - set_self_switch(true, 'B', 18)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - set_self_switch(true, 'A', 26)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 26 The Pokémon returns to the television to gain back its strength.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Healing the Rotom
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - "$user_data[:basement_rotom].hp = $user_data[:basement_rotom].max_hp"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - PFM.game_state.heal_party
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Storing the data of the Rotom
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$user_data[:basement_rotom] ||= PFM::Pokemon.generate_from_hash(id: :rotom,
-                level: 30)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$user_data[:basement_rotom].hp = $user_data[:basement_rotom].max_hp"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 15 The television flickers strangely...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 16 You feel something watching you from inside the screen.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:rotom)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 17 The creature attacks you!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - call_battle_wild($user_data[:basement_rotom], nil)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$game_temp.battle_can_lose = true"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 38
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 17
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &14
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *14
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 18
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &15
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *15
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 18 :[name=Scor]:Did you catch it?
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "ge(22).find_path(to: [gp.x - 1, gp.y])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(22)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 22
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &16
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *16
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &17
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *17
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 19 :[name=Scor]:As I thought, it was a Rotom.
-          - !ruby/object:RPG::EventCommand
-            code: 224
-            indent: 1
-            parameters:
-              - !ruby/object:Color
-                red: 255
-                green: 255
-                blue: 255
-                alpha: 255
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - dynamic_light.stop
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 20 :[name=Scor]:Now.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 21 :[name=Scor]:That was fast.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 22 :[name=Scor]:Thanks for the helping hand, alone it would have been
-                a much harder task, with all the wild Pokémon that tried to enter the room!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 23 :[name=Scor]:Here, take this gift as a token of thanks.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - give_item(:intriguing_stone)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 24 :[name=Scor]:Now that I think about it, I believe a scientist brought
-                a lof of different devices to the Laboratory floor...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 25 :[name=Scor]:If you want to come see me again, you know where to
-                find me!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "ge(22).find_path(to: [44, 53])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(22)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - delete_event_forever(22)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - set_self_switch(true, 'B', 17)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - set_self_switch(true, 'B', 18)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - set_self_switch(true, 'A', 26)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 26 The Pokémon returns to the television to gain back its strength.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Healing the Rotom
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "$user_data[:basement_rotom].hp = $user_data[:basement_rotom].max_hp"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - PFM.game_state.heal_party
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 27 Without Rotom inside, the television is now completely out of order.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 27 Without Rotom inside, the television is now completely out of order.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 43
     y: 48
   18: !ruby/object:RPG::Event
@@ -1687,501 +1686,501 @@ events:
     name: !binary |-
       wqcgVFYtcmlnaHQ=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_television
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_television
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 28 The television flickers strangely...
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - It's safer to not deal with it right now.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 28 The television flickers strangely...
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - It's safer to not deal with it right now.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_television
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Storing the data of the Rotom
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$user_data[:basement_rotom] ||= PFM::Pokemon.generate_from_hash(id: :rotom,
+          level: 30)"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$user_data[:basement_rotom].hp = $user_data[:basement_rotom].max_hp"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 29 The television flickers strangely...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 30 You feel something watching you from inside the screen.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:rotom)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 31 The creature attacks you!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - call_battle_wild($user_data[:basement_rotom], nil)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$game_temp.battle_can_lose = true"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 0
+        - 38
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 17
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_television
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *18
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 18
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *19
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 32 :[name=Scor]:Did you catch it?
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'ge(22).find_path(to: [gp.x - 1, gp.y])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(22)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 22
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &20 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *20
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &21 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *21
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 33 :[name=Scor]:As I thought, it was a Rotom.
+      - !ruby/object:RPG::EventCommand
+        code: 224
+        indent: 1
+        parameters:
+        - !ruby/object:Color
+          red: 255
+          green: 255
+          blue: 255
+          alpha: 255
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - dynamic_light.stop
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 34 :[name=Scor]:Now.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 35 :[name=Scor]:That was fast.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 36 :[name=Scor]:Thanks for the helping hand, alone it would have been
+          a much harder task, with all the wild Pokémon that tried to enter the room!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 37 :[name=Scor]:Here, take this gift as a token of thanks.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - give_item(:intriguing_stone)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 38 :[name=Scor]:Now that I think about it, I believe a scientist brought
+          a lof of different devices to the Laboratory floor...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 39 :[name=Scor]:If you want to come see me again, you know where to
+          find me!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'ge(22).find_path(to: [44, 53])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(22)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - delete_event_forever(22)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - set_self_switch(true, 'B', 17)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - set_self_switch(true, 'B', 18)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - set_self_switch(true, 'A', 26)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 21, 40 The Pokémon returns to the television to gain back its strength.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Healing the Rotom
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - "$user_data[:basement_rotom].hp = $user_data[:basement_rotom].max_hp"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - PFM.game_state.heal_party
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Storing the data of the Rotom
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$user_data[:basement_rotom] ||= PFM::Pokemon.generate_from_hash(id: :rotom,
-                level: 30)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$user_data[:basement_rotom].hp = $user_data[:basement_rotom].max_hp"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 29 The television flickers strangely...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 30 You feel something watching you from inside the screen.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:rotom)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 31 The creature attacks you!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - call_battle_wild($user_data[:basement_rotom], nil)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$game_temp.battle_can_lose = true"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 0
-              - 38
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 17
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &18
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *18
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 18
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &19
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *19
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 32 :[name=Scor]:Did you catch it?
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "ge(22).find_path(to: [gp.x - 1, gp.y])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(22)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 22
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &20
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *20
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &21
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *21
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 33 :[name=Scor]:As I thought, it was a Rotom.
-          - !ruby/object:RPG::EventCommand
-            code: 224
-            indent: 1
-            parameters:
-              - !ruby/object:Color
-                red: 255
-                green: 255
-                blue: 255
-                alpha: 255
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - dynamic_light.stop
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 34 :[name=Scor]:Now.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 35 :[name=Scor]:That was fast.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 36 :[name=Scor]:Thanks for the helping hand, alone it would have been
-                a much harder task, with all the wild Pokémon that tried to enter the room!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 37 :[name=Scor]:Here, take this gift as a token of thanks.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - give_item(:intriguing_stone)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 38 :[name=Scor]:Now that I think about it, I believe a scientist brought
-                a lof of different devices to the Laboratory floor...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 39 :[name=Scor]:If you want to come see me again, you know where to
-                find me!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "ge(22).find_path(to: [44, 53])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(22)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - delete_event_forever(22)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - set_self_switch(true, 'B', 17)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - set_self_switch(true, 'B', 18)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - set_self_switch(true, 'A', 26)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 21, 40 The Pokémon returns to the television to gain back its strength.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Healing the Rotom
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "$user_data[:basement_rotom].hp = $user_data[:basement_rotom].max_hp"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - PFM.game_state.heal_party
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 41 Without Rotom inside, the television is now completely out of order.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 41 Without Rotom inside, the television is now completely out of order.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 44
     y: 48
   19: !ruby/object:RPG::Event
     id: 19
     name: Radio
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 42 An old radio. It seems like it doesn't have any charge left.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 42 An old radio. It seems like it doesn't have any charge left.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 40
     y: 48
   2: !ruby/object:RPG::Event
@@ -2189,472 +2188,472 @@ events:
     name: !binary |-
       wqdMSUdIVDI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 20
     y: 9
   20: !ruby/object:RPG::Event
     id: 20
     name: Trash bin
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 43 Dumpster diving is such a weird obsession...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 44 Do you believe all dumpsters contain things?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 45 Well, sorry not sorry, this one does not.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 46 It does not contain any interesting item, but it contains words.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 47 A lot of words.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 48 ... Oh, wait, there's a CD at the bottom of the dumpster.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - give_item(:tm12)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 49 The dumpster is now forever silent.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 43 Dumpster diving is such a weird obsession...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 44 Do you believe all dumpsters contain things?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 45 Well, sorry not sorry, this one does not.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 46 It does not contain any interesting item, but it contains words.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 47 A lot of words.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 48 ... Oh, wait, there's a CD at the bottom of the dumpster.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - give_item(:tm12)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 49 The dumpster is now forever silent.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 45
     y: 48
   21: !ruby/object:RPG::Event
     id: 21
     name: Laptop
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 50 A laptop.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 50 A laptop.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 45
     y: 53
   22: !ruby/object:RPG::Event
     id: 22
     name: "$Scorbutics2"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Veteran-02
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Veteran-02
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 51 :[name=Scor]:Ah, there you are.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 52 :[name=Scor]:The general lights of this basement and all the devices
+          in here are out of power.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 53 :[name=Scor]:Only the basement's secondary lights are still on, as
+          they're connected to an auxiliary generator...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '21, 54 :[name=Scor]:I''m sure you''ll agree with me: it makes no sense
+          to plug a television to an auxiliary generator.'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 55 :[name=Scor]:So we can deduce the problem is caused by this television..
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 56 :[name=Scor]:I have my own theory, but I prefer to keep it to myself
+          for now.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 57 :[name=Scor]:The only sure thing is, it must be an Electric Pokémon.
+          It would explain why the main generator is down and why the television is
+          still working.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 58 :[name=Scor]:I'm covering you, you take care of this Pokémon.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 59 :[name=Scor]:If you defeat it or if you flee, it will need to enter
+          the television again to recharge its batteries.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 60 :[name=Scor]:And, well, it's certainly a good Pokémon, a rare one
+          at that.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 61 :[name=Scor]:Check the television when you feel ready, and don't
+          forget to bring some Poké Balls!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 62 :[name=Scor]:I'll stand over there to deal with the wild Pokémon
+          attracted by the noise.
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 51 :[name=Scor]:Ah, there you are.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 52 :[name=Scor]:The general lights of this basement and all the devices
-                in here are out of power.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 53 :[name=Scor]:Only the basement's secondary lights are still on, as
-                they're connected to an auxiliary generator...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "21, 54 :[name=Scor]:I'm sure you'll agree with me: it makes no sense
-                to plug a television to an auxiliary generator."
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 55 :[name=Scor]:So we can deduce the problem is caused by this television..
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 56 :[name=Scor]:I have my own theory, but I prefer to keep it to myself
-                for now.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 57 :[name=Scor]:The only sure thing is, it must be an Electric Pokémon.
-                It would explain why the main generator is down and why the television is
-                still working.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 58 :[name=Scor]:I'm covering you, you take care of this Pokémon.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 59 :[name=Scor]:If you defeat it or if you flee, it will need to enter
-                the television again to recharge its batteries.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 60 :[name=Scor]:And, well, it's certainly a good Pokémon, a rare one
-                at that.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 61 :[name=Scor]:Check the television when you feel ready, and don't
-                forget to bring some Poké Balls!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 62 :[name=Scor]:I'll stand over there to deal with the wild Pokémon
-                attracted by the noise.
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'find_path(to: [41, 52])'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - wait_event
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "find_path(to: [41, 52])"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - wait_event
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &22
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Changing the state of the TV
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true, 'A', 17)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - set_self_switch(true, 'A', 18)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - C
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+          - &22 !ruby/object:RPG::MoveCommand
+            code: 16
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: C
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 63 :[name=Scor]:Talk to the television when you feel ready to catch
-                this Pokémon, I've got your back!
-          - !ruby/object:RPG::EventCommand
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - moveto(41, 52)
-            - !ruby/object:RPG::MoveCommand
-              code: 16
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
           repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Changing the state of the TV
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true, 'A', 17)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - set_self_switch(true, 'A', 18)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - C
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: C
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 63 :[name=Scor]:Talk to the television when you feel ready to catch
+          this Pokémon, I've got your back!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - moveto(41, 52)
+        - !ruby/object:RPG::MoveCommand
+          code: 16
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: false
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 41
     y: 50
   23: !ruby/object:RPG::Event
@@ -2662,368 +2661,368 @@ events:
     name: !binary |-
       wqdkb29y
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_13
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Door enter
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &23
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &24
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &25
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &26
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &27
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *23
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *24
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *25
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *26
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *27
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$game_player.moveto(41, 53)"
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_13
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Door enter
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_13
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Door enter
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &28
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &29
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &30
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &31
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &32
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *28
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *29
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *30
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *31
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *32
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &23 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &24 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &25 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &26 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The "true" means the animation will play
-                in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &27 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *25
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *26
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *27
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$game_player.moveto(41, 53)"
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_13
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Door enter
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &28 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &29 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &32 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *30
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *31
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The "true" means the animation will play
+          in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 44
     y: 31
   24: !ruby/object:RPG::Event
@@ -3031,715 +3030,715 @@ events:
     name: !binary |-
       wqcgZXhpdCBkb29y
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Arrow
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: door_exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &33
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &34
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *33
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *34
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This command turns on the self switch on the exterior door to enable the
-                opening door.
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 21
-              - 44
-              - 31
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",23)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Arrow
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: door_exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 31
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 35
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 39
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &33 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &34 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 2
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 2
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *34
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This command turns on the self switch on the exterior door to enable the
+          opening door.
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 21
+        - 44
+        - 31
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",23)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 31
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 35
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 39
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 2
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 2
+      walk_anime: false
     x: 41
     y: 54
   25: !ruby/object:RPG::Event
     id: 25
     name: "[sprite=off] Exiting arrow"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This event displays an arrow under the exit when the player stands in front
-                of it and faces down.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gp.x == 41 && gp.y == 53
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 6
-              - -1
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - 24
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &35
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *35
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - 24
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &36
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *36
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 24
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &37
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *37
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This event displays an arrow under the exit when the player stands in front
+          of it and faces down.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gp.x == 41 && gp.y == 53
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 6
+        - -1
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - 24
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &35 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *35
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - 24
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &36 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *36
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 24
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &37 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *37
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 41
     y: 55
   26: !ruby/object:RPG::Event
     id: 26
     name: Scorbutics3
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Veteran-02
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Veteran-02
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 64 :[name=Scor]:Oh, well, \N[1], thanks for visiting me!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 65 :[name=Scor]:I'm working on a top-secret project, so I can't speak
+          about it here...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 21, 66 :[name=Scor]:Please come back to see me again when you have some
+          time, it's quite lonely here.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 64 :[name=Scor]:Oh, well, \N[1], thanks for visiting me!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 65 :[name=Scor]:I'm working on a top-secret project, so I can't speak
-                about it here...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 21, 66 :[name=Scor]:Please come back to see me again when you have some
-                time, it's quite lonely here.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 45
-              parameters:
-                - moveto(44,53)
-            - !ruby/object:RPG::MoveCommand
-              code: 18
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: false
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 45
+          parameters:
+          - moveto(44,53)
+        - !ruby/object:RPG::MoveCommand
+          code: 18
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: false
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 44
     y: 53
   27: !ruby/object:RPG::Event
     id: 27
     name: Morelull_1
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0755"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0755'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:morelull)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - call_battle_wild(:morelull, 28)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the Morelull was defeated
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(gs[37] = switch 37) or caught"
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(gs[38] = switch 38)"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gs[37] || gs[38]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - if dynamic_light.started?
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "  NuriYuri::DynamicLight.switch_off(18)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "  NuriYuri::DynamicLight.light_sprite(18).update"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - end
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:morelull)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - call_battle_wild(:morelull, 28)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the Morelull was defeated
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(gs[37] = switch 37) or caught"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(gs[38] = switch 38)"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gs[37] || gs[38]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - if dynamic_light.started?
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "  NuriYuri::DynamicLight.switch_off(18)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "  NuriYuri::DynamicLight.light_sprite(18).update"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - end
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 1
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 1
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 30
     y: 18
   28: !ruby/object:RPG::Event
     id: 28
     name: Morelull_2
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0755"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0755'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:morelull)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - call_battle_wild(:morelull, 28)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the Morelull was defeated
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(gs[37] = switch 37) or caught"
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(gs[38] = switch 38)"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gs[37] || gs[38]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - if dynamic_light.started?
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "  NuriYuri::DynamicLight.switch_off(19)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "  NuriYuri::DynamicLight.light_sprite(19).update"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - end
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:morelull)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - call_battle_wild(:morelull, 28)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the Morelull was defeated
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(gs[37] = switch 37) or caught"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(gs[38] = switch 38)"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gs[37] || gs[38]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - if dynamic_light.started?
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "  NuriYuri::DynamicLight.switch_off(19)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "  NuriYuri::DynamicLight.light_sprite(19).update"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - end
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 1
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 1
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 11
     y: 26
   29: !ruby/object:RPG::Event
     id: 29
     name: Morelull_3
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0755"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0755'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:morelull)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - call_battle_wild(:morelull, 28)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the Morelull was defeated
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(gs[37] = switch 37) or caught"
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(gs[38] = switch 38)"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gs[37] || gs[38]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - if dynamic_light.started?
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "  NuriYuri::DynamicLight.switch_off(20)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "  NuriYuri::DynamicLight.light_sprite(20).update"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - end
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:morelull)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - call_battle_wild(:morelull, 28)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the Morelull was defeated
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(gs[37] = switch 37) or caught"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(gs[38] = switch 38)"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gs[37] || gs[38]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - if dynamic_light.started?
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "  NuriYuri::DynamicLight.switch_off(20)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "  NuriYuri::DynamicLight.light_sprite(20).update"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - end
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 1
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 1
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 21
     y: 33
   3: !ruby/object:RPG::Event
@@ -3747,325 +3746,325 @@ events:
     name: !binary |-
       wqdMSUdIVDM=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 26
     y: 9
   30: !ruby/object:RPG::Event
     id: 30
     name: Morelull_4
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0755"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0755'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:morelull)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - call_battle_wild(:morelull, 28)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the Morelull was defeated
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(gs[37] = switch 37) or caught"
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(gs[38] = switch 38)"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gs[37] || gs[38]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - if dynamic_light.started?
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "  NuriYuri::DynamicLight.switch_off(21)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "  NuriYuri::DynamicLight.light_sprite(21).update"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - end
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:morelull)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - call_battle_wild(:morelull, 28)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the Morelull was defeated
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(gs[37] = switch 37) or caught"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(gs[38] = switch 38)"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gs[37] || gs[38]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - if dynamic_light.started?
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "  NuriYuri::DynamicLight.switch_off(21)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "  NuriYuri::DynamicLight.light_sprite(21).update"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - end
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 1
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 1
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 26
   31: !ruby/object:RPG::Event
     id: 31
     name: Morelull_5
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0755"
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0755'
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:morelull)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - call_battle_wild(:morelull, 28)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the Morelull was defeated
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(gs[37] = switch 37) or caught"
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - "(gs[38] = switch 38)"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gs[37] || gs[38]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - if dynamic_light.started?
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "  NuriYuri::DynamicLight.switch_off(22)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "  NuriYuri::DynamicLight.light_sprite(22).update"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - end
+      - !ruby/object:RPG::EventCommand
+        code: 116
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:morelull)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - call_battle_wild(:morelull, 28)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the Morelull was defeated
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(gs[37] = switch 37) or caught"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "(gs[38] = switch 38)"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gs[37] || gs[38]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - if dynamic_light.started?
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "  NuriYuri::DynamicLight.switch_off(22)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "  NuriYuri::DynamicLight.light_sprite(22).update"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - end
-          - !ruby/object:RPG::EventCommand
-            code: 116
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 1
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 1
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 35
     y: 33
   32: !ruby/object:RPG::Event
     id: 32
     name: Smoke ball
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-Pokeball
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-Pokeball
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:smoke_ball)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:smoke_ball)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 15
     y: 18
   4: !ruby/object:RPG::Event
@@ -4073,46 +4072,46 @@ events:
     name: !binary |-
       wqdMSUdIVDQ=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 32
     y: 9
   5: !ruby/object:RPG::Event
@@ -4120,46 +4119,46 @@ events:
     name: !binary |-
       wqdMSUdIVDU=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 11
     y: 16
   6: !ruby/object:RPG::Event
@@ -4167,46 +4166,46 @@ events:
     name: !binary |-
       wqdMSUdIVDY=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 20
     y: 16
   7: !ruby/object:RPG::Event
@@ -4214,46 +4213,46 @@ events:
     name: !binary |-
       wqdMSUdIVDc=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 26
     y: 16
   8: !ruby/object:RPG::Event
@@ -4261,46 +4260,46 @@ events:
     name: !binary |-
       wqdMSUdIVDg=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 32
     y: 16
   9: !ruby/object:RPG::Event
@@ -4308,46 +4307,46 @@ events:
     name: !binary |-
       wqdMSUdIVDk=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 17
     y: 23
 height: 62

--- a/Data/configs/conditions.json
+++ b/Data/configs/conditions.json
@@ -1,0 +1,1 @@
+{"klass":"Configs::Conditions","max_condition_value":255,"coolness_index":0,"beauty_index":1,"cuteness_index":2,"cleverness_index":3,"toughness_index":4,"sheen_index":5}


### PR DESCRIPTION
This MR fixes three issues related to the recent update of the sound design config.

The PC events were playing the sound effects when openning and closing it, since these sound effects were directly added to the `start_pc` method, they were played twice.

The trainers meeting sequence BGM were also set in the events with the `audio/bgm` prefix, leading to the code trying to look for files like `Audio/BGM/audio/bgm/file.ogg`

Some of the battle arena's battles were calling to audio files with the `audio/bgm` prefix, leading to the same issue as above.

## Tests to perform

- [x] Try using every different PC events in the demo, their openning and closing sound effects should only play once
- [x] Try being spotted by all the trainers in the demo, their `eye_bgm` should be played correctly
- [x] In the battle arena, all the battles should correctly play their BGM (Especially the fights number 2, 7 and the one against Palbolsky)