### PR TITLE
Fix the Nurse event's ID to make it work when a player blacks out and return to the Hub

### DIFF
--- a/Data/Map003.rxdata.yml
+++ b/Data/Map003.rxdata.yml
@@ -1,5 +1,4 @@
----
-!ruby/object:RPG::Map
+--- !ruby/object:RPG::Map
 autoplay_bgm: true
 autoplay_bgs: false
 bgm: !ruby/object:RPG::AudioFile
@@ -7,7 +6,7 @@ bgm: !ruby/object:RPG::AudioFile
   pitch: 100
   volume: 100
 bgs: !ruby/object:RPG::AudioFile
-  name: ""
+  name: ''
   pitch: 100
   volume: 100
 data: !ruby/object:Table
@@ -213,459 +212,386 @@ encounter_step: 30
 events:
   1: !ruby/object:RPG::Event
     id: 1
-    name: !binary |-
-      wqcgZXhpdCBkb29y
+    name: Nurse
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Arrow
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Nurse-01
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - For the Nurse event to work flawlessly, it NEEDS to be
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - the first event of the map, so ID:001. You can check
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - whether it's the case of not by checking at the top-left
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - part of the event.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - The first non-comment command must also be the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - Common Event call to the fourth Common Event.
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We set the Map Return depending on the Nurse's position,
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - with a +2 to her Y position so that when we black out, we
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - appear directly on the right position.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 47
+        - 47
+        - 0
+        - 7
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 48
+        - 48
+        - 0
+        - 6
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 49
+        - 49
+        - 0
+        - 6
+        - 5
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 49
+        - 49
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 242
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: door_exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &1
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &2
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *1
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *2
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We set the Map Return depending on the Nurse's position,
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - with a +2 to her Y position so that when we black out, we
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - appear directly on the right position.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 47
-              - 47
-              - 0
-              - 7
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 48
-              - 48
-              - 0
-              - 6
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 49
-              - 49
-              - 0
-              - 6
-              - 5
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 49
-              - 49
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This command turns on the self switch on the exterior door to enable the
-                opening door.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",1,map_id = 19)
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 19
-              - 31
-              - 31
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 31
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 35
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 39
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 2
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 2
-        walk_anime: false
-    x: 28
-    y: 48
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    x: 18
+    y: 40
   10: !ruby/object:RPG::Event
     id: 10
     name: !binary |-
       wqcgYmFzZW1lbnQgd2FycCByaWdodA==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: door_exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &3
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &4
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &5
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &6
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &7
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *3
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *4
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *5
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *6
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *7
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This command turns on the self switch on the basement to settle the tone
-                and the followers.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",3,map_id = 17)
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 17
-              - 19
-              - 29
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: door_exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 31
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 35
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 39
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 2
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 2
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
+          - &1 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+            - 2
+          - &2 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &3 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &4 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &5 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *1
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *2
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *3
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *4
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *5
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This command turns on the self switch on the basement to settle the tone
+          and the followers.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",3,map_id = 17)
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 17
+        - 19
+        - 29
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 31
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 35
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 39
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 2
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 2
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 29
     y: 39
   11: !ruby/object:RPG::Event
@@ -673,401 +599,401 @@ events:
     name: !binary |-
       wqcgUG9rw6liYWxscyByaWdodFtvZmZzZXRfeT0wXQ==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 51
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: pokeballs on left
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'For the information, yes, the switch 51 is also used by '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'another system which disables the Reflection under the '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'map. This hasn''t posed any problem at all in 5 years and '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'is now too ingrained to be changed lightly. Just don''t think '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - about this and use these Nurse events as is.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 13
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 28
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 28
+        - 28
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &6 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 51
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: pokeballs on left
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *6
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 26
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 28
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 28
+        - 28
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &7 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *7
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 26
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 28
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 28
+        - 28
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &8 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *8
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Enabling the screen animation
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",14)
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemon Healed
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 0
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &9 !ruby/object:RPG::MoveCommand
+            code: 33
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *9
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 75
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &10 !ruby/object:RPG::MoveCommand
+            code: 34
+            parameters: []
+          - &11 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - &12 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *10
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *11
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *12
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(false,"A",14)
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 1
+        parameters:
+        - 51
+        - 51
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "For the information, yes, the switch 51 is also used by "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "another system which disables the Reflection under the "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "map. This hasn't posed any problem at all in 5 years and "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "is now too ingrained to be changed lightly. Just don't think "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - about this and use these Nurse events as is.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 13
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 28
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 28
-              - 28
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &8
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *8
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 26
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 28
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 28
-              - 28
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &9
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *9
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 26
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 28
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 28
-              - 28
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &10
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *10
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Enabling the screen animation
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",14)
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemon Healed
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 0
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &11
-                    code: 33
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *11
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 75
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &12
-                    code: 34
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &13
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand &14
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *12
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *13
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *14
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(false,"A",14)
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 1
-            parameters:
-              - 51
-              - 51
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 5
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 5
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 17
     y: 39
   12: !ruby/object:RPG::Event
@@ -1075,371 +1001,371 @@ events:
     name: !binary |-
       wqcgUG9rw6liYWxscyBsZWZ0W29mZnNldF95PTBd
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 51
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: pokeballs on right
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'For the information, yes, the switch 51 is also used by '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'another system which disables the Reflection under the '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'map. This hasn''t posed any problem at all in 5 years and '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'is now too ingrained to be changed lightly. Just don''t think '
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - about this and use these Nurse events as is.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 27
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 27
+        - 27
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &13 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 51
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: pokeballs on right
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *13
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 26
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 27
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 27
+        - 27
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &14 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *14
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 26
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 1
+        - 27
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 1
+        parameters:
+        - 27
+        - 27
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Pokemove
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &15 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *15
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 13
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 0
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &16 !ruby/object:RPG::MoveCommand
+            code: 33
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *16
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 75
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &17 !ruby/object:RPG::MoveCommand
+            code: 34
+            parameters: []
+          - &18 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - &19 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *17
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *18
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *19
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "For the information, yes, the switch 51 is also used by "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "another system which disables the Reflection under the "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "map. This hasn't posed any problem at all in 5 years and "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "is now too ingrained to be changed lightly. Just don't think "
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - about this and use these Nurse events as is.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 27
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 27
-              - 27
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &15
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *15
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 26
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 27
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 27
-              - 27
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &16
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *16
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 26
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 1
-              - 27
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 1
-            parameters:
-              - 27
-              - 27
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Pokemove
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &17
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *17
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 13
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 0
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &18
-                    code: 33
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *18
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 75
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &19
-                    code: 34
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &20
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand &21
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *19
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *20
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *21
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 5
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 5
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 16
     y: 39
   13: !ruby/object:RPG::Event
@@ -1447,221 +1373,221 @@ events:
     name: !binary |-
       wqcgQ29tcHV0ZXI=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Computer-screen
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &22
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_on
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &23
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &24
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand &25
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &26
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &27
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &28
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *22
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *23
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *24
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *25
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *26
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *27
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *28
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - start_pc
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &29
-                    code: 44
-                    parameters:
-                      - !ruby/object:RPG::AudioFile
-                        name: computer_off
-                        pitch: 100
-                        volume: 80
-                  - !ruby/object:RPG::MoveCommand &30
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12,reverse:true)
-                  - !ruby/object:RPG::MoveCommand &31
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &32
-                    code: 45
-                    parameters:
-                      - animate_from_charset([1],12)
-                  - !ruby/object:RPG::MoveCommand &33
-                    code: 15
-                    parameters:
-                      - 12
-                  - !ruby/object:RPG::MoveCommand &34
-                    code: 41
-                    parameters:
-                      - fx_Computer-screen
-                      - 0
-                      - 4
-                      - 0
-                  - !ruby/object:RPG::MoveCommand &35
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *29
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *30
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *31
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *32
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *33
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *34
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *35
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Computer-screen
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &20 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: computer_on
+              pitch: 100
+              volume: 80
+          - &21 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 3
+          - &22 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - &23 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &24 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &25 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &26 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *20
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *21
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *22
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *23
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *24
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *25
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *26
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - start_pc
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &27 !ruby/object:RPG::MoveCommand
+            code: 44
+            parameters:
+            - !ruby/object:RPG::AudioFile
+              name: computer_off
+              pitch: 100
+              volume: 80
+          - &28 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12,reverse:true)
+          - &29 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &30 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - animate_from_charset([1],12)
+          - &31 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 12
+          - &32 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - fx_Computer-screen
+            - 0
+            - 4
+            - 0
+          - &33 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *27
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *28
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *29
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *30
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *31
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *32
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *33
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 21
     y: 39
   14: !ruby/object:RPG::Event
@@ -1669,774 +1595,774 @@ events:
     name: !binary |-
       wqcgUEMgU2NyZWVu
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 51
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 26
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_PC-Screen
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 51
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 26
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_PC-Screen
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 6
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 6
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 5
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 5
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
     x: 18
     y: 38
   15: !ruby/object:RPG::Event
     id: 15
     name: "[sprite=off] Warp destination"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: true
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: true
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 45
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 45
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 28
     y: 43
   16: !ruby/object:RPG::Event
     id: 16
     name: Cashier 2
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Seller-M
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Seller-M
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 0 Welcome! I'm selling Poké Balls for less than next door...
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'open_shop([:poke_ball, :great_ball], {:poke_ball => 180, :great_ball =>
+          550}, show_background: false)'
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Displaying a text if nothing was bought
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 1 I can assure you of their quality!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Displaying a text if a single type of item was bought
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 1
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 2 The paint might be peeled a bit, but you won't be disappointed in those
+          Balls!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Displaying a text if several items were bought
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 2
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 3 These are goods which fell of the truck, but still, it's high quality!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 0 Welcome! I'm selling Poké Balls for less than next door...
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "open_shop([:poke_ball, :great_ball], {:poke_ball => 180, :great_ball =>
-                550}, show_background: false)"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Displaying a text if nothing was bought
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 1 I can assure you of their quality!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Displaying a text if a single type of item was bought
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 1
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 2 The paint might be peeled a bit, but you won't be disappointed in those
-                Balls!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Displaying a text if several items were bought
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 2
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 3 These are goods which fell of the truck, but still, it's high quality!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 38
     y: 40
   17: !ruby/object:RPG::Event
     id: 17
     name: Cashier 1
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Seller-F
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Seller-F
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 26
+        - 26
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Welcoming text
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 4 \t[11, 3]
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,0]"
+          - "\\t[11,1]"
+          - "\\t[11,2]"
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,0]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Buy
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,1]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Sell
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 2
+        - "\\t[11,2]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Exit
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Back
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 26
+        - 26
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Showing a different text when exiting a "buy" or "sell" menu,
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - and geting back to the choice
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 5 \t[11,5]
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,0]"
+          - "\\t[11,1]"
+          - "\\t[11,2]"
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,0]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Buy
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,1]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Sell
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 2
+        - "\\t[11,2]"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Exit
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Buy
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player has money
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 7
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 6 \t[11, 24]
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Back
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 1
+        parameters:
+        - 26
+        - 26
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Script command for the buying menu
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'open_shop([:poke_ball, :great_ball, :ultra_ball, :potion, :super_potion,
+          :revive, :antidote, :paralyze_heal, :awakening, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ":burn_heal, :ice_heal, :escape_rope, :repel, :super_repel], show_background:
+          false)"
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Back
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Sell
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player has any item costing more than 0$
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - each_data_item.none? { |item| item.price > 0 && $bag.contain_item?(item.db_symbol)
+          }
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 7 You have nothing to sell!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Back
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 1
+        parameters:
+        - 26
+        - 26
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Script command for the selling menu
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - GamePlay::Bag.new(:shop).main
+      - !ruby/object:RPG::EventCommand
+        code: 222
+        indent: 1
+        parameters:
+        - ''
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - Back
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Exit
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 26
+        - 26
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Exiting text
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 8 \t[11,4]
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 26
-              - 26
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Welcoming text
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 4 \t[11, 3]
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,0]"
-                - "\\t[11,1]"
-                - "\\t[11,2]"
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,0]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Buy
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,1]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Sell
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 2
-              - "\\t[11,2]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Exit
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Back
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 26
-              - 26
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Showing a different text when exiting a "buy" or "sell" menu,
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - and geting back to the choice
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 5 \t[11,5]
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,0]"
-                - "\\t[11,1]"
-                - "\\t[11,2]"
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,0]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Buy
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,1]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Sell
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 2
-              - "\\t[11,2]"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Exit
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Buy
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player has money
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 7
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 6 \t[11, 24]
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Back
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 1
-            parameters:
-              - 26
-              - 26
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Script command for the buying menu
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "open_shop([:poke_ball, :great_ball, :ultra_ball, :potion, :super_potion,
-                :revive, :antidote, :paralyze_heal, :awakening, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ":burn_heal, :ice_heal, :escape_rope, :repel, :super_repel], show_background:
-                false)"
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Back
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Sell
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player has any item costing more than 0$
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - each_data_item.none? { |item| item.price > 0 && $bag.contain_item?(item.db_symbol)
-                }
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 7 You have nothing to sell!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Back
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 1
-            parameters:
-              - 26
-              - 26
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Script command for the selling menu
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - GamePlay::Bag.new(:shop).main
-          - !ruby/object:RPG::EventCommand
-            code: 222
-            indent: 1
-            parameters:
-              - ""
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - Back
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Exit
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 26
-              - 26
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Exiting text
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 8 \t[11,4]
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 37
     y: 39
   18: !ruby/object:RPG::Event
     id: 18
     name: Item
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx-Pokeball
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx-Pokeball
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 9 As this item is on the ground, you can use the \c[5]"pick_item"\c[0]
+          command to have the event deleted afterward.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:leftovers)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 9 As this item is on the ground, you can use the \c[5]"pick_item"\c[0]
-                command to have the event deleted afterward.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:leftovers)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 40
     y: 46
   19: !ruby/object:RPG::Event
     id: 19
     name: invisible_Item
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 10 As this item has the \c[5]"invisible_"\c[0] tag at the beginning of
+          its name, it does not have a shadow and can be detected by the Drowsing
+          Machine.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - pick_item(:stardust)
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 10 As this item has the \c[5]"invisible_"\c[0] tag at the beginning of
-                its name, it does not have a shadow and can be detected by the Drowsing
-                Machine.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - pick_item(:stardust)
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 34
     y: 38
   2: !ruby/object:RPG::Event
@@ -2444,4490 +2370,4490 @@ events:
     name: !binary |-
       wqcgRXNjYWxhdG9ycyB3YXJw
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 2
-          opacity: 0
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 6
-              - -1
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 42
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &36
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *36
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &37
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &38
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &39
-                    code: 2
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &40
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *37
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *38
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *39
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *40
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Disabling the shadow under the player.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - gp.shadow_disabled = true
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 7
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &41
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *41
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_escalator
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Animation of the escalator, which graphics' are on event 5.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - ge(7).animate_from_charset([2,3],40)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &42
-                    code: 32
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &43
-                    code: 29
-                    parameters:
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &44
-                    code: 15
-                    parameters:
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &45
-                    code: 5
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *42
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *43
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *44
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *45
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true,"A",1,map_id = 18)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 42
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &46
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *46
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 7
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &47
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *47
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 1
-            parameters:
-              - 0
-              - 18
-              - 24
-              - 18
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 2
+        opacity: 0
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 6
+        - -1
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 42
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 1
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
+          - &34 !ruby/object:RPG::MoveCommand
+            code: 42
             parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -238
-                gray: 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 42
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &48
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *48
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 7
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &49
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *49
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the escalator.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - ge(7).animate_from_charset([2,3],40,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &50
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &51
-                    code: 32
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &52
-                    code: 29
-                    parameters:
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &53
-                    code: 8
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &54
-                    code: 31
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *50
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *51
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *52
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *53
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *54
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 6
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Reenabling the shadow under the player.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - gp.shadow_disabled = false
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &55
-                    code: 31
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &56
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &57
-                    code: 3
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &58
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &59
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *55
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *56
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *57
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *58
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *59
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 3
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 7
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &60
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *60
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 42
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &61
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *61
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 255
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *34
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &35 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &36 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &37 !ruby/object:RPG::MoveCommand
+            code: 2
+            parameters: []
+          - &38 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *35
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *36
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *37
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *38
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Disabling the shadow under the player.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - gp.shadow_disabled = true
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 7
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &39 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *39
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_escalator
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Animation of the escalator, which graphics' are on event 5.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - ge(7).animate_from_charset([2,3],40)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &40 !ruby/object:RPG::MoveCommand
+            code: 32
+            parameters: []
+          - &41 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 1
+          - &42 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 1
+          - &43 !ruby/object:RPG::MoveCommand
+            code: 5
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *40
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *41
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *42
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *43
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true,"A",1,map_id = 18)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 42
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &44 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *44
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 7
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &45 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *45
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 1
+        parameters:
+        - 0
+        - 18
+        - 24
+        - 18
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 1
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -238
+          gray: 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 42
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &46 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *46
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 7
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &47 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *47
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the escalator.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - ge(7).animate_from_charset([2,3],40,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &48 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &49 !ruby/object:RPG::MoveCommand
+            code: 32
+            parameters: []
+          - &50 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 1
+          - &51 !ruby/object:RPG::MoveCommand
+            code: 8
+            parameters: []
+          - &52 !ruby/object:RPG::MoveCommand
+            code: 31
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *48
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *49
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *50
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *51
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *52
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 6
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Reenabling the shadow under the player.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - gp.shadow_disabled = false
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &53 !ruby/object:RPG::MoveCommand
+            code: 31
+            parameters: []
+          - &54 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &55 !ruby/object:RPG::MoveCommand
+            code: 3
+            parameters: []
+          - &56 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &57 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *53
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *54
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *55
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *56
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *57
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 3
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 7
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &58 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *58
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 42
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &59 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *59
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 17
     y: 46
   20: !ruby/object:RPG::Event
     id: 20
     name: Malo Cinematic
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 107
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 107
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 28
     y: 42
   21: !ruby/object:RPG::Event
     id: 21
     name: Starting Event
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 20
-              - 0
-              - 28
-              - 42
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &62
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &63
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &64
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *62
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *63
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *64
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &65
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &66
-                    code: 15
-                    parameters:
-                      - 15
-                  - !ruby/object:RPG::MoveCommand &67
-                    code: 45
-                    parameters:
-                      - "emotion(:exclamation, 0, oy_offset: 8)"
-                  - !ruby/object:RPG::MoveCommand &68
-                    code: 15
-                    parameters:
-                      - 20
-                  - !ruby/object:RPG::MoveCommand &69
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &70
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: true
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *65
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *66
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *67
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *68
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *69
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *70
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 11 :[name=SirMalo]:Ah, here you are!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Welcome to the Tower!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 12 :[name=SirMalo]:Sorry, I realized when I got here that I forgot to
-                give you these Running Shoes...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 13 :[name=SirMalo]:I hope you're not angry?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 14 :[name=SirMalo]:Anyway, here, slip these on.
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 53
-              - 53
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Obtained a Key Item!
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$scene.message_window.windowskin_overwrite = 'm_18'"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$scene.message_window.auto_skip = true"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 15 \c[18]\N[1] received a pair of \c[27]Running Shoes\c[18]! [WAIT 130]
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 16 :[name=SirMalo]:Do you want me to give you a tour of the Central Hub?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11, 27]"
-                - "\\t[11, 28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11, 27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 17 :[name=SirMalo]:Follow me, I will show you the different services
-                we offer.
-          - !ruby/object:RPG::EventCommand
-            code: 246
-            indent: 1
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 241
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Hurry Along
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Making the player follow the event number 20
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - get_character(20).set_follower(gp)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the escalator
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [18, 46])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &71
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &72
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *71
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *72
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &73
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &74
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &75
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *73
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *74
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *75
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 18 :[name=SirMalo]:This escalator leads to the Wi-Fi area, where you
-                can test the \c[5]online features\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 19 :[name=SirMalo]:But for now, not all features are available...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 20 :[name=SirMalo]:Do not hesitate to inspect the \c[5]elevator event\c[0]
-                to check how it works and to reuse these in your own game.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the Nurse
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [18, 42])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &76
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &77
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &78
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *76
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *77
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *78
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 21 :[name=SirMalo]:Here is the Pokémon Center counter.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 22 :[name=SirMalo]:You can heal your Pokémon for free!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 23 :[name=SirMalo]:The event is \c[5]dynamic\c[0] and displays as many
-                Poké Balls as Pokémon in your party.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 24 :[name=SirMalo]:It also permits you to \c[5]teleport yourself to the
-                last visited Center\c[0] in case of defeat.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &79
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *79
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 25 :[name=SirMalo]:You also have the PC just right there which allows
-                you to access the Pokémon \c[5]storage system\c[0],
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the battle area
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [28, 42])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &80
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &81
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &82
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *80
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *81
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *82
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &83
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &84
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *83
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *84
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 26 :[name=SirMalo]:If you take these stairs, you'll end up in the Battle
-                Arena.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 27 :[name=SirMalo]:This place allows you to \c[5]setup every type of
-                battle\c[0] permitted by PokémonSDK.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the shop
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [31, 42])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &85
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &86
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &87
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *85
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *86
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *87
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 28 :[name=SirMalo]:This part is the Pokémon Shop.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 29 :[name=SirMalo]:You can buy all sorts of products to help you in your
-                journey.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 30 :[name=SirMalo]:PokémonSDK allows you to setup a lot of different
-                \c[5]shop types\c[0], with limited stocks or not.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the 2nd floor
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [28, 35])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [28, 30])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &88
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &89
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &90
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *88
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *89
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *90
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 31 :[name=SirMalo]:Alright, on this floor we can find many other systems.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &91
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *91
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 32 :[name=SirMalo]:Behind the left counter, you'll find the \c[5]Move
-                Reminder\c[0] and the \c[5]Move Tutor\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &92
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *92
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 33 :[name=SirMalo]:Behind the right counter is the \c[5]Day Care\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 34 :[name=SirMalo]:You can leave there up to two Pokémon to have them
-                train on their side.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 35 :[name=SirMalo]:Who knows, you might even get an Egg!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &93
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *93
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 36 :[name=SirMalo]:The seated people in the relaxation area just here
-                might also teach you useful things.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 37 :[name=SirMalo]:Don't hesitate to have a talk with them!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the elevator on the left
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [19, 30])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &94
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &95
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &96
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *94
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *95
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *96
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 38 :[name=SirMalo]:This elevator here allows you to visit the \c[5]Environmental
-                Zones\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 39 :[name=SirMalo]:These maps showcase all the environments you can create
-                with PokémonSDK, and their associated features.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Moving to the elevator on the right
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "get_character(20).find_path(to: [37, 30])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 20
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &97
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &98
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *97
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *98
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &99
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand &100
-                    code: 19
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &101
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *99
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *100
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *101
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 40 :[name=SirMalo]:Finally, this elevator allows you to visit the \c[5]System
-                Zones\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 41 :[name=SirMalo]:Those are different maps which contain most features
-                permitted inside events by PokémonSDK.
-          - !ruby/object:RPG::EventCommand
-            code: 246
-            indent: 1
-            parameters:
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 40
-          - !ruby/object:RPG::EventCommand
-            code: 241
-            indent: 1
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Battle Frontier Calm
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 20
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11, 28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 42 :[name=SirMalo]:I see I'm talking to a professional!
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 20
+        - 0
+        - 28
+        - 42
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &60 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &61 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &62 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Stopping the player from following Malo
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - get_character(20).reset_follower
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:exclamation, 20, wait=34, oy_offset: 8)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 43 :[name=SirMalo]:Oh, I see you still don't have any Pokémon!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Wait a second...
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 1
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "@choice_result = []"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:squirtle, :ivysaur, :charizard].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 2
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:cyndaquil, :bayleef, :feraligatr].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 3
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:mudkip, :grovyle, :blaziken].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 4
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:piplup, :monferno, :torterra].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:tepig, :dewott, :serperior].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 6
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:chespin, :braixen, :greninja].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Gen 7
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - choice = []
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "choice = [:popplio, :torracat, :decidueye].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
-                db_symbol, "
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "level: 30) }"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@choice_result << choice"
-          - !ruby/object:RPG::EventCommand
-            code: 112
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "@choices = ["
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 147),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 148),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 149),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 150),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 151),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 152),
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - ext_text(3, 153)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - "]"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - choice(26, -1, *@choices)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 44 :[name=SirMalo]:Here, choose one of these teams.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - PFM::Text.set_variable("[TEAM]", @choices[gv[26] - 1])
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - PFM::Text.set_variable("[PKM1]", @choice_result[gv[26] - 1][0].name)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - PFM::Text.set_variable("[PKM2]", @choice_result[gv[26] - 1][1].name)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 1
-            parameters:
-              - PFM::Text.set_variable("[PKM3]", @choice_result[gv[26] - 1][2].name)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 45 :[name=SirMalo]:So, you have chosen the [TEAM] Team, which includes
-                [PKM1], [PKM2] and [PKM3]. Does this suit you?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 1
-            parameters:
-              - - 3, 46 Yes
-                - 3, 47 No
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 0
-              - 3, 46 Yes
-          - !ruby/object:RPG::EventCommand
-            code: 113
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 1
-            parameters:
-              - 1
-              - 3, 47 No
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 413
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 249
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: Received a Pokemon
-                pitch: 100
-                volume: 100
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Changing the windowskin for the next message only
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - and making it end automatically (the "[WAIT]" at the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "end make it better) "
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$scene.message_window.windowskin_overwrite = 'm_18'"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$scene.message_window.auto_skip = true"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 48 \c[18]\N[1] obtains the \c[27][TEAM] \c[18]Team! [WAIT 150]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "@choice_result[gv[26] - 1].each { |pokemon| add_rename_pokemon(pokemon)
-                }"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$user_data[:player_team] = @choice_result[gv[26] - 1]"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "@choices = nil"
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 49 :[name=SirMalo]:Here, take this map of the Island.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - give_item(:town_map)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM::Text.reset_variables
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *60
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *61
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *62
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 50 :[name=SirMalo]:You are now ready to explore everything the Tower
-                has to show you!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 51 :[name=SirMalo]:Be curious, do not hesitate to interact with everything
-                you'll see.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 52 :[name=SirMalo]:By the way, every location on this Island possess
-                an item called \c[5]Intriguing Stone\c[0].
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 53 :[name=SirMalo]:Picking up this item, or getting it from a NPC, means
-                that you should have experienced everything the map offers.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 54 :[name=SirMalo]:Come see me when you've got them all back, I'll be
-                there by the elevator on the left!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 55 :[name=SirMalo]:Well, I'm off.
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Have fun!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Moving Malo to its original position
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "get_character(20).find_path(to: [24, 34])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - wait_event(20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 20
-              - 0
-              - 16
-              - 34
-              - 6
-          - !ruby/object:RPG::EventCommand
-            code: 121
-            indent: 0
-            parameters:
-              - 107
-              - 107
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$quests.speak_to_npc(0, 0)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$quests.check_up_signal"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "$quests.get_earnings(0)"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+          - &63 !ruby/object:RPG::MoveCommand
+            code: 16
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: C
-          self_switch_valid: false
-          switch1_id: 107
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+          - &64 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 15
+          - &65 !ruby/object:RPG::MoveCommand
+            code: 45
+            parameters:
+            - 'emotion(:exclamation, 0, oy_offset: 8)'
+          - &66 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 20
+          - &67 !ruby/object:RPG::MoveCommand
+            code: 1
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+          - &68 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *63
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *64
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *65
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *66
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *67
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *68
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 11 :[name=SirMalo]:Ah, here you are!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Welcome to the Tower!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 12 :[name=SirMalo]:Sorry, I realized when I got here that I forgot to
+          give you these Running Shoes...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 13 :[name=SirMalo]:I hope you're not angry?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 14 :[name=SirMalo]:Anyway, here, slip these on.
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 53
+        - 53
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Obtained a Key Item!
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$scene.message_window.windowskin_overwrite = 'm_18'"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$scene.message_window.auto_skip = true"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 15 \c[18]\N[1] received a pair of \c[27]Running Shoes\c[18]! [WAIT 130]
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 16 :[name=SirMalo]:Do you want me to give you a tour of the Central Hub?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11, 27]"
+          - "\\t[11, 28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11, 27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 17 :[name=SirMalo]:Follow me, I will show you the different services
+          we offer.
+      - !ruby/object:RPG::EventCommand
+        code: 246
+        indent: 1
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 241
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Hurry Along
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Making the player follow the event number 20
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - get_character(20).set_follower(gp)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the escalator
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [18, 46])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &69 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &70 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *69
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *70
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &71 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &72 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - &73 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *71
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *72
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *73
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 18 :[name=SirMalo]:This escalator leads to the Wi-Fi area, where you
+          can test the \c[5]online features\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 19 :[name=SirMalo]:But for now, not all features are available...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 20 :[name=SirMalo]:Do not hesitate to inspect the \c[5]elevator event\c[0]
+          to check how it works and to reuse these in your own game.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the Nurse
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [18, 42])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &74 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &75 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &76 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *74
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *75
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *76
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 21 :[name=SirMalo]:Here is the Pokémon Center counter.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 22 :[name=SirMalo]:You can heal your Pokémon for free!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 23 :[name=SirMalo]:The event is \c[5]dynamic\c[0] and displays as many
+          Poké Balls as Pokémon in your party.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 24 :[name=SirMalo]:It also permits you to \c[5]teleport yourself to the
+          last visited Center\c[0] in case of defeat.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &77 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *77
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 25 :[name=SirMalo]:You also have the PC just right there which allows
+          you to access the Pokémon \c[5]storage system\c[0],
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the battle area
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [28, 42])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &78 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &79 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - &80 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *78
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *79
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *80
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &81 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - &82 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *81
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *82
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 26 :[name=SirMalo]:If you take these stairs, you'll end up in the Battle
+          Arena.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 27 :[name=SirMalo]:This place allows you to \c[5]setup every type of
+          battle\c[0] permitted by PokémonSDK.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the shop
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [31, 42])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &83 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &84 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &85 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *83
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *84
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *85
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 28 :[name=SirMalo]:This part is the Pokémon Shop.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 29 :[name=SirMalo]:You can buy all sorts of products to help you in your
+          journey.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 30 :[name=SirMalo]:PokémonSDK allows you to setup a lot of different
+          \c[5]shop types\c[0], with limited stocks or not.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the 2nd floor
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [28, 35])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [28, 30])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &86 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &87 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &88 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *86
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *87
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *88
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 31 :[name=SirMalo]:Alright, on this floor we can find many other systems.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &89 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *89
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 32 :[name=SirMalo]:Behind the left counter, you'll find the \c[5]Move
+          Reminder\c[0] and the \c[5]Move Tutor\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &90 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *90
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 33 :[name=SirMalo]:Behind the right counter is the \c[5]Day Care\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 34 :[name=SirMalo]:You can leave there up to two Pokémon to have them
+          train on their side.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 35 :[name=SirMalo]:Who knows, you might even get an Egg!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &91 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *91
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 36 :[name=SirMalo]:The seated people in the relaxation area just here
+          might also teach you useful things.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 37 :[name=SirMalo]:Don't hesitate to have a talk with them!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the elevator on the left
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [19, 30])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &92 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &93 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &94 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *92
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *93
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *94
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 38 :[name=SirMalo]:This elevator here allows you to visit the \c[5]Environmental
+          Zones\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 39 :[name=SirMalo]:These maps showcase all the environments you can create
+          with PokémonSDK, and their associated features.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Moving to the elevator on the right
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'get_character(20).find_path(to: [37, 30])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 20
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &95 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &96 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *95
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *96
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &97 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - &98 !ruby/object:RPG::MoveCommand
+            code: 19
+            parameters: []
+          - &99 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *97
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *98
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *99
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 40 :[name=SirMalo]:Finally, this elevator allows you to visit the \c[5]System
+          Zones\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 41 :[name=SirMalo]:Those are different maps which contain most features
+          permitted inside events by PokémonSDK.
+      - !ruby/object:RPG::EventCommand
+        code: 246
+        indent: 1
+        parameters:
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 40
+      - !ruby/object:RPG::EventCommand
+        code: 241
+        indent: 1
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Battle Frontier Calm
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 20
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11, 28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 42 :[name=SirMalo]:I see I'm talking to a professional!
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Stopping the player from following Malo
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - get_character(20).reset_follower
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:exclamation, 20, wait=34, oy_offset: 8)'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 43 :[name=SirMalo]:Oh, I see you still don't have any Pokémon!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Wait a second...
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 1
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "@choice_result = []"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:squirtle, :ivysaur, :charizard].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 2
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:cyndaquil, :bayleef, :feraligatr].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 3
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:mudkip, :grovyle, :blaziken].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 4
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:piplup, :monferno, :torterra].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:tepig, :dewott, :serperior].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 6
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:chespin, :braixen, :greninja].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Gen 7
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - choice = []
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'choice = [:popplio, :torracat, :decidueye].map { |db_symbol| PFM::Pokemon.generate_from_hash(id:
+          db_symbol, '
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - 'level: 30) }'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@choice_result << choice"
+      - !ruby/object:RPG::EventCommand
+        code: 112
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - "@choices = ["
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 147),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 148),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 149),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 150),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 151),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 152),
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - ext_text(3, 153)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - "]"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - choice(26, -1, *@choices)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 44 :[name=SirMalo]:Here, choose one of these teams.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - PFM::Text.set_variable("[TEAM]", @choices[gv[26] - 1])
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - PFM::Text.set_variable("[PKM1]", @choice_result[gv[26] - 1][0].name)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - PFM::Text.set_variable("[PKM2]", @choice_result[gv[26] - 1][1].name)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 1
+        parameters:
+        - PFM::Text.set_variable("[PKM3]", @choice_result[gv[26] - 1][2].name)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 45 :[name=SirMalo]:So, you have chosen the [TEAM] Team, which includes
+          [PKM1], [PKM2] and [PKM3]. Does this suit you?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 1
+        parameters:
+        - - 3, 46 Yes
+          - 3, 47 No
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 0
+        - 3, 46 Yes
+      - !ruby/object:RPG::EventCommand
+        code: 113
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 1
+        parameters:
+        - 1
+        - 3, 47 No
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 413
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 249
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: Received a Pokemon
+          pitch: 100
+          volume: 100
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Changing the windowskin for the next message only
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - and making it end automatically (the "[WAIT]" at the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'end make it better) '
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$scene.message_window.windowskin_overwrite = 'm_18'"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$scene.message_window.auto_skip = true"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 48 \c[18]\N[1] obtains the \c[27][TEAM] \c[18]Team! [WAIT 150]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "@choice_result[gv[26] - 1].each { |pokemon| add_rename_pokemon(pokemon)
+          }"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$user_data[:player_team] = @choice_result[gv[26] - 1]"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "@choices = nil"
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 49 :[name=SirMalo]:Here, take this map of the Island.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - give_item(:town_map)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM::Text.reset_variables
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 50 :[name=SirMalo]:You are now ready to explore everything the Tower
+          has to show you!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 51 :[name=SirMalo]:Be curious, do not hesitate to interact with everything
+          you'll see.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 52 :[name=SirMalo]:By the way, every location on this Island possess
+          an item called \c[5]Intriguing Stone\c[0].
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 53 :[name=SirMalo]:Picking up this item, or getting it from a NPC, means
+          that you should have experienced everything the map offers.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 54 :[name=SirMalo]:Come see me when you've got them all back, I'll be
+          there by the elevator on the left!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 55 :[name=SirMalo]:Well, I'm off.
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Have fun!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Moving Malo to its original position
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'get_character(20).find_path(to: [24, 34])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - wait_event(20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 20
+        - 0
+        - 16
+        - 34
+        - 6
+      - !ruby/object:RPG::EventCommand
+        code: 121
+        indent: 0
+        parameters:
+        - 107
+        - 107
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$quests.speak_to_npc(0, 0)"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$quests.check_up_signal"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "$quests.get_earnings(0)"
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: C
+        self_switch_valid: false
+        switch1_id: 107
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 29
     y: 49
   22: !ruby/object:RPG::Event
     id: 22
     name: Move Reminder
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Scientist-M
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Scientist-M
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 56 Hello!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - I know everything about the moves a Pokémon can learn when growing.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 57 If you want, I can teach one of your companions a move they might
+          have forget during their growth.
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - !binary |-
+          Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - call_party_menu
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - Checking if a move can be reminded
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 12
+        - can_move_reminder_be_called?
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - Checking if no move was reminded
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 2
+        parameters:
+        - 12
+        - "!move_reminder"
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 3
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 3
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 3, 58 Nothing suited you?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 2
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 3, 59 I'm sure your Pokémon will be stronger this way!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 2
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 2
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 3, 60 Unfortunately, there is nothing to teach to your Pokémon...
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 61 You can sometimes come across unsuspected moves!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 56 Hello!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - I know everything about the moves a Pokémon can learn when growing.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 57 If you want, I can teach one of your companions a move they might
-                have forget during their growth.
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - !binary |-
-                Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - call_party_menu
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - Checking if a move can be reminded
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 12
-              - can_move_reminder_be_called?
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - Checking if no move was reminded
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 2
-            parameters:
-              - 12
-              - "!move_reminder"
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 3
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 3
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 3, 58 Nothing suited you?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 2
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 3, 59 I'm sure your Pokémon will be stronger this way!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 2
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 2
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 3, 60 Unfortunately, there is nothing to teach to your Pokémon...
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 61 You can sometimes come across unsuspected moves!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 24
     y: 28
   23: !ruby/object:RPG::Event
     id: 23
     name: Move Tutor
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Scientist-F
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Scientist-F
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 62 I can teach a very useful move to help you catch Pokémon.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 63 Are you interested?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11,27]"
+          - "\\t[11,28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11,27]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 64 To which Pokémon do you want to teach it?
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - !binary |-
+          Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - !binary |-
+          VGhlIGNob3NlbiBQb2vDqW1vbiBpcyBzdG9yZWQgaW4gdmFyaWFibGUgNDMu
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - call_party_menu
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 1
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 1
+        - 43
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - !binary |-
+          VGhlbiwgd2UgY2hlY2sgaWYgdGhlIFBva8OpbW9uIGNhbiBsZWFybiBpdCBvciBub3Q=
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - "(not in the moveset or already learnt)"
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 2
+        parameters:
+        - 12
+        - gv[43] >= 0 && $actors[gv[43]].can_learn?(:false_swipe)
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 3
+        parameters:
+        - Learning the move
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 3
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 3
+        parameters:
+        - skill_learn(gv[43], :false_swipe)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 3, 65 This move always leaves at least 1 HP to its target.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 3, 66 It's a must-have for any self-respecting Trainer, if you want my opinion.
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 3
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 3
+        parameters:
+        - !binary |-
+          SWYgdGhlIGNob3NlbiBQb2vDqW1vbiBjYW4ndCBsZWFybiB0aGUgbW92ZQ==
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 3
+        parameters:
+        - or has already learnt it
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 3
+        parameters:
+        - 3, 67 Unfortunately, I can't teach this move to your Pokémon...
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 3
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 3
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 2
+        parameters:
+        - If the player exited the party menu without selecting a
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 2
+        parameters:
+        - !binary |-
+          UG9rw6ltb24=
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 2
+        parameters:
+        - 3, 68 Did you change your mind?
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 2
+        parameters:
+        - Event end
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11,28]"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 69 But this move can be very useful for some very delicate catches.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - Event End
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 62 I can teach a very useful move to help you catch Pokémon.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 63 Are you interested?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11,27]"
-                - "\\t[11,28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11,27]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 64 To which Pokémon do you want to teach it?
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - !binary |-
-                Q2FsbGluZyB0aGUgUGFydHkgbWVudSB0byBzZWxlY3QgYSBQb2vDqW1vbi4=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - !binary |-
-                VGhlIGNob3NlbiBQb2vDqW1vbiBpcyBzdG9yZWQgaW4gdmFyaWFibGUgNDMu
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - call_party_menu
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 1
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 1
-              - 43
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - !binary |-
-                VGhlbiwgd2UgY2hlY2sgaWYgdGhlIFBva8OpbW9uIGNhbiBsZWFybiBpdCBvciBub3Q=
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - "(not in the moveset or already learnt)"
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 2
-            parameters:
-              - 12
-              - gv[43] >= 0 && $actors[gv[43]].can_learn?(:false_swipe)
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 3
-            parameters:
-              - Learning the move
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 3
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 3
-            parameters:
-              - skill_learn(gv[43], :false_swipe)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 3, 65 This move always leaves at least 1 HP to its target.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 3, 66 It's a must-have for any self-respecting Trainer, if you want my opinion.
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 3
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 3
-            parameters:
-              - !binary |-
-                SWYgdGhlIGNob3NlbiBQb2vDqW1vbiBjYW4ndCBsZWFybiB0aGUgbW92ZQ==
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 3
-            parameters:
-              - or has already learnt it
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 3
-            parameters:
-              - 3, 67 Unfortunately, I can't teach this move to your Pokémon...
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 3
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 3
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 2
-            parameters:
-              - If the player exited the party menu without selecting a
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 2
-            parameters:
-              - !binary |-
-                UG9rw6ltb24=
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 2
-            parameters:
-              - 3, 68 Did you change your mind?
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 2
-            parameters:
-              - Event end
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11,28]"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 69 But this move can be very useful for some very delicate catches.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - Event End
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 26
     y: 28
   24: !ruby/object:RPG::Event
     id: 24
     name: Daycare woman
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Woman-03
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Woman-03
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable allows you to have multiple daycares
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 46
+        - 46
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Calling this common event is enough to launch the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - Daycare management system.
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 16
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable allows you to have multiple daycares
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 46
-              - 46
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Calling this common event is enough to launch the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - Daycare management system.
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 16
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 30
     y: 28
   25: !ruby/object:RPG::Event
     id: 25
     name: Daycare man
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Man-06
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Man-06
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable allows you to have multiple daycares
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 46
+        - 46
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Calling this common event is enough to launch the
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - Daycare status system.
+      - !ruby/object:RPG::EventCommand
+        code: 117
+        indent: 0
+        parameters:
+        - 17
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable allows you to have multiple daycares
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 46
-              - 46
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Calling this common event is enough to launch the
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - Daycare status system.
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 17
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 28
   26: !ruby/object:RPG::Event
     id: 26
     name: Malo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 107
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 107
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 70 :[name=SirMalo]:Well, \N[1]!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - So, how is your exploration faring?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 71 :[name=SirMalo]:Just for the record, there is 16 Intriguing Stones
+          in this demo.
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking the quantity of Intriguing Stones with this
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - command because it's a Rare Object
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$game_variables[26] = $bag.item_quantity(:intriguing_stone)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - PFM::Text.set_variable('[STONE]', gv[26].to_s)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 72 :[name=SirMalo]:And I see you have... [STONE] of these!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking if the player has more than 16 stones and/or
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - if they got one in an inexpected way
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gv[26] >= 16 && get_self_switch('A', 17, 21) == false
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 73 :[name=SirMalo]:... I know someone who used the console!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 74 :[name=SirMalo]:It's very good to learn how to use it!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 75 :[name=SirMalo]:But be sure not to spoil you the game experience and
+          the fun learning moment we're offering with this demo.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 76 :[name=SirMalo]:If you already have completed this demo before, and
+          you just want to receive the reward again, you can continue!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 77 :[name=SirMalo]:Else, I invite you to continue playing the normal
+          way, you'll learn a lot more this way!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 78 :[name=SirMalo]:I'm still going to tell you my speech, just in case.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 16
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 79 :[name=SirMalo]:Congratulations!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - You have obtained every Intriguing Stones!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 80 :[name=SirMalo]:This means you should have memorized where each feature
+          is showed!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 81 :[name=SirMalo]:Thanks to that, you'll know which map you should refer
+          to when you have a doubt about a given feature.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 82 :[name=SirMalo]:Again, congrats!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - By the way, I have a small surprise for you, to commemorate the end of your
+          journey...
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - Follow me!
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 1
+        parameters:
+        - 'NOTE: The events for the screenshot cinematic are'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 1
+        parameters:
+        - located on the top-left corner of this map
+      - !ruby/object:RPG::EventCommand
+        code: 231
+        indent: 1
+        parameters:
+        - 1
+        - black
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 1
+        parameters:
+        - 1
+        - 30
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 40
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - set_self_switch(true, 'A', 41)
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 1
+        parameters:
+        - B
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 13
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 83 :[name=SirMalo]:Just a little more effort, you're almost there!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 10
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 84 :[name=SirMalo]:You're on the right way!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 85 :[name=SirMalo]:Some are harder to find than others, but you can do
+          it!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 8
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 86 :[name=SirMalo]:You've done one half, well played!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - Don't let up in your efforts!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 6
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 87 :[name=SirMalo]:Not bad!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - You've almost done the first half!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - Keep it up!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 3
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 88 :[name=SirMalo]:You're progressing well!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 89 :[name=SirMalo]:Did you encounter some of my colleagues?
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - They all have an Intriguing Stone, so go on and find them!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 1
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 90 :[name=SirMalo]:So, do you enjoy the demo?
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - We gave it our all to make you have a nice moment on it!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 91 :[name=SirMalo]:Don't hesitate to explore and talk to everyone!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 1
+        parameters:
+        - You'll learn lots of things this way!
+      - !ruby/object:RPG::EventCommand
+        code: 119
+        indent: 1
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 118
+        indent: 0
+        parameters:
+        - EndCondition
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - 'Warning: you must ALWAYS reset the variables at the'
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - 'end of the event with: PFM::Text.reset_variables'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - PFM::Text.reset_variables
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 70 :[name=SirMalo]:Well, \N[1]!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - So, how is your exploration faring?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 71 :[name=SirMalo]:Just for the record, there is 16 Intriguing Stones
-                in this demo.
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking the quantity of Intriguing Stones with this
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - command because it's a Rare Object
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$game_variables[26] = $bag.item_quantity(:intriguing_stone)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - PFM::Text.set_variable('[STONE]', gv[26].to_s)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 72 :[name=SirMalo]:And I see you have... [STONE] of these!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking if the player has more than 16 stones and/or
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - if they got one in an inexpected way
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gv[26] >= 16 && get_self_switch('A', 17, 21) == false
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 73 :[name=SirMalo]:... I know someone who used the console!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 74 :[name=SirMalo]:It's very good to learn how to use it!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 75 :[name=SirMalo]:But be sure not to spoil you the game experience and
-                the fun learning moment we're offering with this demo.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 76 :[name=SirMalo]:If you already have completed this demo before, and
-                you just want to receive the reward again, you can continue!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 77 :[name=SirMalo]:Else, I invite you to continue playing the normal
-                way, you'll learn a lot more this way!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 78 :[name=SirMalo]:I'm still going to tell you my speech, just in case.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 16
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 79 :[name=SirMalo]:Congratulations!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - You have obtained every Intriguing Stones!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 80 :[name=SirMalo]:This means you should have memorized where each feature
-                is showed!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 81 :[name=SirMalo]:Thanks to that, you'll know which map you should refer
-                to when you have a doubt about a given feature.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 82 :[name=SirMalo]:Again, congrats!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - By the way, I have a small surprise for you, to commemorate the end of your
-                journey...
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - Follow me!
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 1
-            parameters:
-              - "NOTE: The events for the screenshot cinematic are"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 1
-            parameters:
-              - located on the top-left corner of this map
-          - !ruby/object:RPG::EventCommand
-            code: 231
-            indent: 1
-            parameters:
-              - 1
-              - black
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 1
-            parameters:
-              - 1
-              - 30
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 40
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - set_self_switch(true, 'A', 41)
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 1
-            parameters:
-              - B
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 13
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 83 :[name=SirMalo]:Just a little more effort, you're almost there!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 10
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 84 :[name=SirMalo]:You're on the right way!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 85 :[name=SirMalo]:Some are harder to find than others, but you can do
-                it!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 8
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 86 :[name=SirMalo]:You've done one half, well played!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - Don't let up in your efforts!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 6
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 87 :[name=SirMalo]:Not bad!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - You've almost done the first half!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - Keep it up!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 3
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 88 :[name=SirMalo]:You're progressing well!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 89 :[name=SirMalo]:Did you encounter some of my colleagues?
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - They all have an Intriguing Stone, so go on and find them!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 1
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 90 :[name=SirMalo]:So, do you enjoy the demo?
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - We gave it our all to make you have a nice moment on it!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 91 :[name=SirMalo]:Don't hesitate to explore and talk to everyone!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 1
-            parameters:
-              - You'll learn lots of things this way!
-          - !ruby/object:RPG::EventCommand
-            code: 119
-            indent: 1
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 118
-            indent: 0
-            parameters:
-              - EndCondition
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - "Warning: you must ALWAYS reset the variables at the"
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - "end of the event with: PFM::Text.reset_variables"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - PFM::Text.reset_variables
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: B
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: B
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 92 :[name=SirMalo]:Oh hi \N[1], how are you? I hope you enjoyed this
+          little surprise, and you had fun playing this technical demo!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 93 :[name=SirMalo]:I also hope it'll be useful to you in the future,
+          if you're seeking some information for your own fangame!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 94 :[name=SirMalo]:Let us know if you happen to create your own!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 92 :[name=SirMalo]:Oh hi \N[1], how are you? I hope you enjoyed this
-                little surprise, and you had fun playing this technical demo!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 93 :[name=SirMalo]:I also hope it'll be useful to you in the future,
-                if you're seeking some information for your own fangame!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 94 :[name=SirMalo]:Let us know if you happen to create your own!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 16
     y: 34
   27: !ruby/object:RPG::Event
     id: 27
     name: Roughneck
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Maximo
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 95 Who's daddy's little good boy?
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "emotion(:nocomment, 27, wait=70, oy_offset: 16)"
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &102
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &103
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *102
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *103
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 96 Erm, it's not what it looks like..!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &104
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &105
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &106
-                    code: 15
-                    parameters:
-                      - 10
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *104
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *105
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *106
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 97 Rockruff, use Growl!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - emotion(:exclamation, 28, wait=70)
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - cry_pokemon(:rockruff)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 15
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 98 Good!
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Maximo
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 95 Who's daddy's little good boy?
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'emotion(:nocomment, 27, wait=70, oy_offset: 16)'
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Maximo
-          direction: 6
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 99 My Rockruff is very strong, and it intimidates every Pokémon we're
-                battling!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+          - &100 !ruby/object:RPG::MoveCommand
+            code: 36
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &101 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *100
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *101
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 96 Erm, it's not what it looks like..!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &102 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - &103 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - &104 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 10
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *102
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *103
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *104
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 97 Rockruff, use Growl!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - emotion(:exclamation, 28, wait=70)
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - cry_pokemon(:rockruff)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 15
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 98 Good!
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Maximo
+        direction: 6
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 99 My Rockruff is very strong, and it intimidates every Pokémon we're
+          battling!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 31
     y: 33
   28: !ruby/object:RPG::Event
     id: 28
     name: Rockruff
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: "0744"
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 100 Would you like to pet the Rockruff?
-          - !ruby/object:RPG::EventCommand
-            code: 102
-            indent: 0
-            parameters:
-              - - "\\t[11, 27]"
-                - "\\t[11, 28]"
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 0
-              - "\\t[11, 27]"
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &107
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &108
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &109
-                    code: 15
-                    parameters:
-                      - 15
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *107
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *108
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *109
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "emotion(:love, 28, wait=70, oy_offset: 8)"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - cry_pokemon(:rockruff)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 101 Ruff! Ruff!
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &110
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &111
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *110
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *111
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 402
-            indent: 0
-            parameters:
-              - 1
-              - "\\t[11, 28]"
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &112
-                    code: 36
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &113
-                    code: 25
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &114
-                    code: 15
-                    parameters:
-                      - 15
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *112
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *113
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *114
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 1
-            parameters:
-              - "emotion(:sad, 28, wait=70, oy_offset: 8)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 1
-            parameters:
-              - 3, 102 Rockruff seems disappointed...
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 1
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &115
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &116
-                    code: 35
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *115
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *116
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 404
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: '0744'
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 100 Would you like to pet the Rockruff?
+      - !ruby/object:RPG::EventCommand
+        code: 102
+        indent: 0
+        parameters:
+        - - "\\t[11, 27]"
+          - "\\t[11, 28]"
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 0
+        - "\\t[11, 27]"
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &105 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - &106 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &107 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 15
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *105
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *106
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *107
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'emotion(:love, 28, wait=70, oy_offset: 8)'
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - cry_pokemon(:rockruff)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 101 Ruff! Ruff!
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &108 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - &109 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *108
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *109
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 402
+        indent: 0
+        parameters:
+        - 1
+        - "\\t[11, 28]"
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &110 !ruby/object:RPG::MoveCommand
+            code: 36
+            parameters: []
+          - &111 !ruby/object:RPG::MoveCommand
+            code: 25
+            parameters: []
+          - &112 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 15
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *110
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *111
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *112
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 1
+        parameters:
+        - 'emotion(:sad, 28, wait=70, oy_offset: 8)'
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 1
+        parameters:
+        - 3, 102 Rockruff seems disappointed...
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 1
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &113 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - &114 !ruby/object:RPG::MoveCommand
+            code: 35
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *113
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *114
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 404
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 32
     y: 33
   29: !ruby/object:RPG::Event
     id: 29
     name: "$Jules"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 101
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Roughneck
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 101
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Roughneck
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 103 :[name=Jules]:Do you know about this chick who fell off the other
+          side of the guardrail not long ago, behind the Tower?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 104 :[name=Jules]:No kidding, dying like that is wack, not even badass
+          or something...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 105 :[name=Jules]:Some people are saying her ghost haunts the grounds
+          at night since her death.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 106 :[name=Jules]:If I died the same way, I'd be too salty not to haunt
+          the area.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 107 :[name=Jules]:But well, revenants don't exist, the only ghosts are
+          the Pokémon, right..?
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 103 :[name=Jules]:Do you know about this chick who fell off the other
-                side of the guardrail not long ago, behind the Tower?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 104 :[name=Jules]:No kidding, dying like that is wack, not even badass
-                or something...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 105 :[name=Jules]:Some people are saying her ghost haunts the grounds
-                at night since her death.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 106 :[name=Jules]:If I died the same way, I'd be too salty not to haunt
-                the area.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 107 :[name=Jules]:But well, revenants don't exist, the only ghosts are
-                the Pokémon, right..?
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 101
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 108 :[name=Jules]:Ya want some help maybe?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 109 :[name=Jules]:... Yo, you got somethin' to say to me?
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Spit it out, I'm all ears.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 110 .[WAIT 10].[WAIT 10].[WAIT 30]
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - emotion(:exclamation)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 40
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 111 :[name=Jules]:What you talkin' 'bout, fam?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 112 :[name=Jules]:Ayy, there's this chick Marissa lookin' to drop some
+          love letters on me?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 113 :[name=Jules]:I'm feelin' it, but like...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 114 :[name=Jules]:LMFAO, who's that?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 115 :[name=Jules]:Like, why ain't she come up and tell me herself?
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - I don't even know this Marissa chick.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 116 :[name=Jules]:Alright, if she's lookin' to get to know each other,
+          I'll make an effort, you know, being the classy gentleman I am and all that.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 117 :[name=Jules]:So where's she at then?
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - emotion(:nocomment, 0, wait=60, oy_offset:16)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 118 :[name=Jules]:Huh... What? She literally dead?!
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Elle est morte ?!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 119 :[name=Jules]:Hold up, you ain't tellin' me she's the chick who went
+          down recently, right?!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 120 :[name=Jules]:Aight, I don't wanna know nothin' more, I'm out, peace.
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &115 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - &116 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 101
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *115
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *116
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$quests.speak_to_npc(2, 0)"
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 108 :[name=Jules]:Ya want some help maybe?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 109 :[name=Jules]:... Yo, you got somethin' to say to me?
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Spit it out, I'm all ears.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 110 .[WAIT 10].[WAIT 10].[WAIT 30]
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - emotion(:exclamation)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 40
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 111 :[name=Jules]:What you talkin' 'bout, fam?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 112 :[name=Jules]:Ayy, there's this chick Marissa lookin' to drop some
-                love letters on me?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 113 :[name=Jules]:I'm feelin' it, but like...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 114 :[name=Jules]:LMFAO, who's that?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 115 :[name=Jules]:Like, why ain't she come up and tell me herself?
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - I don't even know this Marissa chick.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 116 :[name=Jules]:Alright, if she's lookin' to get to know each other,
-                I'll make an effort, you know, being the classy gentleman I am and all that.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 117 :[name=Jules]:So where's she at then?
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - emotion(:nocomment, 0, wait=60, oy_offset:16)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 118 :[name=Jules]:Huh... What? She literally dead?!
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Elle est morte ?!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 119 :[name=Jules]:Hold up, you ain't tellin' me she's the chick who went
-                down recently, right?!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 120 :[name=Jules]:Aight, I don't wanna know nothin' more, I'm out, peace.
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &117
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &118
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *117
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *118
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$quests.speak_to_npc(2, 0)"
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 101
-          switch1_valid: true
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 101
+        switch1_valid: true
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 121 :[name=Jules]:Yo, stop talkin' to me, please. That ghost story of
+          yours is giving me the chills. I'm out.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 122 :[name=Jules]:Hope you ain't cursed me with that nonsense of yours.
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 121 :[name=Jules]:Yo, stop talkin' to me, please. That ghost story of
-                yours is giving me the chills. I'm out.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 122 :[name=Jules]:Hope you ain't cursed me with that nonsense of yours.
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 28
     y: 36
   3: !ruby/object:RPG::Event
@@ -6935,1228 +6861,1228 @@ events:
     name: !binary |-
       wqcgTGVmdCBlbGV2YXRvciBkb29y
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &119
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &120
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &121
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &122
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &123
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *119
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *120
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *121
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *122
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *123
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable tells the game from which floor the playe came inside the
-                elevator.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 4
-              - 12
-              - 16
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &124
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &125
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &126
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &127
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &128
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *124
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *125
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *126
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *127
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *128
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &117 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &118 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &119 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &120 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The animation will play in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &121 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *117
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *118
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *119
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *120
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *121
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable tells the game from which floor the playe came inside the
+          elevator.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 4
+        - 12
+        - 16
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &122 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &123 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &124 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &125 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &126 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *122
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *123
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *124
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *125
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *126
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The animation will play in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 19
     y: 29
   30: !ruby/object:RPG::Event
     id: 30
     name: EasterEggOWO
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 123 It's a promotional poster. A slogan is written on it.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 124 "You wanna be the very best, like no one ever was.
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - If catching the best is your real quest, and to train them is your cause,
+          join your local league!"
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 123 It's a promotional poster. A slogan is written on it.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 124 "You wanna be the very best, like no one ever was.
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - If catching the best is your real quest, and to train them is your cause,
-                join your local league!"
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 22
     y: 38
   31: !ruby/object:RPG::Event
     id: 31
     name: Malo Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 0
     y: 0
   32: !ruby/object:RPG::Event
     id: 32
     name: Rey Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_ranger
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_ranger
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 1
     y: 0
   33: !ruby/object:RPG::Event
     id: 33
     name: Yuri Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Book-girl
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Book-girl
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 2
     y: 0
   34: !ruby/object:RPG::Event
     id: 34
     name: Aerun Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Hiker-03
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Hiker-03
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 3
     y: 0
   35: !ruby/object:RPG::Event
     id: 35
     name: Palbolsky Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Dragon-tamer-02
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Dragon-tamer-02
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 4
     y: 0
   36: !ruby/object:RPG::Event
     id: 36
     name: Walven Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Rich-Boy-2
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Rich-Boy-2
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 5
     y: 0
   37: !ruby/object:RPG::Event
     id: 37
     name: Scorbutics Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Veteran-02
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Veteran-02
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 6
     y: 0
   38: !ruby/object:RPG::Event
     id: 38
     name: Starter1 Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 0
     y: 1
   39: !ruby/object:RPG::Event
     id: 39
     name: Starter2 Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 1
     y: 1
   4: !ruby/object:RPG::Event
@@ -8164,1002 +8090,1002 @@ events:
     name: !binary |-
       wqcgcmlnaHQgZWxldmF0b3IgZG9vcg==
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Animation of the door above
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &129
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &130
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &131
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &132
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &133
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *129
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *130
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *131
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *132
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *133
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This variable tells the game from which floor the playe came
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - inside the elevator.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 103
-              - 103
-              - 0
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 12
-              - 12
-              - 16
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Animation of the door above
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 2
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: door_elevator
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: se_door_slide
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Opening animation of this door
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &134
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand &135
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &136
-                    code: 1
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &137
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand &138
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *134
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *135
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *136
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *137
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *138
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
+          - &127 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
+          - &128 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
+            - 2
+          - &129 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &130 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - Closing animation of this door. The animation will play in reverse.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - animate_from_charset([0,1],20,reverse:true)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 22
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
+            - 3
+          - &131 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
             code: 0
-            indent: 0
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *127
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *128
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *129
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *130
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *131
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This variable tells the game from which floor the playe came
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - inside the elevator.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 103
+        - 103
+        - 0
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 12
+        - 12
+        - 16
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 2
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: door_elevator
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: se_door_slide
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Opening animation of this door
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &132 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - &133 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 2
+          - &134 !ruby/object:RPG::MoveCommand
+            code: 1
+            parameters: []
+          - &135 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - &136 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *132
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *133
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *134
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *135
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *136
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Closing animation of this door. The animation will play in reverse.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - animate_from_charset([0,1],20,reverse:true)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 22
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          UmVlbmFibGluZyB0aGUgZm9sbG93ZXIgUG9rw6ltb24gaWYgdGhpcyBvcHRpb24gd2FzIGFjdGl2YXRlZA==
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 37
     y: 29
   40: !ruby/object:RPG::Event
     id: 40
     name: Starter3 Photo
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 0
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Clerk
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 0
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Clerk
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 2
     y: 1
   41: !ruby/object:RPG::Event
     id: 41
     name: Photo Event
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "(31..40).each { |id| set_self_switch(true, 'A', id) }"
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 3
-              - 28
-              - 43
-              - 4
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 31
-              - 0
-              - 27
-              - 43
-              - 6
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 32
-              - 0
-              - 29
-              - 43
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 33
-              - 0
-              - 28
-              - 42
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 34
-              - 0
-              - 27
-              - 42
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 35
-              - 0
-              - 29
-              - 42
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 36
-              - 0
-              - 26
-              - 42
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 37
-              - 0
-              - 30
-              - 42
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - ge(38).set_appearance($user_data[:player_team][0].character_name)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - ge(39).set_appearance($user_data[:player_team][1].character_name)
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - ge(40).set_appearance($user_data[:player_team][2].character_name)
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 38
-              - 0
-              - 27
-              - 44
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 39
-              - 0
-              - 28
-              - 44
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 202
-            indent: 0
-            parameters:
-              - 40
-              - 0
-              - 29
-              - 44
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 0
-            parameters:
-              - 1
-              - 30
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 235
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 125 :[name=SirMalo]:Here we are, with the whole team and your very first
-                Pokémon!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 126 :[name=SirMalo]:What we're going to do?
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 127 :[name=SirMalo]:We're going to take a commemorative photo!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 128 :[name=SirMalo]:Look down...
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &139
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *139
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 31
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &140
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *140
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 32
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &141
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *141
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 129 :[name=SirMalo]:Say "Chespin"!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 130 :[name=Everyone]::[align=center]:CHESPIN!
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - take_screenshot("technical_demo.png", scale = 2)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 224
-            indent: 0
-            parameters:
-              - !ruby/object:Color
-                red: 255
-                green: 255
-                blue: 255
-                alpha: 255
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &142
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *142
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 31
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &143
-                    code: 18
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *143
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 32
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &144
-                    code: 17
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *144
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 131 :[name=SirMalo]:There, the photo is taken... Or should I say the
-                screenshot!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 132 :[name=SirMalo]:You can find it in the folder of the demo, named
-                "technical_demo.png".
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - "3, 133 :[name=SirMalo]:We would love if you could share this screen and
-                your reactions about the demo on the Pokémon Workshop Discord server, in
-                the channel #psdk-talk!"
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - !binary |-
-                cmVtYXJxdWVzIGV0IHRlcyBjb21tZW50YWlyZXMgc3VyIGNldHRlIGTDqW1vICE=
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 134 :[name=SirMalo]:Thanks again for playing until the end, we hope you
-                had as much fun when journeying through this demo as us creating it!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 135 :[name=SirMalo]:We hope to see you soon on the Discord!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 136 :[name=SirMalo]:And now, roll the credits!
-          - !ruby/object:RPG::EventCommand
-            code: 231
-            indent: 0
-            parameters:
-              - 1
-              - black
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 0
-            parameters:
-              - 1
-              - 10
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 255
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 3
-              - 25
-              - 33
-              - 2
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "(31..40).each { |id| delete_event_forever(id) }"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$scene.call_scene(GamePlay::CreditScene)"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - force_save
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - "@wait = 1"
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 232
-            indent: 0
-            parameters:
-              - 1
-              - 30
-              - 0
-              - 0
-              - 0
-              - 0
-              - 100
-              - 100
-              - 0
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 30
-          - !ruby/object:RPG::EventCommand
-            code: 235
-            indent: 0
-            parameters:
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "(31..40).each { |id| set_self_switch(true, 'A', id) }"
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 3
+        - 28
+        - 43
+        - 4
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 31
+        - 0
+        - 27
+        - 43
+        - 6
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 32
+        - 0
+        - 29
+        - 43
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 33
+        - 0
+        - 28
+        - 42
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 34
+        - 0
+        - 27
+        - 42
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 35
+        - 0
+        - 29
+        - 42
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 36
+        - 0
+        - 26
+        - 42
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 37
+        - 0
+        - 30
+        - 42
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - ge(38).set_appearance($user_data[:player_team][0].character_name)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - ge(39).set_appearance($user_data[:player_team][1].character_name)
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - ge(40).set_appearance($user_data[:player_team][2].character_name)
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 38
+        - 0
+        - 27
+        - 44
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 39
+        - 0
+        - 28
+        - 44
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 202
+        indent: 0
+        parameters:
+        - 40
+        - 0
+        - 29
+        - 44
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 0
+        parameters:
+        - 1
+        - 30
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 235
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 125 :[name=SirMalo]:Here we are, with the whole team and your very first
+          Pokémon!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 126 :[name=SirMalo]:What we're going to do?
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 127 :[name=SirMalo]:We're going to take a commemorative photo!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 128 :[name=SirMalo]:Look down...
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &137 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *137
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 31
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &138 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *138
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 32
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &139 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *139
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 129 :[name=SirMalo]:Say "Chespin"!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 130 :[name=Everyone]::[align=center]:CHESPIN!
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - take_screenshot("technical_demo.png", scale = 2)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 224
+        indent: 0
+        parameters:
+        - !ruby/object:Color
+          red: 255
+          green: 255
+          blue: 255
+          alpha: 255
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &140 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *140
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 31
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &141 !ruby/object:RPG::MoveCommand
+            code: 18
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *141
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 32
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &142 !ruby/object:RPG::MoveCommand
+            code: 17
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *142
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 131 :[name=SirMalo]:There, the photo is taken... Or should I say the
+          screenshot!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 132 :[name=SirMalo]:You can find it in the folder of the demo, named
+          "technical_demo.png".
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - '3, 133 :[name=SirMalo]:We would love if you could share this screen and
+          your reactions about the demo on the Pokémon Workshop Discord server, in
+          the channel #psdk-talk!'
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - !binary |-
+          cmVtYXJxdWVzIGV0IHRlcyBjb21tZW50YWlyZXMgc3VyIGNldHRlIGTDqW1vICE=
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 134 :[name=SirMalo]:Thanks again for playing until the end, we hope you
+          had as much fun when journeying through this demo as us creating it!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 135 :[name=SirMalo]:We hope to see you soon on the Discord!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 136 :[name=SirMalo]:And now, roll the credits!
+      - !ruby/object:RPG::EventCommand
+        code: 231
+        indent: 0
+        parameters:
+        - 1
+        - black
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 0
+        parameters:
+        - 1
+        - 10
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 255
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 3
+        - 25
+        - 33
+        - 2
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "(31..40).each { |id| delete_event_forever(id) }"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$scene.call_scene(GamePlay::CreditScene)"
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - force_save
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - "@wait = 1"
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 232
+        indent: 0
+        parameters:
+        - 1
+        - 30
+        - 0
+        - 0
+        - 0
+        - 0
+        - 100
+        - 100
+        - 0
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 30
+      - !ruby/object:RPG::EventCommand
+        code: 235
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 0
     y: 2
   42: !ruby/object:RPG::Event
@@ -9167,664 +9093,767 @@ events:
     name: !binary |-
       wqcgZXNjYWxhdG9yIHJhaWxpbmc=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Escalator-railings
-          direction: 4
-          opacity: 0
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Escalator-railings
+        direction: 4
+        opacity: 0
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 17
     y: 47
   43: !ruby/object:RPG::Event
     id: 43
     name: Give item
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Aroma-Lady
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Aroma-Lady
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 137 Here, we encourage young Trainers to catch lots and lots of Pokémon!
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 138 I'm going to use the \c[5]"give_item"\c[0] command to give you 10
+          Poké Balls.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - give_item(:poke_ball, 10)
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 139 The Tower brims with a great variety of Pokémon to catch.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 140 So don't hesitate to launch a lot of these in all directions!
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 137 Here, we encourage young Trainers to catch lots and lots of Pokémon!
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 138 I'm going to use the \c[5]"give_item"\c[0] command to give you 10
-                Poké Balls.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - give_item(:poke_ball, 10)
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 139 The Tower brims with a great variety of Pokémon to catch.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 140 So don't hesitate to launch a lot of these in all directions!
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Aroma-Lady
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Aroma-Lady
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 141 The Tower brims with a great variety of Pokémon to catch.
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 142 So don't hesitate to launch a lot of these in all directions!
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 1
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 141 The Tower brims with a great variety of Pokémon to catch.
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 142 So don't hesitate to launch a lot of these in all directions!
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 1
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 1
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 1
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 34
     y: 43
   44: !ruby/object:RPG::Event
     id: 44
     name: Silently give an item
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Burglar
-          direction: 4
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 143 Hey, psst...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 144 I'm gonna slip you something on the down low...
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 145 I put it directly in your bag using the \c[5]"$bag.add_item"\c[0]
-                command.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "$bag.add_item(:rare_candy)"
-          - !ruby/object:RPG::EventCommand
-            code: 101
-            indent: 0
-            parameters:
-              - 3, 146 .[WAIT 20].[WAIT 20].[WAIT 20]
-          - !ruby/object:RPG::EventCommand
-            code: 401
-            indent: 0
-            parameters:
-              - Now scram.
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - Checking the position of the player
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 26
-              - 26
-              - 0
-              - 6
-              - -1
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 1
-              - 26
-              - 0
-              - 34
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &145
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &146
-                    code: 13
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *145
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *146
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - "get_character(44).find_path(to: [28, 47])"
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - wait_event(44)
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - 0
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &147
-                    code: 16
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &148
-                    code: 15
-                    parameters:
-                      - 4
-                  - !ruby/object:RPG::MoveCommand &149
-                    code: 41
-                    parameters:
-                      - npc_Burglar
-                      - 0
-                      - 2
-                      - 1
-                  - !ruby/object:RPG::MoveCommand &150
-                    code: 15
-                    parameters:
-                      - 8
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *147
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *148
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *149
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *150
-          - !ruby/object:RPG::EventCommand
-            code: 210
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - delete_this_event_forever
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 2
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: npc_Burglar
+        direction: 4
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 143 Hey, psst...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 144 I'm gonna slip you something on the down low...
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 145 I put it directly in your bag using the \c[5]"$bag.add_item"\c[0]
+          command.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - "$bag.add_item(:rare_candy)"
+      - !ruby/object:RPG::EventCommand
+        code: 101
+        indent: 0
+        parameters:
+        - 3, 146 .[WAIT 20].[WAIT 20].[WAIT 20]
+      - !ruby/object:RPG::EventCommand
+        code: 401
+        indent: 0
+        parameters:
+        - Now scram.
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - Checking the position of the player
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 26
+        - 26
+        - 0
+        - 6
+        - -1
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 1
+        - 26
+        - 0
+        - 34
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 24
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &143 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - &144 !ruby/object:RPG::MoveCommand
+            code: 13
+            parameters: []
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 3
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *143
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *144
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - 'get_character(44).find_path(to: [28, 47])'
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - wait_event(44)
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - 0
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &145 !ruby/object:RPG::MoveCommand
+            code: 16
+            parameters: []
+          - &146 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 4
+          - &147 !ruby/object:RPG::MoveCommand
+            code: 41
+            parameters:
+            - npc_Burglar
+            - 0
+            - 2
+            - 1
+          - &148 !ruby/object:RPG::MoveCommand
+            code: 15
+            parameters:
+            - 8
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *145
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *146
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *147
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *148
+      - !ruby/object:RPG::EventCommand
+        code: 210
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - delete_this_event_forever
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 2
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 24
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 3
+      step_anime: false
+      through: false
+      trigger: 0
+      walk_anime: true
     x: 35
     y: 47
-  5: !ruby/object:RPG::Event
-    id: 5
-    name: Nurse
+  45: !ruby/object:RPG::Event
+    id: 45
+    name: !binary |-
+      wqcgZXhpdCBkb29y
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: npc_Nurse-01
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 117
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - We set the Map Return depending on the Nurse's position,
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - with a +2 to her Y position so that when we black out, we
-          - !ruby/object:RPG::EventCommand
-            code: 408
-            indent: 0
-            parameters:
-              - appear directly on the right position.
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 47
-              - 47
-              - 0
-              - 7
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 48
-              - 48
-              - 0
-              - 6
-              - 5
-              - 0
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 49
-              - 49
-              - 0
-              - 6
-              - 5
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 122
-            indent: 0
-            parameters:
-              - 49
-              - 49
-              - 1
-              - 0
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Arrow
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 242
+        indent: 0
+        parameters:
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: door_exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &149 !ruby/object:RPG::MoveCommand
+            code: 37
+            parameters: []
+          - &150 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 0
-        walk_anime: true
-    x: 18
-    y: 40
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *149
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *150
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - We set the Map Return depending on the Nurse's position,
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - with a +2 to her Y position so that when we black out, we
+      - !ruby/object:RPG::EventCommand
+        code: 408
+        indent: 0
+        parameters:
+        - appear directly on the right position.
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 47
+        - 47
+        - 0
+        - 7
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 48
+        - 48
+        - 0
+        - 6
+        - 5
+        - 0
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 49
+        - 49
+        - 0
+        - 6
+        - 5
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 122
+        indent: 0
+        parameters:
+        - 49
+        - 49
+        - 1
+        - 0
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This command turns on the self switch on the exterior door to enable the
+          opening door.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",1,map_id = 19)
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 19
+        - 31
+        - 31
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 31
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 35
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 39
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 2
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 2
+      walk_anime: false
+    x: 28
+    y: 48
   6: !ruby/object:RPG::Event
     id: 6
     name: "[sprite=off] Exiting arrow"
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This event displays an arrow under the exit when the player stands in front
-                of it and faces down.
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 0
-            parameters:
-              - 12
-              - gp.x == 28 && gp.y == 47
-          - !ruby/object:RPG::EventCommand
-            code: 111
-            indent: 1
-            parameters:
-              - 6
-              - -1
-              - 2
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - 1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &151
-                    code: 42
-                    parameters:
-                      - 255
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *151
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 2
-            parameters:
-              - 1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &152
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 2
-            parameters:
-              - *152
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 2
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 411
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 1
-            parameters:
-              - 1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &153
-                    code: 42
-                    parameters:
-                      - 0
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 1
-            parameters:
-              - *153
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 1
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 412
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This event displays an arrow under the exit when the player stands in front
+          of it and faces down.
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 0
+        parameters:
+        - 12
+        - gp.x == 28 && gp.y == 47
+      - !ruby/object:RPG::EventCommand
+        code: 111
+        indent: 1
+        parameters:
+        - 6
+        - -1
+        - 2
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - 45
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &151 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 255
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *151
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 2
+        parameters:
+        - 45
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &152 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 2
+        parameters:
+        - *152
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 2
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 411
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 1
+        parameters:
+        - 45
+        - !ruby/object:RPG::MoveRoute
+          list:
+          - &153 !ruby/object:RPG::MoveCommand
+            code: 42
+            parameters:
+            - 0
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
+          skippable: false
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 1
+        parameters:
+        - *153
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 1
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 412
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 28
     y: 49
   7: !ruby/object:RPG::Event
@@ -9832,51 +9861,51 @@ events:
     name: !binary |-
       wqcgRXNjYWxhdG9yIGdyYXBoaWNz
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: fx_Escalator-up
-          direction: 6
-          opacity: 0
-          pattern: 0
-          tile_id: 0
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: fx_Escalator-up
+        direction: 6
+        opacity: 0
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - ge(7).z = 0
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
         list:
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - ge(7).z = 0
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 4
-        walk_anime: true
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 4
+      walk_anime: true
     x: 16
     y: 47
   8: !ruby/object:RPG::Event
@@ -9884,249 +9913,249 @@ events:
     name: !binary |-
       wqcgYmFzZW1lbnQgd2FycCBsZWZ0
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: door_exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &154
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &155
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &156
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &157
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &158
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *154
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *155
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *156
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *157
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *158
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This command turns on the self switch on the basement to settle the tone
-                and the followers.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",1,map_id = 17)
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 17
-              - 17
-              - 29
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: door_exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 31
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 35
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 39
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 2
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 2
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
+          - &154 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+            - 2
+          - &155 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &156 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &157 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &158 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *154
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *155
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *156
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *157
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *158
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This command turns on the self switch on the basement to settle the tone
+          and the followers.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",1,map_id = 17)
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 17
+        - 17
+        - 29
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 31
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 35
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 39
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 2
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 2
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 27
     y: 39
   9: !ruby/object:RPG::Event
@@ -10134,249 +10163,249 @@ events:
     name: !binary |-
       wqcgYmFzZW1lbnQgd2FycCBtaWRkbGU=
     pages:
-      - !ruby/object:RPG::Event::Page
-        always_on_top: true
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: false
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: true
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: zz_blocker
-          direction: 8
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - !binary |-
-                RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_disable
-          - !ruby/object:RPG::EventCommand
-            code: 655
-            indent: 0
-            parameters:
-              - gp.leave_cycling_state
-          - !ruby/object:RPG::EventCommand
-            code: 250
-            indent: 0
-            parameters:
-              - !ruby/object:RPG::AudioFile
-                name: door_exit
-                pitch: 100
-                volume: 80
-          - !ruby/object:RPG::EventCommand
-            code: 221
-            indent: 0
-            parameters: []
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 4
-          - !ruby/object:RPG::EventCommand
-            code: 209
-            indent: 0
-            parameters:
-              - -1
-              - !ruby/object:RPG::MoveRoute
-                list:
-                  - !ruby/object:RPG::MoveCommand &159
-                    code: 29
-                    parameters:
-                      - 2
-                  - !ruby/object:RPG::MoveCommand &160
-                    code: 37
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &161
-                    code: 4
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &162
-                    code: 38
-                    parameters: []
-                  - !ruby/object:RPG::MoveCommand &163
-                    code: 29
-                    parameters:
-                      - 3
-                  - !ruby/object:RPG::MoveCommand
-                    code: 0
-                    parameters: []
-                repeat: false
-                skippable: false
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *159
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *160
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *161
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *162
-          - !ruby/object:RPG::EventCommand
-            code: 509
-            indent: 0
-            parameters:
-              - *163
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
-            parameters:
-              - !ruby/object:Tone
-                red: -255
-                green: -255
-                blue: -255
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 12
-          - !ruby/object:RPG::EventCommand
-            code: 108
-            indent: 0
-            parameters:
-              - This command turns on the self switch on the basement to settle the tone
-                and the followers.
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - set_self_switch(true,"A",2,map_id = 17)
-          - !ruby/object:RPG::EventCommand
-            code: 201
-            indent: 0
-            parameters:
-              - 0
-              - 17
-              - 18
-              - 29
-              - 0
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
-            parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
+    - !ruby/object:RPG::Event::Page
+      always_on_top: true
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: false
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: true
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: zz_blocker
+        direction: 8
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - !binary |-
+          RGlzYWJsaW5nIHRoZSBmb2xsb3dlciBQb2vDqW1vbiBpZiB0aGlzIG9wdGlvbiB3YXMgYWN0aXZhdGVk
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_disable
+      - !ruby/object:RPG::EventCommand
+        code: 655
+        indent: 0
+        parameters:
+        - gp.leave_cycling_state
+      - !ruby/object:RPG::EventCommand
+        code: 250
+        indent: 0
+        parameters:
+        - !ruby/object:RPG::AudioFile
+          name: door_exit
+          pitch: 100
+          volume: 80
+      - !ruby/object:RPG::EventCommand
+        code: 221
+        indent: 0
+        parameters: []
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 4
+      - !ruby/object:RPG::EventCommand
+        code: 209
+        indent: 0
+        parameters:
+        - -1
+        - !ruby/object:RPG::MoveRoute
           list:
-            - !ruby/object:RPG::MoveCommand
-              code: 31
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 35
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 39
-              parameters: []
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
-          skippable: false
-        move_speed: 2
-        move_type: 0
-        step_anime: true
-        through: false
-        trigger: 2
-        walk_anime: false
-      - !ruby/object:RPG::Event::Page
-        always_on_top: false
-        condition: !ruby/object:RPG::Event::Page::Condition
-          self_switch_ch: A
-          self_switch_valid: true
-          switch1_id: 1
-          switch1_valid: false
-          switch2_id: 1
-          switch2_valid: false
-          variable_id: 1
-          variable_valid: false
-          variable_value: 0
-        direction_fix: false
-        graphic: !ruby/object:RPG::Event::Page::Graphic
-          blend_type: 0
-          character_hue: 0
-          character_name: ""
-          direction: 2
-          opacity: 255
-          pattern: 0
-          tile_id: 0
-        list:
-          - !ruby/object:RPG::EventCommand
-            code: 223
-            indent: 0
+          - &159 !ruby/object:RPG::MoveCommand
+            code: 29
             parameters:
-              - !ruby/object:Tone
-                red: 0
-                green: 0
-                blue: 0
-                gray: 0
-              - 10
-          - !ruby/object:RPG::EventCommand
-            code: 106
-            indent: 0
-            parameters:
-              - 5
-          - !ruby/object:RPG::EventCommand
-            code: 355
-            indent: 0
-            parameters:
-              - Yuki::FollowMe.smart_enable
-          - !ruby/object:RPG::EventCommand
-            code: 123
-            indent: 0
-            parameters:
-              - A
-              - 1
-          - !ruby/object:RPG::EventCommand
-            code: 0
-            indent: 0
+            - 2
+          - &160 !ruby/object:RPG::MoveCommand
+            code: 37
             parameters: []
-        move_frequency: 3
-        move_route: !ruby/object:RPG::MoveRoute
-          list:
-            - !ruby/object:RPG::MoveCommand
-              code: 0
-              parameters: []
-          repeat: true
+          - &161 !ruby/object:RPG::MoveCommand
+            code: 4
+            parameters: []
+          - &162 !ruby/object:RPG::MoveCommand
+            code: 38
+            parameters: []
+          - &163 !ruby/object:RPG::MoveCommand
+            code: 29
+            parameters:
+            - 3
+          - !ruby/object:RPG::MoveCommand
+            code: 0
+            parameters: []
+          repeat: false
           skippable: false
-        move_speed: 3
-        move_type: 0
-        step_anime: false
-        through: false
-        trigger: 3
-        walk_anime: true
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *159
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *160
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *161
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *162
+      - !ruby/object:RPG::EventCommand
+        code: 509
+        indent: 0
+        parameters:
+        - *163
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: -255
+          green: -255
+          blue: -255
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 12
+      - !ruby/object:RPG::EventCommand
+        code: 108
+        indent: 0
+        parameters:
+        - This command turns on the self switch on the basement to settle the tone
+          and the followers.
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - set_self_switch(true,"A",2,map_id = 17)
+      - !ruby/object:RPG::EventCommand
+        code: 201
+        indent: 0
+        parameters:
+        - 0
+        - 17
+        - 18
+        - 29
+        - 0
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 31
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 35
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 39
+          parameters: []
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 2
+      move_type: 0
+      step_anime: true
+      through: false
+      trigger: 2
+      walk_anime: false
+    - !ruby/object:RPG::Event::Page
+      always_on_top: false
+      condition: !ruby/object:RPG::Event::Page::Condition
+        self_switch_ch: A
+        self_switch_valid: true
+        switch1_id: 1
+        switch1_valid: false
+        switch2_id: 1
+        switch2_valid: false
+        variable_id: 1
+        variable_valid: false
+        variable_value: 0
+      direction_fix: false
+      graphic: !ruby/object:RPG::Event::Page::Graphic
+        blend_type: 0
+        character_hue: 0
+        character_name: ''
+        direction: 2
+        opacity: 255
+        pattern: 0
+        tile_id: 0
+      list:
+      - !ruby/object:RPG::EventCommand
+        code: 223
+        indent: 0
+        parameters:
+        - !ruby/object:Tone
+          red: 0
+          green: 0
+          blue: 0
+          gray: 0
+        - 10
+      - !ruby/object:RPG::EventCommand
+        code: 106
+        indent: 0
+        parameters:
+        - 5
+      - !ruby/object:RPG::EventCommand
+        code: 355
+        indent: 0
+        parameters:
+        - Yuki::FollowMe.smart_enable
+      - !ruby/object:RPG::EventCommand
+        code: 123
+        indent: 0
+        parameters:
+        - A
+        - 1
+      - !ruby/object:RPG::EventCommand
+        code: 0
+        indent: 0
+        parameters: []
+      move_frequency: 3
+      move_route: !ruby/object:RPG::MoveRoute
+        list:
+        - !ruby/object:RPG::MoveCommand
+          code: 0
+          parameters: []
+        repeat: true
+        skippable: false
+      move_speed: 3
+      move_type: 0
+      step_anime: false
+      through: false
+      trigger: 3
+      walk_anime: true
     x: 28
     y: 39
 height: 64

--- a/Data/configs/conditions.json
+++ b/Data/configs/conditions.json
@@ -1,0 +1,1 @@
+{"klass":"Configs::Conditions","max_condition_value":255,"coolness_index":0,"beauty_index":1,"cuteness_index":2,"cleverness_index":3,"toughness_index":4,"sheen_index":5}


### PR DESCRIPTION
# PR Description
This PR fixes and closes #52. Currently, the nurse's ID isn't 1, which means that the "Return to center" common event cannot find the nurse event. This PR switches the IDs of the nurse's event with the door arrow one. It also ensures that it does not include any regression due to this switch.

# Tests to realize before merging
- [ ] Lose a battle by any means: you should be teleported to the Hub, and the nurse's animation and texts should properly work
- [ ] In the Hub, walk in the direction of the exit: just before exiting, you should still see the arrow 