### PR TITLE
Update the Teleport and Escape Rod common events' behavior

### DIFF
--- a/Data/CommonEvents.rxdata.yml
+++ b/Data/CommonEvents.rxdata.yml
@@ -3031,6 +3031,21 @@
     parameters:
     - Yuki::FollowMe.smart_enable
   - !ruby/object:RPG::EventCommand
+    code: 108
+    indent: 1
+    parameters:
+    - Used to reset the state of the player. Very useful to
+  - !ruby/object:RPG::EventCommand
+    code: 408
+    indent: 1
+    parameters:
+    - disable the bridge state notably.
+  - !ruby/object:RPG::EventCommand
+    code: 355
+    indent: 1
+    parameters:
+    - "$game_player.fly_reset_attributes"
+  - !ruby/object:RPG::EventCommand
     code: 201
     indent: 1
     parameters:
@@ -7671,6 +7686,21 @@
     - 19
     - 19
     - 0
+  - !ruby/object:RPG::EventCommand
+    code: 108
+    indent: 2
+    parameters:
+    - Used to reset the state of the player. Very useful to
+  - !ruby/object:RPG::EventCommand
+    code: 408
+    indent: 2
+    parameters:
+    - disable the bridge state notably.
+  - !ruby/object:RPG::EventCommand
+    code: 355
+    indent: 2
+    parameters:
+    - "$game_player.fly_reset_attributes"
   - !ruby/object:RPG::EventCommand
     code: 201
     indent: 2

--- a/Data/Map019.rxdata.yml
+++ b/Data/Map019.rxdata.yml
@@ -485,6 +485,53 @@ events:
         parameters:
         - 5
       - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - PSDK is able to infer the Dig/Escape Rode/Teleport
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - back coordinates right, but in some cases we want to
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - overwrite them to be at a specific place. That's what we
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - do here.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 23
+        - 23
+        - 0
+        - 0
+        - 19
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 24
+        - 24
+        - 0
+        - 0
+        - 31
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 25
+        - 25
+        - 0
+        - 0
+        - 32
+      - !ruby/object:RPG::EventCommand
         code: 223
         indent: 0
         parameters:
@@ -4398,6 +4445,53 @@ events:
         indent: 0
         parameters:
         - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - PSDK is able to infer the Dig/Escape Rode/Teleport
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - back coordinates right, but in some cases we want to
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - overwrite them to be at a specific place. That's what we
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - do here.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 23
+        - 23
+        - 0
+        - 0
+        - 19
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 24
+        - 24
+        - 0
+        - 0
+        - 32
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 25
+        - 25
+        - 0
+        - 0
+        - 32
       - !ruby/object:RPG::EventCommand
         code: 223
         indent: 0


### PR DESCRIPTION
# PR Description
As reported in [this help topic on Discord](https://ptb.discord.com/channels/143824995867557888/1511508807656931488), the Technical Demo doesn't reset the player's state when using Teleport, the Escape Rod and Dig which uses the Escape Rod's behavior. This PR solves this issue.

# Before testing
- Make a Pokémon of yours learn Teleport: `S.MI.skill_learn($actors[0], :teleport)`
- Give yourself some Escape Ropes: `$bag.add_item(:escape_rope, 10) `
- If you're using an existing save, make sure to walk in and out of the Tower once or twice to ensure the new return coordinates variables will be properly saved

# Tests to realize before merging
- [ ] For all of the tests below, make sure to test the `$game_player.z` command in the console. If it returns anything other than 1, then the test case is invalid
- [ ] Go to the River map and walk to the middle of the bridge, then use both an Escape Rope and Teleport with your Pokémon: you should appear below the Tower's door and you should be able to walk with no issue
- [ ] Go to the March map, walk into the swamp, then use both an Escape Rope and Teleport with your Pokémon: you should appear below the Tower's door and you should be able to walk with no issue
- [ ] Go to the Bike map, step onto your own bike, then use both an Escape Rope and Teleport with your Pokémon: you should appear below the Tower's door and you should be able to walk with no issue